### PR TITLE
Fix "New Group By" behavior by counting groups

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -807,7 +807,14 @@ const huntComponent = {
     buildGroupByRoute(field) {
       route = this.buildCurrentRoute()
       route.query.groupByField = field;
-      route.query.groupByGroup = this.groupBys.length - 1;
+
+      const groups = (this.query || '').replaceAll(/\s/g, '').match(/\|groupby/gi);
+      if (groups) {
+        route.query.groupByGroup = groups.length - 1;
+      } else {
+        route.query.groupByGroup = 1;
+      }
+
       return route;
     },
     buildGroupByNewRoute(field) {

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -751,3 +751,17 @@ test('query string filterToggles', () => {
   expect(comp.filterToggles[0].enabled).toBe(true);
   expect(comp.filterToggles[1].enabled).toBe(false);
 });
+
+test('buildGroupByRoute', () => {
+  comp.query = "*"; // no groupBy clause results in hard coded response of 1
+  let r = comp.buildGroupByRoute('x');
+  expect(r.query.groupByGroup).toBe(1);
+
+  comp.query = `* | groupby "log.level"`;
+  r = comp.buildGroupByRoute('x');
+  expect(r.query.groupByGroup).toBe(0);
+
+  comp.query = `* | groupby "log.level" |GrOuPbY "field.groupBy" |   GROUPBY "@version"`;
+  r = comp.buildGroupByRoute('x');
+  expect(r.query.groupByGroup).toBe(2);
+});


### PR DESCRIPTION
When deciding which groupby to add a new field to, we use the `groupBys` array built from the last time a hunt was executed. However if autohunt is turned off, multiple modifications may produce incorrect queries. Now we build the request with some light parsing to count how many groupby clauses actually exist when using "Group By" from the quick action list.