### PR TITLE
Fix conversion of Elasticsearch timestamps with timezones

### DIFF
--- a/server/modules/elastic/converter.go
+++ b/server/modules/elastic/converter.go
@@ -331,7 +331,7 @@ func convertFromElasticResults(store *ElasticEventstore, esJson string, results 
 		} else if event.Payload["timestamp"] != nil {
 			event.Time, _ = time.Parse(time.RFC3339, event.Payload["timestamp"].(string))
 		}
-		event.Timestamp = event.Time.Format("2006-01-02T15:04:05.000Z")
+		event.Timestamp = event.Time.UTC().Format("2006-01-02T15:04:05.000Z")
 		results.Events = append(results.Events, event)
 	}
 


### PR DESCRIPTION
When timestamps in Elasticsearch have a time zone such as '2022-03-28T16:49:39.000+02:00', the SOC interface shows an incorrect time because /api/events/ returns timestamp="2022-03-28T16:49:39.000Z".

time.Format("2006-01-02T15:04:05.000Z") does not convert time zones, so a prior conversion to UTC is required.


