### PR TITLE
add hook to extract common observables

### DIFF
--- a/server/modules/elastic/elasticcasestore.go
+++ b/server/modules/elastic/elasticcasestore.go
@@ -7,17 +7,18 @@
 package elastic
 
 import (
-  "context"
-  "errors"
-  "fmt"
-  "github.com/apex/log"
-  "github.com/security-onion-solutions/securityonion-soc/model"
-  "github.com/security-onion-solutions/securityonion-soc/server"
-  "github.com/security-onion-solutions/securityonion-soc/web"
-  "regexp"
-  "sort"
-  "strconv"
-  "time"
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
 )
 
 const AUDIT_DOC_ID = "audit_doc_id"
@@ -26,830 +27,860 @@ const LONG_STRING_MAX = 1000000
 const MAX_ARRAY_ELEMENTS = 50
 
 type ElasticCasestore struct {
-  server          *server.Server
-  index           string
-  auditIndex      string
-  maxAssociations int
-  schemaPrefix    string
+	server            *server.Server
+	index             string
+	auditIndex        string
+	maxAssociations   int
+	schemaPrefix      string
+	commonObservables []string
+	observables       Observables
 }
 
 func NewElasticCasestore(srv *server.Server) *ElasticCasestore {
-  return &ElasticCasestore{
-    server: srv,
-  }
+	return &ElasticCasestore{
+		server:      srv,
+		observables: NewObservables(),
+	}
 }
 
