### PR TITLE
Change ntp.config to ntp.config.servers in index.html

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -3274,7 +3274,7 @@
                   <p class="font-weight-bold">{{i18n.configQLGridTitle}}</p>
                   <ul>
                     <li>
-                      <router-link :to="{ name: 'config', query: {s: 'ntp.config'}}">{{i18n.configQLNTP}}</router-link>
+                      <router-link :to="{ name: 'config', query: {s: 'ntp.config.servers'}}">{{i18n.configQLNTP}}</router-link>
                     </li>
                     <li>
                       {{i18n.configQLFirewallHeader}}


### PR DESCRIPTION
The SOC Configuration quick link for NTP currently links to `ntp.config`:
![Screenshot 2023-06-05 at 10 41 14 AM](https://github.com/Security-Onion-Solutions/securityonion-soc/assets/1659467/b0aefedc-55d2-4792-be5d-eb360a8e94dd)


We probably want to change that to `ntp.config.servers`:
![Screenshot 2023-06-05 at 10 41 47 AM](https://github.com/Security-Onion-Solutions/securityonion-soc/assets/1659467/5aa53159-0777-402a-9c97-0b5e0db555b3)
