### PR TITLE
Create a shortcut for the Alerts Drilldown menu option

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -439,7 +439,7 @@
                     </v-btn>                    
                   </td>
                   <td>
-                    {{ item.count.toLocaleString() }}
+                    <div class="count-drilldown d-inline-block" v-text="item.count.toLocaleString()" @click="countDrilldown(item)"></div>
                   </td>
                   <td v-for="field in groupByHeaders.slice(2)" :key="field.value">
                     <div class="quick-action-trigger d-inline-block" v-text="item[field.value]" @click="toggleQuickAction($event, item, field.value, item[field.value])"></div>

--- a/html/index.html
+++ b/html/index.html
@@ -439,7 +439,15 @@
                     </v-btn>                    
                   </td>
                   <td>
-                    <div class="count-drilldown d-inline-block" v-text="item.count.toLocaleString()" @click="countDrilldown(item)"></div>
+		     <v-tooltip bottom v-if="loaded && eventsEnabled && metricsEnabled && ( (groupByHeaders.length==3 && groupByHeaders[1]['value']=='count' ) || (groupByHeaders.length==5 && groupByHeaders[1]['value']=='count' && groupByHeaders[2]['value']=='rule.name' && groupByHeaders[3]['value']=='event.module' && groupByHeaders[4]['value']=='event.severity_label') ) ">
+		       <template v-slot:activator="{ on, attrs }">
+	                 <span v-bind="attrs" v-on="on">
+                           <div class="count-drilldown d-inline-block" v-text="item.count.toLocaleString()" v-bind="attrs" @click="countDrilldown(item)"></div>
+			 </span>
+		       </template>
+		       <span>Click to drill down into these events</span>
+	             </v-tooltip>
+                     <div v-else class="count-drilldown d-inline-block" v-text="item.count.toLocaleString()"></div>
                   </td>
                   <td v-for="field in groupByHeaders.slice(2)" :key="field.value">
                     <div class="quick-action-trigger d-inline-block" v-text="item[field.value]" @click="toggleQuickAction($event, item, field.value, item[field.value])"></div>

--- a/html/index.html
+++ b/html/index.html
@@ -445,7 +445,7 @@
                            <div class="count-drilldown d-inline-block" v-text="item.count.toLocaleString()" v-bind="attrs" @click="countDrilldown(item)"></div>
 			 </span>
 		       </template>
-		       <span>Click to drill down into these events</span>
+		       <span>{{ i18n.quickDrilldown }}</span>
 	             </v-tooltip>
                      <div v-else class="count-drilldown d-inline-block" v-text="item.count.toLocaleString()"></div>
                   </td>

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -222,6 +222,7 @@ const i18n = {
       pcap: 'PCAP',
       pending: 'Pending',
       product: 'Security Onion',
+      quickDrilldown: 'Quick Drilldown',
       queriesHelp: 'Choose from several pre-defined queries',
       queryHelp: 'Specify a hunting query in Onion Query Language (OQL)',
       quickActions: 'Actions',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -623,6 +623,12 @@ const huntComponent = {
       route.query.groupByField = field;
       return route;
     },
+    countDrilldown(event) {
+      if ( this.category == 'alerts' && Object.keys(event).length == 4 && Object.keys(event)[0] == "count" && Object.keys(event)[1] == "rule.name" && Object.keys(event)[2] == "event.module" && Object.keys(event)[3] == "event.severity_label" ) {
+        this.filterRouteDrilldown = this.buildFilterRoute('rule.name', event['rule.name'], FILTER_DRILLDOWN);
+        this.$router.push(this.filterRouteDrilldown);
+      }
+    },
     toggleQuickAction(domEvent, event, field, value) {
       if (!domEvent || this.quickActionVisible) {
         this.quickActionVisible = false;

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -624,8 +624,8 @@ const huntComponent = {
       return route;
     },
     countDrilldown(event) {
-      if ( this.category == 'alerts' && Object.keys(event).length == 4 && Object.keys(event)[0] == "count" && Object.keys(event)[1] == "rule.name" && Object.keys(event)[2] == "event.module" && Object.keys(event)[3] == "event.severity_label" ) {
-        this.filterRouteDrilldown = this.buildFilterRoute('rule.name', event['rule.name'], FILTER_DRILLDOWN);
+      if ( (Object.keys(event).length == 2 && Object.keys(event)[0] == "count") || (Object.keys(event).length == 4 && Object.keys(event)[0] == "count" && Object.keys(event)[1] == "rule.name" && Object.keys(event)[2] == "event.module" && Object.keys(event)[3] == "event.severity_label") ) {
+        this.filterRouteDrilldown = this.buildFilterRoute(Object.keys(event)[1], event[Object.keys(event)[1]], FILTER_DRILLDOWN);
         this.$router.push(this.filterRouteDrilldown);
       }
     },


### PR DESCRIPTION
As an analyst, I often find myself on the Alerts page in the default view of `Group By Name, Module` wanting to drill down and show all instances of a particular alert. For example, in the following screenshot, I would want to show all instances of the `ET JA3 Hash` alert on the first row:
![image](https://user-images.githubusercontent.com/1659467/120679329-0df88b00-c467-11eb-844c-f3a75d94f96b.png)

Traditionally, we could click on the `rule.name` value (`ET JA3 Hash` in this case) and then click the `Drilldown` option on the Quick Action menu. This PR allows the user to simply click on the value in the `Count` column to accomplish the same thing, saving a click.