-func (store *ElasticCasestore) Init(index string, auditIndex string, maxAssociations int, schemaPrefix string) error {
-  store.index = index
-  store.auditIndex = auditIndex
-  store.maxAssociations = maxAssociations
-  store.schemaPrefix = schemaPrefix
-  return nil
+func (store *ElasticCasestore) Init(index string, auditIndex string, maxAssociations int, schemaPrefix string,
+	commonObservables []string) error {
+	store.index = index
+	store.auditIndex = auditIndex
+	store.maxAssociations = maxAssociations
+	store.schemaPrefix = schemaPrefix
+	store.commonObservables = commonObservables
+	return nil
 }
 
 func (store *ElasticCasestore) validateId(id string, label string) error {
-  var err error
+	var err error
 
-  isValidId := regexp.MustCompile(`^[A-Za-z0-9-_]{5,50}$`).MatchString
-  if !isValidId(id) {
-    err = errors.New(fmt.Sprintf("invalid ID for %s", label))
-  }
-  return err
+	isValidId := regexp.MustCompile(`^[A-Za-z0-9-_]{5,50}$`).MatchString
+	if !isValidId(id) {
+		err = fmt.Errorf("invalid ID for %s", label)
+	}
+	return err
 }
 
 func (store *ElasticCasestore) validateString(str string, max int, label string) error {
-  return store.validateStringRequired(str, 0, max, label)
+	return store.validateStringRequired(str, 0, max, label)
 }
 
 func (store *ElasticCasestore) validateStringRequired(str string, min int, max int, label string) error {
-  var err error
-  length := len(str)
-  if length > max {
-    err = errors.New(fmt.Sprintf("%s is too long (%d/%d)", label, length, max))
-  } else if length < min {
-    err = errors.New(fmt.Sprintf("%s is too short (%d/%d)", label, length, min))
-  }
-  return err
+	var err error
+	length := len(str)
+	if length > max {
+		err = errors.New(fmt.Sprintf("%s is too long (%d/%d)", label, length, max))
+	} else if length < min {
+		err = errors.New(fmt.Sprintf("%s is too short (%d/%d)", label, length, min))
+	}
+	return err
 }
 
 func (store *ElasticCasestore) validateStringArray(array []string, maxLen int, maxElements int, label string) error {
-  var err error
-  length := len(array)
-  if length > maxElements {
-    err = errors.New(fmt.Sprintf("Field 'Tags' contains excessive elements (%d/%d)", length, maxElements))
-  } else {
-    for idx, tag := range array {
-      err = store.validateString(tag, maxLen, fmt.Sprintf("tag[%d]", idx))
-      if err != nil {
-        break
-      }
-    }
-  }
-  return err
+	var err error
+	length := len(array)
+	if length > maxElements {
+		err = errors.New(fmt.Sprintf("Field 'Tags' contains excessive elements (%d/%d)", length, maxElements))
+	} else {
+		for idx, tag := range array {
+			err = store.validateString(tag, maxLen, fmt.Sprintf("tag[%d]", idx))
+			if err != nil {
+				break
+			}
+		}
+	}
+	return err
 }
 
 func (store *ElasticCasestore) validateCase(socCase *model.Case) error {
-  var err error
+	var err error
 
-  if err == nil && socCase.Id != "" {
-    err = store.validateId(socCase.Id, "caseId")
-  }
-  if err == nil && socCase.UserId != "" {
-    err = store.validateId(socCase.UserId, "userId")
-  }
-  if err == nil && socCase.AssigneeId != "" {
-    err = store.validateId(socCase.AssigneeId, "assigneeId")
-  }
-  if err == nil && socCase.Priority < 0 {
-    err = errors.New("Invalid priority")
-  }
-  if err == nil {
-    socCase.Severity = convertSeverity(socCase.Severity)
-    err = store.validateString(socCase.Severity, SHORT_STRING_MAX, "severity")
-  }
-  if err == nil && len(socCase.Kind) > 0 {
-    err = errors.New("Field 'Kind' must not be specified")
-  }
-  if err == nil && len(socCase.Operation) > 0 {
-    err = errors.New("Field 'Operation' must not be specified")
-  }
-  if err == nil {
-    err = store.validateStringRequired(socCase.Title, 1, SHORT_STRING_MAX, "title")
-  }
-  if err == nil {
-    err = store.validateString(socCase.Category, SHORT_STRING_MAX, "category")
-  }
-  if err == nil {
-    err = store.validateStringRequired(socCase.Status, 1, SHORT_STRING_MAX, "status")
-  }
-  if err == nil {
-    err = store.validateString(socCase.Template, SHORT_STRING_MAX, "template")
-  }
-  if err == nil {
-    err = store.validateString(socCase.Tlp, SHORT_STRING_MAX, "tlp")
-  }
-  if err == nil {
-    err = store.validateString(socCase.Pap, SHORT_STRING_MAX, "pap")
-  }
-  if err == nil {
-    err = store.validateStringRequired(socCase.Description, 1, LONG_STRING_MAX, "description")
-  }
-  if err == nil {
-    err = store.validateStringArray(socCase.Tags, SHORT_STRING_MAX, MAX_ARRAY_ELEMENTS, "tags")
-  }
-  return err
+	if err == nil && socCase.Id != "" {
+		err = store.validateId(socCase.Id, "caseId")
+	}
+	if err == nil && socCase.UserId != "" {
+		err = store.validateId(socCase.UserId, "userId")
+	}
+	if err == nil && socCase.AssigneeId != "" {
+		err = store.validateId(socCase.AssigneeId, "assigneeId")
+	}
+	if err == nil && socCase.Priority < 0 {
+		err = errors.New("Invalid priority")
+	}
+	if err == nil {
+		socCase.Severity = convertSeverity(socCase.Severity)
+		err = store.validateString(socCase.Severity, SHORT_STRING_MAX, "severity")
+	}
+	if err == nil && len(socCase.Kind) > 0 {
+		err = errors.New("Field 'Kind' must not be specified")
+	}
+	if err == nil && len(socCase.Operation) > 0 {
+		err = errors.New("Field 'Operation' must not be specified")
+	}
+	if err == nil {
+		err = store.validateStringRequired(socCase.Title, 1, SHORT_STRING_MAX, "title")
+	}
+	if err == nil {
+		err = store.validateString(socCase.Category, SHORT_STRING_MAX, "category")
+	}
+	if err == nil {
+		err = store.validateStringRequired(socCase.Status, 1, SHORT_STRING_MAX, "status")
+	}
+	if err == nil {
+		err = store.validateString(socCase.Template, SHORT_STRING_MAX, "template")
+	}
+	if err == nil {
+		err = store.validateString(socCase.Tlp, SHORT_STRING_MAX, "tlp")
+	}
+	if err == nil {
+		err = store.validateString(socCase.Pap, SHORT_STRING_MAX, "pap")
+	}
+	if err == nil {
+		err = store.validateStringRequired(socCase.Description, 1, LONG_STRING_MAX, "description")
+	}
+	if err == nil {
+		err = store.validateStringArray(socCase.Tags, SHORT_STRING_MAX, MAX_ARRAY_ELEMENTS, "tags")
+	}
+	return err
 }
 
 func (store *ElasticCasestore) validateRelatedEvent(event *model.RelatedEvent) error {
-  var err error
+	var err error
 
-  if err == nil && event.Id != "" {
-    err = store.validateId(event.Id, "relatedEventId")
-  }
-  if err == nil && event.CaseId != "" {
-    err = store.validateId(event.CaseId, "caseId")
-  }
-  if err == nil && event.UserId != "" {
-    err = store.validateId(event.UserId, "userId")
-  }
-  if err == nil && len(event.Kind) > 0 {
-    err = errors.New("Field 'Kind' must not be specified")
-  }
-  if err == nil && len(event.Operation) > 0 {
-    err = errors.New("Field 'Operation' must not be specified")
-  }
-  if err == nil && len(event.Fields) == 0 {
-    err = errors.New("Related event fields cannot not be empty")
-  }
-  return err
+	if err == nil && event.Id != "" {
+		err = store.validateId(event.Id, "relatedEventId")
+	}
+	if err == nil && event.CaseId != "" {
+		err = store.validateId(event.CaseId, "caseId")
+	}
+	if err == nil && event.UserId != "" {
+		err = store.validateId(event.UserId, "userId")
+	}
+	if err == nil && len(event.Kind) > 0 {
+		err = errors.New("Field 'Kind' must not be specified")
+	}
+	if err == nil && len(event.Operation) > 0 {
+		err = errors.New("Field 'Operation' must not be specified")
+	}
+	if err == nil && len(event.Fields) == 0 {
+		err = errors.New("Related event fields cannot not be empty")
+	}
+	return err
 }
 
 func (store *ElasticCasestore) validateComment(comment *model.Comment) error {
-  var err error
+	var err error
 
-  if err == nil && comment.Id != "" {
-    err = store.validateId(comment.Id, "commentId")
-  }
-  if err == nil && comment.CaseId != "" {
-    err = store.validateId(comment.CaseId, "caseId")
-  }
-  if err == nil && comment.UserId != "" {
-    err = store.validateId(comment.UserId, "userId")
-  }
-  if err == nil && len(comment.Kind) > 0 {
-    err = errors.New("Field 'Kind' must not be specified")
-  }
-  if err == nil && len(comment.Operation) > 0 {
-    err = errors.New("Field 'Operation' must not be specified")
-  }
-  if err == nil {
-    err = store.validateStringRequired(comment.Description, 1, LONG_STRING_MAX, "description")
-  }
-  return err
+	if err == nil && comment.Id != "" {
+		err = store.validateId(comment.Id, "commentId")
+	}
+	if err == nil && comment.CaseId != "" {
+		err = store.validateId(comment.CaseId, "caseId")
+	}
+	if err == nil && comment.UserId != "" {
+		err = store.validateId(comment.UserId, "userId")
+	}
+	if err == nil && len(comment.Kind) > 0 {
+		err = errors.New("Field 'Kind' must not be specified")
+	}
+	if err == nil && len(comment.Operation) > 0 {
+		err = errors.New("Field 'Operation' must not be specified")
+	}
+	if err == nil {
+		err = store.validateStringRequired(comment.Description, 1, LONG_STRING_MAX, "description")
+	}
+	return err
 }
 
 func (store *ElasticCasestore) validateArtifact(artifact *model.Artifact) error {
-  var err error
+	var err error
 
-  if err == nil && artifact.Id != "" {
-    err = store.validateId(artifact.Id, "artifactId")
-  }
-  if err == nil && artifact.UserId != "" {
-    err = store.validateId(artifact.UserId, "userId")
-  }
-  if err == nil && artifact.CaseId != "" {
-    err = store.validateId(artifact.CaseId, "caseId")
-  }
-  if err == nil && artifact.StreamLen != 0 && artifact.ArtifactType != "file" {
-    err = errors.New("Invalid streamLength")
-  }
-  if err == nil && len(artifact.Kind) > 0 {
-    err = errors.New("Field 'Kind' must not be specified")
-  }
-  if err == nil && len(artifact.Operation) > 0 {
-    err = errors.New("Field 'Operation' must not be specified")
-  }
-  if err == nil {
-    err = store.validateStringRequired(artifact.Value, 1, LONG_STRING_MAX, "value")
-  }
-  if err == nil {
-    err = store.validateId(artifact.GroupType, "groupType")
-  }
-  if err == nil && len(artifact.GroupId) > 0 {
-    err = store.validateId(artifact.GroupId, "groupId")
-  }
-  if err == nil {
-    err = store.validateStringRequired(artifact.ArtifactType, 1, SHORT_STRING_MAX, "artifactType")
-  }
-  if err == nil {
-    err = store.validateString(artifact.Tlp, SHORT_STRING_MAX, "tlp")
-  }
-  if err == nil {
-    err = store.validateString(artifact.MimeType, SHORT_STRING_MAX, "mimeType")
-  }
-  if err == nil {
-    err = store.validateString(artifact.Description, LONG_STRING_MAX, "description")
-  }
-  if err == nil {
-    err = store.validateStringArray(artifact.Tags, SHORT_STRING_MAX, MAX_ARRAY_ELEMENTS, "tags")
-  }
-  if err == nil {
-    err = store.validateString(artifact.Md5, SHORT_STRING_MAX, "md5")
-  }
-  if err == nil {
-    err = store.validateString(artifact.Sha1, SHORT_STRING_MAX, "sha1")
-  }
-  if err == nil {
-    err = store.validateString(artifact.Sha256, SHORT_STRING_MAX, "sha256")
-  }
-  return err
+	if err == nil && artifact.Id != "" {
+		err = store.validateId(artifact.Id, "artifactId")
+	}
+	if err == nil && artifact.UserId != "" {
+		err = store.validateId(artifact.UserId, "userId")
+	}
+	if err == nil && artifact.CaseId != "" {
+		err = store.validateId(artifact.CaseId, "caseId")
+	}
+	if err == nil && artifact.StreamLen != 0 && artifact.ArtifactType != "file" {
+		err = errors.New("Invalid streamLength")
+	}
+	if err == nil && len(artifact.Kind) > 0 {
+		err = errors.New("Field 'Kind' must not be specified")
+	}
+	if err == nil && len(artifact.Operation) > 0 {
+		err = errors.New("Field 'Operation' must not be specified")
+	}
+	if err == nil {
+		err = store.validateStringRequired(artifact.Value, 1, LONG_STRING_MAX, "value")
+	}
+	if err == nil {
+		err = store.validateId(artifact.GroupType, "groupType")
+	}
+	if err == nil && len(artifact.GroupId) > 0 {
+		err = store.validateId(artifact.GroupId, "groupId")
+	}
+	if err == nil {
+		err = store.validateStringRequired(artifact.ArtifactType, 1, SHORT_STRING_MAX, "artifactType")
+	}
+	if err == nil {
+		err = store.validateString(artifact.Tlp, SHORT_STRING_MAX, "tlp")
+	}
+	if err == nil {
+		err = store.validateString(artifact.MimeType, SHORT_STRING_MAX, "mimeType")
+	}
+	if err == nil {
+		err = store.validateString(artifact.Description, LONG_STRING_MAX, "description")
+	}
+	if err == nil {
+		err = store.validateStringArray(artifact.Tags, SHORT_STRING_MAX, MAX_ARRAY_ELEMENTS, "tags")
+	}
+	if err == nil {
+		err = store.validateString(artifact.Md5, SHORT_STRING_MAX, "md5")
+	}
+	if err == nil {
+		err = store.validateString(artifact.Sha1, SHORT_STRING_MAX, "sha1")
+	}
+	if err == nil {
+		err = store.validateString(artifact.Sha256, SHORT_STRING_MAX, "sha256")
+	}
+	return err
 }
 
 func (store *ElasticCasestore) validateArtifactStream(artifactstream *model.ArtifactStream) error {
-  var err error
+	var err error
 
-  if err == nil && artifactstream.Id != "" {
-    err = store.validateId(artifactstream.Id, "artifactStreamId")
-  }
-  if err == nil && artifactstream.UserId != "" {
-    err = store.validateId(artifactstream.UserId, "userId")
-  }
-  if err == nil && len(artifactstream.Content) == 0 {
-    err = errors.New("Missing stream content")
-  }
-  if err == nil && len(artifactstream.Kind) > 0 {
-    err = errors.New("Field 'Kind' must not be specified")
-  }
-  if err == nil && len(artifactstream.Operation) > 0 {
-    err = errors.New("Field 'Operation' must not be specified")
-  }
-  return err
+	if err == nil && artifactstream.Id != "" {
+		err = store.validateId(artifactstream.Id, "artifactStreamId")
+	}
+	if err == nil && artifactstream.UserId != "" {
+		err = store.validateId(artifactstream.UserId, "userId")
+	}
+	if err == nil && len(artifactstream.Content) == 0 {
+		err = errors.New("Missing stream content")
+	}
+	if err == nil && len(artifactstream.Kind) > 0 {
+		err = errors.New("Field 'Kind' must not be specified")
+	}
+	if err == nil && len(artifactstream.Operation) > 0 {
+		err = errors.New("Field 'Operation' must not be specified")
+	}
+	return err
 }
 
 func (store *ElasticCasestore) prepareForSave(ctx context.Context, obj *model.Auditable) string {
-  obj.UserId = ctx.Value(web.ContextKeyRequestorId).(string)
+	obj.UserId = ctx.Value(web.ContextKeyRequestorId).(string)
 
-  // Don't waste space by saving the these values which are already part of ES documents
-  id := obj.Id
-  obj.Id = ""
-  obj.UpdateTime = nil
+	// Don't waste space by saving the these values which are already part of ES documents
+	id := obj.Id
+	obj.Id = ""
+	obj.UpdateTime = nil
 
-  return id
+	return id
 }
 
 func (store *ElasticCasestore) save(ctx context.Context, obj interface{}, kind string, id string) (*model.EventIndexResults, error) {
-  var results *model.EventIndexResults
-  var err error
+	var results *model.EventIndexResults
+	var err error
 
-  if err = store.server.CheckAuthorized(ctx, "write", "cases"); err == nil {
-    document := convertObjectToDocumentMap(kind, obj, store.schemaPrefix)
-    document[store.schemaPrefix+"kind"] = kind
-    results, err = store.server.Eventstore.Index(ctx, store.index, document, id)
-    if err == nil {
-      document[store.schemaPrefix+AUDIT_DOC_ID] = results.DocumentId
-      if id == "" {
-        document[store.schemaPrefix+"operation"] = "create"
-      } else {
-        document[store.schemaPrefix+"operation"] = "update"
-      }
-      _, err = store.server.Eventstore.Index(ctx, store.auditIndex, document, "")
-      if err != nil {
-        log.WithFields(log.Fields{
-          "documentId": results.DocumentId,
-          "kind":       kind,
-        }).WithError(err).Error("Object indexed successfully however audit record failed to index")
-      }
-    }
-  }
+	if err = store.server.CheckAuthorized(ctx, "write", "cases"); err == nil {
+		document := convertObjectToDocumentMap(kind, obj, store.schemaPrefix)
+		document[store.schemaPrefix+"kind"] = kind
+		results, err = store.server.Eventstore.Index(ctx, store.index, document, id)
+		if err == nil {
+			document[store.schemaPrefix+AUDIT_DOC_ID] = results.DocumentId
+			if id == "" {
+				document[store.schemaPrefix+"operation"] = "create"
+			} else {
+				document[store.schemaPrefix+"operation"] = "update"
+			}
+			_, err = store.server.Eventstore.Index(ctx, store.auditIndex, document, "")
+			if err != nil {
+				log.WithFields(log.Fields{
+					"documentId": results.DocumentId,
+					"kind":       kind,
+				}).WithError(err).Error("Object indexed successfully however audit record failed to index")
+			}
+		}
+	}
 
-  return results, err
+	return results, err
 }
 
 func (store *ElasticCasestore) delete(ctx context.Context, obj interface{}, kind string, id string) error {
-  var err error
+	var err error
 
-  if err = store.server.CheckAuthorized(ctx, "write", "cases"); err == nil {
-    err = store.server.Eventstore.Delete(ctx, store.index, id)
-    if err == nil {
-      document := convertObjectToDocumentMap(kind, obj, store.schemaPrefix)
-      document[store.schemaPrefix+AUDIT_DOC_ID] = id
-      document[store.schemaPrefix+"kind"] = kind
-      document[store.schemaPrefix+"operation"] = "delete"
-      _, err = store.server.Eventstore.Index(ctx, store.auditIndex, document, "")
-      if err != nil {
-        log.WithFields(log.Fields{
-          "documentId": id,
-          "kind":       kind,
-        }).WithError(err).Error("Object deleted successfully however audit record failed to index")
-      }
-    }
-  }
+	if err = store.server.CheckAuthorized(ctx, "write", "cases"); err == nil {
+		err = store.server.Eventstore.Delete(ctx, store.index, id)
+		if err == nil {
+			document := convertObjectToDocumentMap(kind, obj, store.schemaPrefix)
+			document[store.schemaPrefix+AUDIT_DOC_ID] = id
+			document[store.schemaPrefix+"kind"] = kind
+			document[store.schemaPrefix+"operation"] = "delete"
+			_, err = store.server.Eventstore.Index(ctx, store.auditIndex, document, "")
+			if err != nil {
+				log.WithFields(log.Fields{
+					"documentId": id,
+					"kind":       kind,
+				}).WithError(err).Error("Object deleted successfully however audit record failed to index")
+			}
+		}
+	}
 
-  return err
+	return err
 }
 
 func (store *ElasticCasestore) get(ctx context.Context, id string, kind string) (interface{}, error) {
-  query := fmt.Sprintf(`_index:"%s" AND %skind:"%s" AND _id:"%s"`, store.index, store.schemaPrefix, kind, id)
-  objects, err := store.getAll(ctx, query, 1)
-  if err == nil {
-    if len(objects) > 0 {
-      return objects[0], err
-    }
-    err = errors.New("Object not found")
-  }
-  return nil, err
+	query := fmt.Sprintf(`_index:"%s" AND %skind:"%s" AND _id:"%s"`, store.index, store.schemaPrefix, kind, id)
+	objects, err := store.getAll(ctx, query, 1)
+	if err == nil {
+		if len(objects) > 0 {
+			return objects[0], err
+		}
+		err = errors.New("Object not found")
+	}
+	return nil, err
 }
 
 func (store *ElasticCasestore) getAll(ctx context.Context, query string, max int) ([]interface{}, error) {
-  var err error
-  var objects []interface{}
+	var err error
+	var objects []interface{}
 
-  if err = store.server.CheckAuthorized(ctx, "read", "cases"); err == nil {
-    criteria := model.NewEventSearchCriteria()
-    format := "2006-01-02 3:04:05 PM"
-    var zeroTime time.Time
-    zeroTimeStr := zeroTime.Format(format)
-    now := time.Now()
-    endTime := now.Format(format)
-    zone := now.Location().String()
-    err = criteria.Populate(query,
-      zeroTimeStr+" - "+endTime, // timeframe range
-      format,                    // timeframe format
-      zone,                      // timezone
-      "0",                       // no metrics
-      strconv.Itoa(max))
+	if err = store.server.CheckAuthorized(ctx, "read", "cases"); err == nil {
+		criteria := model.NewEventSearchCriteria()
+		format := "2006-01-02 3:04:05 PM"
+		var zeroTime time.Time
+		zeroTimeStr := zeroTime.Format(format)
+		now := time.Now()
+		endTime := now.Format(format)
+		zone := now.Location().String()
+		err = criteria.Populate(query,
+			zeroTimeStr+" - "+endTime, // timeframe range
+			format,                    // timeframe format
+			zone,                      // timezone
+			"0",                       // no metrics
+			strconv.Itoa(max))
 
-    if err == nil {
-      var results *model.EventSearchResults
-      results, err = store.server.Eventstore.Search(ctx, criteria)
-      if err == nil {
-        for _, event := range results.Events {
-          var obj interface{}
-          obj, err = convertElasticEventToObject(event, store.schemaPrefix)
-          if err == nil {
-            objects = append(objects, obj)
-          } else {
-            log.WithField("event", event).WithError(err).Error("Unable to convert case object")
-          }
-        }
-      }
-    }
-  }
+		if err == nil {
+			var results *model.EventSearchResults
+			results, err = store.server.Eventstore.Search(ctx, criteria)
+			if err == nil {
+				for _, event := range results.Events {
+					var obj interface{}
+					obj, err = convertElasticEventToObject(event, store.schemaPrefix)
+					if err == nil {
+						objects = append(objects, obj)
+					} else {
+						log.WithField("event", event).WithError(err).Error("Unable to convert case object")
+					}
+				}
+			}
+		}
+	}
 
-  return objects, err
+	return objects, err
 }
 
 func (store *ElasticCasestore) Create(ctx context.Context, socCase *model.Case) (*model.Case, error) {
-  var err error
+	var err error
 
-  socCase.Status = model.CASE_STATUS_NEW
-  err = store.validateCase(socCase)
-  if err == nil {
-    if socCase.Id != "" {
-      err = errors.New("Unexpected ID found in new case")
-    } else {
-      socCase = store.applyTemplate(ctx, socCase)
-      now := time.Now()
-      socCase.CreateTime = &now
-      var results *model.EventIndexResults
-      results, err = store.save(ctx, socCase, "case", store.prepareForSave(ctx, &socCase.Auditable))
-      if err == nil {
-        // Read object back to get new modify date, etc
-        socCase, err = store.GetCase(ctx, results.DocumentId)
-      }
-    }
-  }
-  return socCase, err
+	socCase.Status = model.CASE_STATUS_NEW
+	err = store.validateCase(socCase)
+	if err == nil {
+		if socCase.Id != "" {
+			err = errors.New("Unexpected ID found in new case")
+		} else {
+			socCase = store.applyTemplate(ctx, socCase)
+			now := time.Now()
+			socCase.CreateTime = &now
+			var results *model.EventIndexResults
+			results, err = store.save(ctx, socCase, "case", store.prepareForSave(ctx, &socCase.Auditable))
+			if err == nil {
+				// Read object back to get new modify date, etc
+				socCase, err = store.GetCase(ctx, results.DocumentId)
+			}
+		}
+	}
+	return socCase, err
 }
 
 func (store *ElasticCasestore) Update(ctx context.Context, socCase *model.Case) (*model.Case, error) {
-  var err error
+	var err error
 
-  err = store.validateCase(socCase)
-  if err == nil {
-    if socCase.Id == "" {
-      err = errors.New("Missing case ID")
-    } else {
-      var oldCase *model.Case
-      oldCase, err = store.GetCase(ctx, socCase.Id)
-      if err == nil {
-        // Preserve read-only fields
-        socCase.CreateTime = oldCase.CreateTime
-        socCase.CompleteTime = oldCase.CompleteTime
-        socCase.StartTime = oldCase.StartTime
-        socCase.ProcessWorkflowForStatus(oldCase)
-        var results *model.EventIndexResults
-        results, err = store.save(ctx, socCase, "case", store.prepareForSave(ctx, &socCase.Auditable))
-        if err == nil {
-          // Read object back to get new modify date, etc
-          socCase, err = store.GetCase(ctx, results.DocumentId)
-        }
-      }
-    }
-  }
-  return socCase, err
+	err = store.validateCase(socCase)
+	if err == nil {
+		if socCase.Id == "" {
+			err = errors.New("Missing case ID")
+		} else {
+			var oldCase *model.Case
+			oldCase, err = store.GetCase(ctx, socCase.Id)
+			if err == nil {
+				// Preserve read-only fields
+				socCase.CreateTime = oldCase.CreateTime
+				socCase.CompleteTime = oldCase.CompleteTime
+				socCase.StartTime = oldCase.StartTime
+				socCase.ProcessWorkflowForStatus(oldCase)
+				var results *model.EventIndexResults
+				results, err = store.save(ctx, socCase, "case", store.prepareForSave(ctx, &socCase.Auditable))
+				if err == nil {
+					// Read object back to get new modify date, etc
+					socCase, err = store.GetCase(ctx, results.DocumentId)
+				}
+			}
+		}
+	}
+	return socCase, err
 }
 
 func (store *ElasticCasestore) GetCase(ctx context.Context, id string) (*model.Case, error) {
-  var err error
-  var socCase *model.Case
+	var err error
+	var socCase *model.Case
 
-  err = store.validateId(id, "caseId")
-  if err == nil {
-    var obj interface{}
-    obj, err = store.get(ctx, id, "case")
-    if err == nil {
-      socCase = obj.(*model.Case)
-    }
-  }
-  return socCase, err
+	err = store.validateId(id, "caseId")
+	if err == nil {
+		var obj interface{}
+		obj, err = store.get(ctx, id, "case")
+		if err == nil {
+			socCase = obj.(*model.Case)
+		}
+	}
+	return socCase, err
 }
 
 func (store *ElasticCasestore) GetCaseHistory(ctx context.Context, caseId string) ([]interface{}, error) {
-  var err error
-  var history []interface{}
+	var err error
+	var history []interface{}
 
-  err = store.validateId(caseId, "caseId")
-  if err == nil {
-    query := fmt.Sprintf(`_index:"%s" AND (%s%s:"%s" OR %scomment.caseId:"%s" OR %srelated.caseId:"%s" OR %sartifact.caseId:"%s") | sortby @timestamp^`,
-      store.auditIndex, store.schemaPrefix, AUDIT_DOC_ID, caseId, store.schemaPrefix, caseId, store.schemaPrefix, caseId, store.schemaPrefix, caseId)
-    history, err = store.getAll(ctx, query, store.maxAssociations)
-  }
-  return history, err
+	err = store.validateId(caseId, "caseId")
+	if err == nil {
+		query := fmt.Sprintf(`_index:"%s" AND (%s%s:"%s" OR %scomment.caseId:"%s" OR %srelated.caseId:"%s" OR %sartifact.caseId:"%s") | sortby @timestamp^`,
+			store.auditIndex, store.schemaPrefix, AUDIT_DOC_ID, caseId, store.schemaPrefix, caseId, store.schemaPrefix, caseId, store.schemaPrefix, caseId)
+		history, err = store.getAll(ctx, query, store.maxAssociations)
+	}
+	return history, err
 }
 
 func (store *ElasticCasestore) CreateRelatedEvent(ctx context.Context, event *model.RelatedEvent) (*model.RelatedEvent, error) {
-  var err error
+	var err error
 
-  err = store.validateRelatedEvent(event)
-  if err == nil {
-    if event.Id != "" {
-      return nil, errors.New("Unexpected ID found in new related event")
-    } else if event.CaseId == "" {
-      return nil, errors.New("Missing Case ID in new related event")
-    } else {
-      _, err = store.GetCase(ctx, event.CaseId)
-      if err == nil {
-        var newId string
-        if value, ok := event.Fields["soc_id"]; ok {
-          newId = value.(string)
-          var existingEvents []*model.RelatedEvent
-          existingEvents, err = store.GetRelatedEvents(ctx, event.CaseId)
-          for _, existingEvent := range existingEvents {
-            if value, ok := existingEvent.Fields["soc_id"]; ok {
-              existingId := value.(string)
-              if existingId == newId {
-                err = errors.New("ERROR_CASE_EVENT_ALREADY_ATTACHED")
-                break
-              }
-            }
-          }
-        }
-        if err == nil {
-          var results *model.EventIndexResults
-          results, err = store.save(ctx, event, "related", store.prepareForSave(ctx, &event.Auditable))
-          if err == nil {
-            // Read object back to get new modify date, etc
-            event, err = store.GetRelatedEvent(ctx, results.DocumentId)
-          }
-        }
-      }
-    }
-  }
+	err = store.validateRelatedEvent(event)
+	if err == nil {
+		if event.Id != "" {
+			return nil, errors.New("Unexpected ID found in new related event")
+		} else if event.CaseId == "" {
+			return nil, errors.New("Missing Case ID in new related event")
+		} else {
+			_, err = store.GetCase(ctx, event.CaseId)
+			if err == nil {
+				var newId string
+				if value, ok := event.Fields["soc_id"]; ok {
+					newId = value.(string)
+					var existingEvents []*model.RelatedEvent
+					existingEvents, err = store.GetRelatedEvents(ctx, event.CaseId)
+					for _, existingEvent := range existingEvents {
+						if value, ok := existingEvent.Fields["soc_id"]; ok {
+							existingId := value.(string)
+							if existingId == newId {
+								err = errors.New("ERROR_CASE_EVENT_ALREADY_ATTACHED")
+								break
+							}
+						}
+					}
+				}
+				if err == nil {
+					var results *model.EventIndexResults
+					results, err = store.save(ctx, event, "related", store.prepareForSave(ctx, &event.Auditable))
+					if err == nil {
+						// Read object back to get new modify date, etc
+						event, err = store.GetRelatedEvent(ctx, results.DocumentId)
+						if err == nil {
+							if err = store.ExtractCommonObservables(ctx, event); err != nil {
+								return nil, fmt.Errorf("error extracting common observables: %w", err)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
-  return event, err
+	return event, err
 }
 
 func (store *ElasticCasestore) GetRelatedEvent(ctx context.Context, id string) (*model.RelatedEvent, error) {
-  var err error
-  var event *model.RelatedEvent
+	var err error
+	var event *model.RelatedEvent
 
-  err = store.validateId(id, "relatedEventId")
-  if err == nil {
-    var obj interface{}
-    obj, err = store.get(ctx, id, "related")
-    if err == nil {
-      event = obj.(*model.RelatedEvent)
-    }
-  }
-  return event, err
+	err = store.validateId(id, "relatedEventId")
+	if err == nil {
+		var obj interface{}
+		obj, err = store.get(ctx, id, "related")
+		if err == nil {
+			event = obj.(*model.RelatedEvent)
+		}
+	}
+	return event, err
 }
 
 func (store *ElasticCasestore) GetRelatedEvents(ctx context.Context, caseId string) ([]*model.RelatedEvent, error) {
-  var err error
-  var events []*model.RelatedEvent
+	var err error
+	var events []*model.RelatedEvent
 
-  err = store.validateId(caseId, "caseId")
-  if err == nil {
-    events = make([]*model.RelatedEvent, 0)
-    // JBE 10/20/2022: Remove sortby due to issue with Elastic 8.4 causing incompatible sort field types
-    //  | sortby %srelated.fields.timestamp^
-    query := fmt.Sprintf(`_index:"%s" AND %skind:"related" AND %srelated.caseId:"%s"`, store.index, store.schemaPrefix, store.schemaPrefix, caseId)
-    var objects []interface{}
-    objects, err = store.getAll(ctx, query, store.maxAssociations)
-    if err == nil {
-      for _, obj := range objects {
-        events = append(events, obj.(*model.RelatedEvent))
-      }
+	err = store.validateId(caseId, "caseId")
+	if err == nil {
+		events = make([]*model.RelatedEvent, 0)
+		// JBE 10/20/2022: Remove sortby due to issue with Elastic 8.4 causing incompatible sort field types
+		//  | sortby %srelated.fields.timestamp^
+		query := fmt.Sprintf(`_index:"%s" AND %skind:"related" AND %srelated.caseId:"%s"`, store.index, store.schemaPrefix, store.schemaPrefix, caseId)
+		var objects []interface{}
+		objects, err = store.getAll(ctx, query, store.maxAssociations)
+		if err == nil {
+			for _, obj := range objects {
+				events = append(events, obj.(*model.RelatedEvent))
+			}
 
-      // JBE 10/20/2022: Manually sort the related events by the timestamp field, in ascending order. This can remain
-      // in place even if the above ES issue is resolved.
-      sort.Slice(events, func(a, b int) bool {
-        if ts_a, ts_a_exists := events[a].Fields["timestamp"]; ts_a_exists {
-          if ts_a_typed, ts_a_correct_type := ts_a.(time.Time); ts_a_correct_type {
-            if ts_b, ts_b_exists := events[b].Fields["timestamp"]; ts_b_exists {
-              if ts_b_typed, ts_b_correct_type := ts_b.(time.Time); ts_b_correct_type {
-                return ts_a_typed.Before(ts_b_typed)
-              }
-            }
-          }
-        }
-        return false
-      })
-    }
-  }
-  return events, err
+			// JBE 10/20/2022: Manually sort the related events by the timestamp field, in ascending order. This can remain
+			// in place even if the above ES issue is resolved.
+			sort.Slice(events, func(a, b int) bool {
+				if ts_a, ts_a_exists := events[a].Fields["timestamp"]; ts_a_exists {
+					if ts_a_typed, ts_a_correct_type := ts_a.(time.Time); ts_a_correct_type {
+						if ts_b, ts_b_exists := events[b].Fields["timestamp"]; ts_b_exists {
+							if ts_b_typed, ts_b_correct_type := ts_b.(time.Time); ts_b_correct_type {
+								return ts_a_typed.Before(ts_b_typed)
+							}
+						}
+					}
+				}
+				return false
+			})
+		}
+	}
+	return events, err
 }
 
 func (store *ElasticCasestore) DeleteRelatedEvent(ctx context.Context, id string) error {
-  var err error
+	var err error
 
-  var event *model.RelatedEvent
-  err = store.validateId(id, "relatedEventId")
-  if err == nil {
-    event, err = store.GetRelatedEvent(ctx, id)
-    if err == nil {
-      err = store.delete(ctx, event, "related", store.prepareForSave(ctx, &event.Auditable))
-    }
-  }
+	var event *model.RelatedEvent
+	err = store.validateId(id, "relatedEventId")
+	if err == nil {
+		event, err = store.GetRelatedEvent(ctx, id)
+		if err == nil {
+			err = store.delete(ctx, event, "related", store.prepareForSave(ctx, &event.Auditable))
+		}
+	}
 
-  return err
+	return err
 }
 
 func (store *ElasticCasestore) CreateComment(ctx context.Context, comment *model.Comment) (*model.Comment, error) {
-  var err error
+	var err error
 
-  err = store.validateComment(comment)
-  if err == nil {
-    if comment.Id != "" {
-      return nil, errors.New("Unexpected ID found in new comment")
-    } else if comment.CaseId == "" {
-      return nil, errors.New("Missing Case ID in new comment")
-    } else {
-      _, err = store.GetCase(ctx, comment.CaseId)
-      if err == nil {
-        now := time.Now()
-        comment.CreateTime = &now
-        var results *model.EventIndexResults
-        results, err = store.save(ctx, comment, "comment", store.prepareForSave(ctx, &comment.Auditable))
-        if err == nil {
-          // Read object back to get new modify date, etc
-          comment, err = store.GetComment(ctx, results.DocumentId)
-        }
-      }
-    }
-  }
-  return comment, err
+	err = store.validateComment(comment)
+	if err == nil {
+		if comment.Id != "" {
+			return nil, errors.New("Unexpected ID found in new comment")
+		} else if comment.CaseId == "" {
+			return nil, errors.New("Missing Case ID in new comment")
+		} else {
+			_, err = store.GetCase(ctx, comment.CaseId)
+			if err == nil {
+				now := time.Now()
+				comment.CreateTime = &now
+				var results *model.EventIndexResults
+				results, err = store.save(ctx, comment, "comment", store.prepareForSave(ctx, &comment.Auditable))
+				if err == nil {
+					// Read object back to get new modify date, etc
+					comment, err = store.GetComment(ctx, results.DocumentId)
+				}
+			}
+		}
+	}
+	return comment, err
 }
 
 func (store *ElasticCasestore) GetComment(ctx context.Context, id string) (*model.Comment, error) {
-  var err error
-  var comment *model.Comment
+	var err error
+	var comment *model.Comment
 
-  err = store.validateId(id, "commentId")
-  if err == nil {
-    var obj interface{}
-    obj, err = store.get(ctx, id, "comment")
-    if err == nil {
-      comment = obj.(*model.Comment)
-    }
-  }
-  return comment, err
+	err = store.validateId(id, "commentId")
+	if err == nil {
+		var obj interface{}
+		obj, err = store.get(ctx, id, "comment")
+		if err == nil {
+			comment = obj.(*model.Comment)
+		}
+	}
+	return comment, err
 }
 
 func (store *ElasticCasestore) GetComments(ctx context.Context, caseId string) ([]*model.Comment, error) {
-  var err error
-  var comments []*model.Comment
+	var err error
+	var comments []*model.Comment
 
-  err = store.validateId(caseId, "caseId")
-  if err == nil {
-    comments = make([]*model.Comment, 0)
-    query := fmt.Sprintf(`_index:"%s" AND %skind:"comment" AND %scomment.caseId:"%s" | sortby %scomment.createTime^`, store.index, store.schemaPrefix, store.schemaPrefix, caseId, store.schemaPrefix)
-    var objects []interface{}
-    objects, err = store.getAll(ctx, query, store.maxAssociations)
-    if err == nil {
-      for _, obj := range objects {
-        comments = append(comments, obj.(*model.Comment))
-      }
-    }
-  }
-  return comments, err
+	err = store.validateId(caseId, "caseId")
+	if err == nil {
+		comments = make([]*model.Comment, 0)
+		query := fmt.Sprintf(`_index:"%s" AND %skind:"comment" AND %scomment.caseId:"%s" | sortby %scomment.createTime^`, store.index, store.schemaPrefix, store.schemaPrefix, caseId, store.schemaPrefix)
+		var objects []interface{}
+		objects, err = store.getAll(ctx, query, store.maxAssociations)
+		if err == nil {
+			for _, obj := range objects {
+				comments = append(comments, obj.(*model.Comment))
+			}
+		}
+	}
+	return comments, err
 }
 
 func (store *ElasticCasestore) UpdateComment(ctx context.Context, comment *model.Comment) (*model.Comment, error) {
-  var err error
+	var err error
 
-  err = store.validateComment(comment)
-  if err == nil {
-    if comment.Id == "" {
-      err = errors.New("Missing comment ID")
-    } else {
-      var old *model.Comment
-      old, err = store.GetComment(ctx, comment.Id)
-      if err == nil {
-        // Preserve read-only fields
-        comment.CreateTime = old.CreateTime
-        var results *model.EventIndexResults
-        results, err = store.save(ctx, comment, "comment", store.prepareForSave(ctx, &comment.Auditable))
-        if err == nil {
-          // Read object back to get new modify date, etc
-          comment, err = store.GetComment(ctx, results.DocumentId)
-        }
-      }
-    }
-  }
-  return comment, err
+	err = store.validateComment(comment)
+	if err == nil {
+		if comment.Id == "" {
+			err = errors.New("Missing comment ID")
+		} else {
+			var old *model.Comment
+			old, err = store.GetComment(ctx, comment.Id)
+			if err == nil {
+				// Preserve read-only fields
+				comment.CreateTime = old.CreateTime
+				var results *model.EventIndexResults
+				results, err = store.save(ctx, comment, "comment", store.prepareForSave(ctx, &comment.Auditable))
+				if err == nil {
+					// Read object back to get new modify date, etc
+					comment, err = store.GetComment(ctx, results.DocumentId)
+				}
+			}
+		}
+	}
+	return comment, err
 }
 
 func (store *ElasticCasestore) DeleteComment(ctx context.Context, id string) error {
-  var err error
+	var err error
 
-  var comment *model.Comment
-  comment, err = store.GetComment(ctx, id)
-  if err == nil {
-    err = store.delete(ctx, comment, "comment", store.prepareForSave(ctx, &comment.Auditable))
-  }
+	var comment *model.Comment
+	comment, err = store.GetComment(ctx, id)
+	if err == nil {
+		err = store.delete(ctx, comment, "comment", store.prepareForSave(ctx, &comment.Auditable))
+	}
 
-  return err
+	return err
 }
 
 func (store *ElasticCasestore) CreateArtifact(ctx context.Context, artifact *model.Artifact) (*model.Artifact, error) {
-  var err error
+	var err error
 
-  err = store.validateArtifact(artifact)
-  if err == nil {
-    if artifact.Id != "" {
-      return nil, errors.New("Unexpected ID found in new artifact")
-    } else if artifact.CaseId == "" {
-      return nil, errors.New("Missing Case ID in new artifact")
-    } else if artifact.GroupType == "" {
-      return nil, errors.New("Missing GroupType in new artifact")
-    } else {
-      _, err = store.GetCase(ctx, artifact.CaseId)
-      if err == nil {
-        now := time.Now()
-        artifact.CreateTime = &now
-        var results *model.EventIndexResults
-        results, err = store.save(ctx, artifact, "artifact", store.prepareForSave(ctx, &artifact.Auditable))
-        if err == nil {
-          // Read object back to get new modify date, etc
-          artifact, err = store.GetArtifact(ctx, results.DocumentId)
-        }
-      }
-    }
-  }
-  return artifact, err
+	err = store.validateArtifact(artifact)
+	if err == nil {
+		if artifact.Id != "" {
+			return nil, errors.New("Unexpected ID found in new artifact")
+		} else if artifact.CaseId == "" {
+			return nil, errors.New("Missing Case ID in new artifact")
+		} else if artifact.GroupType == "" {
+			return nil, errors.New("Missing GroupType in new artifact")
+		} else {
+			_, err = store.GetCase(ctx, artifact.CaseId)
+			if err == nil {
+				now := time.Now()
+				artifact.CreateTime = &now
+				var results *model.EventIndexResults
+				results, err = store.save(ctx, artifact, "artifact", store.prepareForSave(ctx, &artifact.Auditable))
+				if err == nil {
+					// Read object back to get new modify date, etc
+					artifact, err = store.GetArtifact(ctx, results.DocumentId)
+				}
+			}
+		}
+	}
+	return artifact, err
 }
 
 func (store *ElasticCasestore) GetArtifact(ctx context.Context, id string) (*model.Artifact, error) {
-  var err error
-  var artifact *model.Artifact
+	var err error
+	var artifact *model.Artifact
 
-  err = store.validateId(id, "artifactId")
-  if err == nil {
-    var obj interface{}
-    obj, err = store.get(ctx, id, "artifact")
-    if err == nil {
-      artifact = obj.(*model.Artifact)
-    }
-  }
-  return artifact, err
+	err = store.validateId(id, "artifactId")
+	if err == nil {
+		var obj interface{}
+		obj, err = store.get(ctx, id, "artifact")
+		if err == nil {
+			artifact = obj.(*model.Artifact)
+		}
+	}
+	return artifact, err
 }
 
 func (store *ElasticCasestore) GetArtifacts(ctx context.Context, caseId string, groupType string, groupId string) ([]*model.Artifact, error) {
-  var err error
-  var artifacts []*model.Artifact
+	var err error
+	var artifacts []*model.Artifact
 
-  err = store.validateId(caseId, "caseId")
-  if err == nil {
-    err = store.validateId(groupType, "groupType") // It's not technically an ID but the possible values confirm to an ID, so let's validate it as an ID.
-    if err == nil {
-      if len(groupId) > 0 {
-        // groupId is optional, since some group won't have multiple groups per case.
-        err = store.validateId(groupId, "groupId")
-      }
-      if err == nil {
-        artifacts = make([]*model.Artifact, 0)
-        var groupIdTerm string
-        if len(groupId) > 0 {
-          groupIdTerm = fmt.Sprintf(`AND %sartifact.groupId:"%s" `, store.schemaPrefix, groupId)
-        }
-        query := fmt.Sprintf(`_index:"%s" AND %skind:"artifact" AND %sartifact.caseId:"%s" AND %sartifact.groupType:"%s" %s| sortby %sartifact.createTime^`,
-          store.index, store.schemaPrefix, store.schemaPrefix, caseId, store.schemaPrefix, groupType, groupIdTerm, store.schemaPrefix)
-        var objects []interface{}
-        objects, err = store.getAll(ctx, query, store.maxAssociations)
-        if err == nil {
-          for _, obj := range objects {
-            artifacts = append(artifacts, obj.(*model.Artifact))
-          }
-        }
-      }
-    }
-  }
-  return artifacts, err
+	err = store.validateId(caseId, "caseId")
+	if err == nil {
+		err = store.validateId(groupType, "groupType") // It's not technically an ID but the possible values confirm to an ID, so let's validate it as an ID.
+		if err == nil {
+			if len(groupId) > 0 {
+				// groupId is optional, since some group won't have multiple groups per case.
+				err = store.validateId(groupId, "groupId")
+			}
+			if err == nil {
+				artifacts = make([]*model.Artifact, 0)
+				var groupIdTerm string
+				if len(groupId) > 0 {
+					groupIdTerm = fmt.Sprintf(`AND %sartifact.groupId:"%s" `, store.schemaPrefix, groupId)
+				}
+				query := fmt.Sprintf(`_index:"%s" AND %skind:"artifact" AND %sartifact.caseId:"%s" AND %sartifact.groupType:"%s" %s| sortby %sartifact.createTime^`,
+					store.index, store.schemaPrefix, store.schemaPrefix, caseId, store.schemaPrefix, groupType, groupIdTerm, store.schemaPrefix)
+				var objects []interface{}
+				objects, err = store.getAll(ctx, query, store.maxAssociations)
+				if err == nil {
+					for _, obj := range objects {
+						artifacts = append(artifacts, obj.(*model.Artifact))
+					}
+				}
+			}
+		}
+	}
+	return artifacts, err
 }
 
 func (store *ElasticCasestore) UpdateArtifact(ctx context.Context, artifact *model.Artifact) (*model.Artifact, error) {
-  var err error
+	var err error
 
-  err = store.validateArtifact(artifact)
-  if err == nil {
-    if artifact.Id == "" {
-      err = errors.New("Missing artifact ID")
-    } else {
-      var old *model.Artifact
-      old, err = store.GetArtifact(ctx, artifact.Id)
-      if err == nil {
-        // Preserve read-only fields
-        artifact.CreateTime = old.CreateTime
-        artifact.ArtifactType = old.ArtifactType
-        artifact.Value = old.Value
-        artifact.GroupType = old.GroupType
-        artifact.GroupId = old.GroupId
-        artifact.StreamLen = old.StreamLen
-        artifact.MimeType = old.MimeType
-        artifact.StreamId = old.StreamId
-        artifact.Md5 = old.Md5
-        artifact.Sha1 = old.Sha1
-        artifact.Sha256 = old.Sha256
-        var results *model.EventIndexResults
-        results, err = store.save(ctx, artifact, "artifact", store.prepareForSave(ctx, &artifact.Auditable))
-        if err == nil {
-          // Read object back to get new modify date, etc
-          artifact, err = store.GetArtifact(ctx, results.DocumentId)
-        }
-      }
-    }
-  }
-  return artifact, err
+	err = store.validateArtifact(artifact)
+	if err == nil {
+		if artifact.Id == "" {
+			err = errors.New("Missing artifact ID")
+		} else {
+			var old *model.Artifact
+			old, err = store.GetArtifact(ctx, artifact.Id)
+			if err == nil {
+				// Preserve read-only fields
+				artifact.CreateTime = old.CreateTime
+				artifact.ArtifactType = old.ArtifactType
+				artifact.Value = old.Value
+				artifact.GroupType = old.GroupType
+				artifact.GroupId = old.GroupId
+				artifact.StreamLen = old.StreamLen
+				artifact.MimeType = old.MimeType
+				artifact.StreamId = old.StreamId
+				artifact.Md5 = old.Md5
+				artifact.Sha1 = old.Sha1
+				artifact.Sha256 = old.Sha256
+				var results *model.EventIndexResults
+				results, err = store.save(ctx, artifact, "artifact", store.prepareForSave(ctx, &artifact.Auditable))
+				if err == nil {
+					// Read object back to get new modify date, etc
+					artifact, err = store.GetArtifact(ctx, results.DocumentId)
+				}
+			}
+		}
+	}
+	return artifact, err
 }
 
 func (store *ElasticCasestore) DeleteArtifact(ctx context.Context, id string) error {
-  artifact, err := store.GetArtifact(ctx, id)
-  if err == nil {
-    if len(artifact.StreamId) > 0 {
-      err = store.DeleteArtifactStream(ctx, artifact.StreamId)
-      if err != nil {
-        log.WithError(err).WithFields(log.Fields{
-          "artifactStreamId": artifact.StreamId,
-          "artifactId":       artifact.Id,
-        }).Error("Unable to delete artifact stream; proceeding with artifact deletion anyway")
-      }
-    }
+	artifact, err := store.GetArtifact(ctx, id)
+	if err == nil {
+		if len(artifact.StreamId) > 0 {
+			err = store.DeleteArtifactStream(ctx, artifact.StreamId)
+			if err != nil {
+				log.WithError(err).WithFields(log.Fields{
+					"artifactStreamId": artifact.StreamId,
+					"artifactId":       artifact.Id,
+				}).Error("Unable to delete artifact stream; proceeding with artifact deletion anyway")
+			}
+		}
 
-    // Delete analyzer results
-    if store.server.Datastore != nil {
-      idPair := make(map[string]interface{})
-      idPair["id"] = id
-      params := make(map[string]interface{})
-      params["artifact"] = idPair
-      jobs := store.server.Datastore.GetJobs(ctx, "analyze", params)
-      for _, job := range jobs {
-        job, err := store.server.Datastore.DeleteJob(ctx, job.Id)
-        if err != nil {
-          log.WithError(err).WithFields(log.Fields{
-            "artifactId": artifact.Id,
-            "jobId":      job.Id,
-          }).Error("Unable to delete analyze job; continuing")
-        }
-      }
-    }
+		// Delete analyzer results
+		if store.server.Datastore != nil {
+			idPair := make(map[string]interface{})
+			idPair["id"] = id
+			params := make(map[string]interface{})
+			params["artifact"] = idPair
+			jobs := store.server.Datastore.GetJobs(ctx, "analyze", params)
+			for _, job := range jobs {
+				job, err := store.server.Datastore.DeleteJob(ctx, job.Id)
+				if err != nil {
+					log.WithError(err).WithFields(log.Fields{
+						"artifactId": artifact.Id,
+						"jobId":      job.Id,
+					}).Error("Unable to delete analyze job; continuing")
+				}
+			}
+		}
 
-    err = store.delete(ctx, artifact, "artifact", store.prepareForSave(ctx, &artifact.Auditable))
-  }
+		err = store.delete(ctx, artifact, "artifact", store.prepareForSave(ctx, &artifact.Auditable))
+	}
 
-  return err
+	return err
 }
 
 func (store *ElasticCasestore) CreateArtifactStream(ctx context.Context, artifactstream *model.ArtifactStream) (string, error) {
-  var id string
-  err := store.validateArtifactStream(artifactstream)
-  if err == nil {
-    if artifactstream.Id != "" {
-      return "", errors.New("Unexpected ID found in new artifactstream")
-    } else {
-      now := time.Now()
-      artifactstream.CreateTime = &now
-      var results *model.EventIndexResults
-      results, err = store.save(ctx, artifactstream, "artifactstream", store.prepareForSave(ctx, &artifactstream.Auditable))
-      if err == nil {
-        id = results.DocumentId
-      }
-    }
-  }
-  return id, err
+	var id string
+	err := store.validateArtifactStream(artifactstream)
+	if err == nil {
+		if artifactstream.Id != "" {
+			return "", errors.New("Unexpected ID found in new artifactstream")
+		} else {
+			now := time.Now()
+			artifactstream.CreateTime = &now
+			var results *model.EventIndexResults
+			results, err = store.save(ctx, artifactstream, "artifactstream", store.prepareForSave(ctx, &artifactstream.Auditable))
+			if err == nil {
+				id = results.DocumentId
+			}
+		}
+	}
+	return id, err
 }
 
 func (store *ElasticCasestore) GetArtifactStream(ctx context.Context, id string) (*model.ArtifactStream, error) {
-  var err error
-  var artifactstream *model.ArtifactStream
+	var err error
+	var artifactstream *model.ArtifactStream
 
-  err = store.validateId(id, "artifactStreamId")
-  if err == nil {
-    var obj interface{}
-    obj, err = store.get(ctx, id, "artifactstream")
-    if err == nil {
-      artifactstream = obj.(*model.ArtifactStream)
-    }
-  }
-  return artifactstream, err
+	err = store.validateId(id, "artifactStreamId")
+	if err == nil {
+		var obj interface{}
+		obj, err = store.get(ctx, id, "artifactstream")
+		if err == nil {
+			artifactstream = obj.(*model.ArtifactStream)
+		}
+	}
+	return artifactstream, err
 }
 
 func (store *ElasticCasestore) DeleteArtifactStream(ctx context.Context, id string) error {
-  artifactstream, err := store.GetArtifactStream(ctx, id)
-  if err == nil {
-    err = store.delete(ctx, artifactstream, "artifactstream", store.prepareForSave(ctx, &artifactstream.Auditable))
-  }
+	artifactstream, err := store.GetArtifactStream(ctx, id)
+	if err == nil {
+		err = store.delete(ctx, artifactstream, "artifactstream", store.prepareForSave(ctx, &artifactstream.Auditable))
+	}
 
-  return err
+	return err
+}
+
+func (store *ElasticCasestore) ExtractCommonObservables(ctx context.Context, event *model.RelatedEvent) error {
+	for key, value := range event.Fields {
+		for _, obs := range store.commonObservables {
+			if key == obs {
+				artifact := model.NewArtifact()
+				artifact.CaseId = event.CaseId
+				artifact.Value = fmt.Sprintf("%v", value)
+				artifact.ArtifactType = string(store.observables.GetType(artifact.Value))
+				artifact.GroupType = "evidence"
+				_, err := store.CreateArtifact(ctx, artifact)
+				if err != nil {
+					// TODO: log warning and continue?
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/server/modules/elastic/elasticcasestore_test.go
+++ b/server/modules/elastic/elasticcasestore_test.go
@@ -8,20 +8,23 @@ package elastic
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInit(tester *testing.T) {
 	store := NewElasticCasestore(nil)
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, []string{"source.ip", "destination.ip"})
 	assert.Equal(tester, "myIndex", store.index)
 	assert.Equal(tester, "myAuditIndex", store.auditIndex)
 	assert.Equal(tester, 45, store.maxAssociations)
+	assert.Equal(tester, []string{"source.ip", "destination.ip"}, store.commonObservables)
 }
 
 func TestPrepareForSave(tester *testing.T) {
@@ -39,7 +42,7 @@ func TestPrepareForSave(tester *testing.T) {
 
 func TestValidateIdInvalid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	err = store.validateId("", "test")
@@ -66,7 +69,7 @@ func TestValidateIdInvalid(tester *testing.T) {
 
 func TestValidateIdValid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	err = store.validateId("12345", "test")
@@ -87,7 +90,7 @@ func TestValidateIdValid(tester *testing.T) {
 
 func TestValidateStringInvalid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	err = store.validateString("1234567", 6, "test")
@@ -99,7 +102,7 @@ func TestValidateStringInvalid(tester *testing.T) {
 
 func TestValidateStringValid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	err = store.validateString("12345", 6, "test")
@@ -114,7 +117,7 @@ func TestValidateStringValid(tester *testing.T) {
 
 func TestValidateCaseInvalid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	socCase := model.NewCase()
@@ -224,7 +227,7 @@ func TestValidateCaseInvalid(tester *testing.T) {
 
 func TestValidateCaseValid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	socCase := model.NewCase()
@@ -257,7 +260,7 @@ func TestValidateCaseValid(tester *testing.T) {
 
 func TestValidateRelatedEventInvalid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	event := model.NewRelatedEvent()
@@ -293,7 +296,7 @@ func TestValidateRelatedEventInvalid(tester *testing.T) {
 
 func TestValidateRelatedEventValid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	event := model.NewRelatedEvent()
@@ -304,7 +307,7 @@ func TestValidateRelatedEventValid(tester *testing.T) {
 
 func TestValidateCommentInvalid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	comment := model.NewComment()
@@ -344,7 +347,7 @@ func TestValidateCommentInvalid(tester *testing.T) {
 
 func TestValidateCommentValid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	comment := model.NewComment()
@@ -363,7 +366,7 @@ func TestValidateCommentValid(tester *testing.T) {
 
 func TestValidateArtifactInvalid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	artifact := model.NewArtifact()
@@ -482,7 +485,7 @@ func TestValidateArtifactInvalid(tester *testing.T) {
 
 func TestValidateArtifactValid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	artifact := model.NewArtifact()
@@ -499,7 +502,7 @@ func TestValidateArtifactValid(tester *testing.T) {
 
 func TestValidateArtifactStreamInvalid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	artifactstream := model.NewArtifactStream()
@@ -520,7 +523,7 @@ func TestValidateArtifactStreamInvalid(tester *testing.T) {
 
 func TestValidateArtifactStreamValid(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 
 	var err error
 	artifactstream := model.NewArtifactStream()
@@ -535,7 +538,7 @@ func TestValidateArtifactStreamValid(tester *testing.T) {
 
 func TestSaveCreate(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -555,7 +558,7 @@ func TestSaveCreate(tester *testing.T) {
 
 func TestSaveUpdate(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -575,7 +578,7 @@ func TestSaveUpdate(tester *testing.T) {
 
 func TestDelete(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -594,7 +597,7 @@ func TestDelete(tester *testing.T) {
 
 func TestGetAll(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -622,7 +625,7 @@ func TestGetAll(tester *testing.T) {
 
 func TestGet(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -642,7 +645,7 @@ func TestGet(tester *testing.T) {
 
 func TestGetNotFound(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -677,7 +680,7 @@ func TestUpdateError(tester *testing.T) {
 
 func TestGetCase(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -697,7 +700,7 @@ func TestGetCase(tester *testing.T) {
 
 func TestGetCaseHistory(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -738,7 +741,7 @@ func TestCreateCommentMissingCaseId(tester *testing.T) {
 
 func TestCreateComment(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -770,7 +773,7 @@ func TestCreateComment(tester *testing.T) {
 
 func TestGetComment(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -790,7 +793,7 @@ func TestGetComment(tester *testing.T) {
 
 func TestGetComments(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -820,7 +823,7 @@ func TestUpdateComment(tester *testing.T) {
 
 func TestDeleteComment(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -873,7 +876,8 @@ func TestCreateRelatedEventMissingFields(tester *testing.T) {
 
 func TestCreateRelatedEvent(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	commonTags := []string{"source.ip", "destination.ip"}
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, commonTags)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -898,6 +902,7 @@ func TestCreateRelatedEvent(tester *testing.T) {
 	event := model.NewRelatedEvent()
 	event.CaseId = "123444"
 	event.Fields["foo"] = "bar"
+	event.Fields["source.ip"] = "127.0.0.1"
 	newEvent, err := store.CreateRelatedEvent(ctx, event)
 	assert.NoError(tester, err)
 	assert.NotNil(tester, newEvent)
@@ -905,7 +910,7 @@ func TestCreateRelatedEvent(tester *testing.T) {
 
 func TestCreateRelatedEventAlreadyExists(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -939,7 +944,7 @@ func TestCreateRelatedEventAlreadyExists(tester *testing.T) {
 
 func TestGetRelatedEvent(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -959,7 +964,7 @@ func TestGetRelatedEvent(tester *testing.T) {
 
 func TestGetRelatedEvents(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1008,7 +1013,7 @@ func TestGetRelatedEvents(tester *testing.T) {
 
 func TestDeleteRelatedEvent(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1090,7 +1095,7 @@ func TestCreateArtifactMissingValue(tester *testing.T) {
 
 func TestCreateArtifact(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1124,7 +1129,7 @@ func TestCreateArtifact(tester *testing.T) {
 
 func TestGetArtifact(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1144,7 +1149,7 @@ func TestGetArtifact(tester *testing.T) {
 
 func TestGetArtifactsBadGroupType(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1154,7 +1159,7 @@ func TestGetArtifactsBadGroupType(tester *testing.T) {
 
 func TestGetArtifactsBadGroupId(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1164,7 +1169,7 @@ func TestGetArtifactsBadGroupId(tester *testing.T) {
 
 func TestGetArtifactsNoGroupId(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1184,7 +1189,7 @@ func TestGetArtifactsNoGroupId(tester *testing.T) {
 
 func TestGetArtifacts(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1204,7 +1209,7 @@ func TestGetArtifacts(tester *testing.T) {
 
 func TestDeleteArtifact(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1248,7 +1253,7 @@ func TestCreateArtifactStreamMissingValue(tester *testing.T) {
 
 func TestCreateArtifactStream(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1279,7 +1284,7 @@ func TestCreateArtifactStream(tester *testing.T) {
 
 func TestGetArtifactStream(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1299,7 +1304,7 @@ func TestGetArtifactStream(tester *testing.T) {
 
 func TestGetArtifactStreamBadId(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1309,7 +1314,7 @@ func TestGetArtifactStreamBadId(tester *testing.T) {
 
 func TestDeleteArtifactStream(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1332,7 +1337,7 @@ func TestDeleteArtifactStream(tester *testing.T) {
 
 func TestUpdateArtifact(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
 
 	fakeEventStore := server.NewFakeEventstore()
@@ -1394,4 +1399,49 @@ func TestUpdateArtifact(tester *testing.T) {
 	assert.Equal(tester, "mySha256", newArtifact.Sha256)
 	assert.Equal(tester, "myValue", newArtifact.Value)
 	assert.Equal(tester, 123, newArtifact.StreamLen)
+}
+
+func TestExtractCommonObservables(t *testing.T) {
+	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, []string{"my IP addr"})
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
+	event := model.NewRelatedEvent()
+	event.CaseId = "testID"
+
+	// Test with no observable
+	assert.NoError(t, store.ExtractCommonObservables(ctx, event))
+
+	// Test with observable
+	fakeEventStore := server.NewFakeEventstore()
+	store.server.Eventstore = fakeEventStore
+
+	// Do we need this query for anything?
+	//_ = `_index:"myIndex" AND so_kind:"case" AND _id:"myCaseId"`
+
+	casePayload := make(map[string]interface{})
+	casePayload["so_kind"] = "case"
+	caseEvent := &model.EventRecord{
+		Payload: casePayload,
+	}
+	eventPayload := make(map[string]interface{})
+	eventPayload["so_kind"] = "artifact"
+	elasticEvent := &model.EventRecord{
+		Payload: eventPayload,
+	}
+	fakeEventStore.SearchResults[0].Events = append(fakeEventStore.SearchResults[0].Events, caseEvent)
+	fakeEventStore.IndexResults[0].Success = true
+	fakeEventStore.IndexResults[0].DocumentId = "myCaseId"
+	eventSearchResults := model.NewEventSearchResults()
+	eventSearchResults.Events = append(eventSearchResults.Events, elasticEvent)
+	fakeEventStore.SearchResults = append(fakeEventStore.SearchResults, eventSearchResults)
+
+	event.Fields["my IP addr"] = "127.0.0.1"
+	assert.NoError(t, store.ExtractCommonObservables(ctx, event))
+	assert.Len(t, fakeEventStore.InputDocuments, 2)
+	assert.Equal(t, "artifact", fakeEventStore.InputDocuments[0]["so_kind"])
+	artifact := fakeEventStore.InputDocuments[0]["so_artifact"].(*model.Artifact)
+	require.NotNil(t, artifact)
+	assert.Equal(t, "evidence", artifact.GroupType)
+	assert.Equal(t, "127.0.0.1", artifact.Value)
+	assert.Equal(t, "ip", artifact.ArtifactType)
 }

--- a/server/modules/elastic/observables.go
+++ b/server/modules/elastic/observables.go
@@ -1,0 +1,85 @@
+// Copyright 2020-2022 Security Onion Solutions, LLC. All rights reserved.
+//
+// This program is distributed under the terms of version 2 of the
+// GNU General Public License.  See LICENSE for further details.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+package elastic
+
+import (
+	"net"
+	"net/url"
+	"regexp"
+)
+
+type ObservableType string
+
+const (
+	ObservableIP       ObservableType = "ip"
+	ObservableFQDN     ObservableType = "fqdn"
+	ObservableDomain   ObservableType = "domain"
+	ObservableURL      ObservableType = "url"
+	ObservableFilename ObservableType = "filename"
+	ObservableURIPath  ObservableType = "uriPath"
+	ObservableHash     ObservableType = "hash"
+	ObservableOther    ObservableType = "other"
+)
+
+// Use a regexp for validtion if it is set, else use the match function.
+type matchFunc func(string) bool
+type matcher struct {
+	exp     *regexp.Regexp
+	matcher matchFunc
+}
+type Observables struct {
+	match map[ObservableType]*matcher
+	order []ObservableType
+}
+
+func NewObservables() Observables {
+	match := make(map[ObservableType]*matcher)
+
+	// Perl regexp doesn't work with Golang, besides, IP parse() function is more bullet-proof.
+	//obs[ObservableIP] = &matcher{exp: regexp.MustCompile(`/^[0-9a-fA-F:]*([0-9a-fA-F]{1,4}:){1,7}[0-9a-fA-F:]*$|^(\d{1,3}\.){3}\d{1,3}$/`)}
+	match[ObservableIP] = &matcher{matcher: func(s string) bool { return net.ParseIP(s) != nil }}
+
+	// Regexp too simplistic, let Go parse URL and ensure it is a full URL.
+	//obs[ObservableURL] = &matcher{exp: regexp.MustCompile(`/^[a-z]+:\/\//`)}
+	match[ObservableURL] = &matcher{matcher: func(s string) bool { u, err := url.Parse(s); return err == nil && u.Scheme != "" }}
+
+	// Perl regexp for fqdn not supported in Go, use alternate expression, source:
+	// https://www.folkstalk.com/2022/09/golang-regular-expression-to-validate-domain-name-with-code-examples.html
+	//obs[ObservableFQDN] = regexp.MustCompile(`/(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,63}$)/`)
+	match[ObservableFQDN] = &matcher{exp: regexp.MustCompile(
+		`(\b(?:(?:[^.-/]{0,1})[\w-]{1,63}[-]{0,1}[.]{1})+(?:[a-zA-Z]{2,63})\b)`)}
+	//`^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|([a-zA-Z0-9][a-zA-Z0-9-_]{1,61}[a-zA-Z0-9]))\.([a-zA-Z]{2,6}|[a-zA-Z0-9-]{2,30}\.[a-zA-Z]{2,3})$`)}
+
+	match[ObservableDomain] = &matcher{exp: regexp.MustCompile(`/^(xn\-\-)?([a-z0-9\-]{1,61}|[a-z0-9\-]{1,30})\.[a-z]{2,}$/`)}
+
+	match[ObservableFilename] = &matcher{exp: regexp.MustCompile(`/(\/)?[\w,\\s-]+\.[A-Za-z]{3}$/`)}
+	match[ObservableURIPath] = &matcher{exp: regexp.MustCompile(`/^\/[\w,\s-]/`)}
+	match[ObservableHash] = &matcher{exp: regexp.MustCompile(`/^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$|^[0-9a-fA-F]{128}$/`)}
+	return Observables{
+		match: match,
+		order: []ObservableType{
+			ObservableIP, ObservableURL, ObservableFilename, ObservableFQDN,
+			ObservableDomain, ObservableURIPath, ObservableHash},
+	}
+}
+
+func (obs Observables) GetType(expr string) ObservableType {
+	for _, v := range obs.order {
+		match := obs.match[v]
+		if match.exp != nil {
+			if match.exp.MatchString(expr) {
+				return v
+			}
+		} else if match.matcher(expr) {
+			return v
+		}
+	}
+	return ObservableOther
+}

--- a/server/modules/elastic/observables_test.go
+++ b/server/modules/elastic/observables_test.go
@@ -23,9 +23,23 @@ func TestObservables(t *testing.T) {
 		expect ObservableType
 	}{
 		{expr: "www.google.com", expect: ObservableFQDN},
+		{expr: "sub.www.google.com", expect: ObservableFQDN},
+		{expr: "test.com", expect: ObservableDomain},
+		{expr: "test.co", expect: ObservableDomain},
+		{expr: "c:/test.doc", expect: ObservableFilename},
+		{expr: "/var/log/syslog.tgz", expect: ObservableFilename},
+		{expr: "/test/foo", expect: ObservableURIPath},
+		{expr: "/test/foo/bar", expect: ObservableURIPath},
+		{expr: "file://some/file/path.txt", expect: ObservableURL},
 		{expr: "http://www.example.com:8080/path", expect: ObservableURL},
-		{expr: "xyz", expect: ObservableOther},
 		{expr: "127.0.0.1", expect: ObservableIP},
+		{expr: "ff02::1:ffc5:a922", expect: ObservableIP},
+		{expr: "ff02::16", expect: ObservableIP},
+		{expr: "0e2fc59194659497c8d0aec1762add1324ad2e02549bb3e41d58ca8f39e14843", expect: ObservableHash},
+		{expr: "3b43c8fadd64750525a2e285d83fa01d62227999", expect: ObservableHash},
+		{expr: "db7298d2ae5733b53f40ab2e99058a9f", expect: ObservableHash},
+		{expr: "ea04541a17986a92e4d68f57e97d477845e778721044d0dcf96d380a7eddfc427a7ff0528931c39c35428cf78176da2c9741023b9c298be82521c96d547d68e8", expect: ObservableHash},
+		{expr: "xyz", expect: ObservableOther},
 	} {
 		ot := obs.GetType(v.expr)
 		assert.Equal(t, v.expect, ot, "%d: input: '%s' - expected '%s' but got '%s", i, v.expr, v.expect, ot)

--- a/server/modules/elastic/observables_test.go
+++ b/server/modules/elastic/observables_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Jason Ertel (jertel). All rights reserved.
+// Copyright 2020-2022 Security Onion Solutions, LLC. All rights reserved.
+//
+// This program is distributed under the terms of version 2 of the
+// GNU General Public License.  See LICENSE for further details.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+package elastic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObservables(t *testing.T) {
+	obs := NewObservables()
+	for i, v := range []struct {
+		expr   string
+		expect ObservableType
+	}{
+		{expr: "www.google.com", expect: ObservableFQDN},
+		{expr: "http://www.example.com:8080/path", expect: ObservableURL},
+		{expr: "xyz", expect: ObservableOther},
+		{expr: "127.0.0.1", expect: ObservableIP},
+	} {
+		ot := obs.GetType(v.expr)
+		assert.Equal(t, v.expect, ot, "%d: input: '%s' - expected '%s' but got '%s", i, v.expr, v.expect, ot)
+	}
+}

--- a/server/modules/elastic/template_test.go
+++ b/server/modules/elastic/template_test.go
@@ -8,16 +8,17 @@ package elastic
 
 import (
 	"context"
+	"testing"
+
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestApplyTemplate(tester *testing.T) {
 	store := NewElasticCasestore(server.NewFakeAuthorizedServer(nil))
-	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, nil)
 	fakeEventStore := server.NewFakeEventstore()
 	store.server.Eventstore = fakeEventStore
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")


### PR DESCRIPTION
Fixes #7972.  As per https://github.com/Security-Onion-Solutions/securityonion/issues/7972, this change adds the ability to enable dynamic observable extraction.

Note, I have added the type `Observables` which is the rules engine for pattern matching of observables.  For example, an observable with a valid IP address will be tagged with ArtifactType of "ip".  The observables are an attempt to port the pattern matching from the JavaScript code, but some of the Perl regular expressions don't work in Go.  As a workaround, the ability to invoke a Go function to do the pattern matching (such as the built-in Go function to match an IP address) was added to the functionality.  That said, I wasn't able to get all the matchers defined in the JavaScript code functioning in Go, so some types will resolve to "other".  More work needs to be done to flesh out the implementation.