### PR TITLE
On Error, Hunt

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -244,6 +244,12 @@
               <v-icon>fa-life-ring</v-icon>
             </a>
           </div>
+          <div class="mt-2 no-underline">
+            {{ i18n.huntForError }}
+            <router-link :to="{ name: 'hunt', query: {q: i18n.huntForErrorQuery, t: moment().subtract(1, 'hours').format(i18n.timePickerFormat) + ' - ' + moment().format(i18n.timePickerFormat) }}" class="text-decoration-none error-hunt">
+              <v-icon :title="i18n.huntForError">fa-crosshairs</v-icon>
+            </router-link>
+          </div>
         </v-snackbar>
         <v-snackbar id="warning" top centered rounded close :timeout="warningTimeout" v-model="warning" color="warning">
           <template v-slot:action="{ attrs }">

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -333,6 +333,8 @@ const i18n = {
       hunt: 'Hunt',
       huntForEvent: 'Hunt for this event',
       huntForFieldValue: 'Hunt for this field\'s value',
+      huntForError: 'The Hunt interface may contain additional log messages to further diagnose the issue.',
+      huntForErrorQuery: 'event.module:"soc" | groupby event.dataset log.level event.action',
       huntForEvidence: 'Hunt for this observable value',
       huntHelp: 'Start a new hunt based on the current filters',
       id: 'ID',


### PR DESCRIPTION
New footnote added to the error popup with button that takes you to the hunt page and searches for internal (`event.module:"soc"`) log events.