### PR TITLE
Better Behavior around modifying queries with `*Missing`

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -7,7 +7,7 @@
 const i18n = {
   translations: {
     "en-US": {
-      __missing__: '*Missing',
+      __missing__: '*Missing', // This should be sufficiently unique to avoid collisions with actual values
       accept: 'Accept',
       accepted: 'Accepted',
       acceptingMinionsTakesTime: 'Accepting new minions can take 1-2 minutes to complete.',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -540,6 +540,10 @@ const huntComponent = {
           }
         }
         if (isAlert) {
+          for (let prop in docEvent) {
+            docEvent[prop] = this.subMissing(docEvent[prop]);
+          }
+
           const response = await this.$root.papi.post('events/ack', {
             searchFilter: await this.getQuery(),
             eventFilter: docEvent,
@@ -799,9 +803,11 @@ const huntComponent = {
     },
     buildFilterRoute(filterField, filterValue, filterMode) {
       route = this.buildCurrentRoute()
+
       route.query.filterField = filterField;
-      route.query.filterValue = filterValue;
+      route.query.filterValue = this.subMissing(filterValue);
       route.query.filterMode = filterMode;
+
       return route;
     },
     buildGroupByRoute(field) {
@@ -1667,6 +1673,13 @@ const huntComponent = {
     },
     isExpandedSection(item) {
       return (this.collapsedSections.indexOf(item) == -1);
+    },
+    subMissing(value) {
+      if (value === this.i18n.__missing__) {
+        return '__missing__';
+      }
+
+      return value;
     }
   }
 };

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -765,3 +765,14 @@ test('buildGroupByRoute', () => {
   r = comp.buildGroupByRoute('x');
   expect(r.query.groupByGroup).toBe(2);
 });
+
+test('subMissing', () => {
+  expect(comp.subMissing("")).toBe("");
+  expect(comp.subMissing("foo")).toBe("foo");
+  expect(comp.subMissing("Missing")).toBe("Missing");
+  expect(comp.subMissing(comp.i18n.__missing__)).toBe("__missing__");
+  expect(comp.subMissing(comp.i18n.__missing__ + " foo")).toBe(comp.i18n.__missing__ + " foo");
+  expect(comp.subMissing(null)).toBe(null)
+  expect(comp.subMissing(undefined)).toBe(undefined)
+  expect(comp.subMissing(10)).toBe(10)
+});

--- a/model/query.go
+++ b/model/query.go
@@ -211,6 +211,12 @@ func (segment *SearchSegment) AddFilter(field string, value string, scalar bool,
 		field = field[3:]
 	}
 
+	if value == "__missing__" {
+		value = field
+		field = "_exists_"
+		inclusive = !inclusive
+	}
+
 	if condense {
 		// Combine existing terms into a single grouped term
 		condensed, _ := NewQueryTerm(segment.String())

--- a/server/queryhandler.go
+++ b/server/queryhandler.go
@@ -59,7 +59,17 @@ func (h *QueryHandler) getQuery(w http.ResponseWriter, r *http.Request) {
 		value := r.Form.Get("value")
 		condense := r.Form.Get("condense") == "true"
 
-		if len(value) > 0 {
+		if value == "*Missing" {
+			exists := "_exists_"
+			if mode == model.FILTER_DRILLDOWN {
+				exists = "NOT _exists_"
+			}
+			alteredQuery, err = query.Filter(exists, field, scalar, mode, condense)
+			if err != nil {
+				web.Respond(w, r, http.StatusBadRequest, errors.New("Invalid query after filter applied"))
+				return
+			}
+		} else if len(value) > 0 {
 			alteredQuery, err = query.Filter(field, value, scalar, mode, condense)
 			if err != nil {
 				web.Respond(w, r, http.StatusBadRequest, errors.New("Invalid query after filter applied"))

--- a/server/queryhandler.go
+++ b/server/queryhandler.go
@@ -59,17 +59,7 @@ func (h *QueryHandler) getQuery(w http.ResponseWriter, r *http.Request) {
 		value := r.Form.Get("value")
 		condense := r.Form.Get("condense") == "true"
 
-		if value == "*Missing" {
-			exists := "_exists_"
-			if mode == model.FILTER_DRILLDOWN {
-				exists = "NOT _exists_"
-			}
-			alteredQuery, err = query.Filter(exists, field, scalar, mode, condense)
-			if err != nil {
-				web.Respond(w, r, http.StatusBadRequest, errors.New("Invalid query after filter applied"))
-				return
-			}
-		} else if len(value) > 0 {
+		if len(value) > 0 {
 			alteredQuery, err = query.Filter(field, value, scalar, mode, condense)
 			if err != nil {
 				web.Respond(w, r, http.StatusBadRequest, errors.New("Invalid query after filter applied"))

--- a/server/queryhandler_test.go
+++ b/server/queryhandler_test.go
@@ -22,17 +22,17 @@ func TestFilterMissing(t *testing.T) {
 	}{
 		{
 			Name:          "Include",
-			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=*Missing&scalar=false&mode=INCLUDE",
-			ExpectedQuery: `"* AND _exists_:\"unit.type\" | groupby unit.type*"`,
-		},
-		{
-			Name:          "Exclude",
-			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=*Missing&scalar=false&mode=EXCLUDE",
+			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=__missing__&scalar=false&mode=INCLUDE",
 			ExpectedQuery: `"* AND NOT _exists_:\"unit.type\" | groupby unit.type*"`,
 		},
 		{
+			Name:          "Exclude",
+			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=__missing__&scalar=false&mode=EXCLUDE",
+			ExpectedQuery: `"* AND _exists_:\"unit.type\" | groupby unit.type*"`,
+		},
+		{
 			Name:          "Drilldown",
-			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=*Missing&scalar=false&mode=DRILLDOWN",
+			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=__missing__&scalar=false&mode=DRILLDOWN",
 			ExpectedQuery: `"* AND NOT _exists_:\"unit.type\""`,
 		},
 	}

--- a/server/queryhandler_test.go
+++ b/server/queryhandler_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterMissing(t *testing.T) {
+	t.Parallel()
+
+	table := []struct {
+		Name          string
+		Path          string
+		ExpectedQuery string
+	}{
+		{
+			Name:          "Include",
+			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=*Missing&scalar=false&mode=INCLUDE",
+			ExpectedQuery: `"* AND _exists_:\"unit.type\" | groupby unit.type*"`,
+		},
+		{
+			Name:          "Exclude",
+			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=*Missing&scalar=false&mode=EXCLUDE",
+			ExpectedQuery: `"* AND NOT _exists_:\"unit.type\" | groupby unit.type*"`,
+		},
+		{
+			Name:          "Drilldown",
+			Path:          "/api/query/filtered?query=*+%7C+groupby+unit.type*&field=unit.type&value=*Missing&scalar=false&mode=DRILLDOWN",
+			ExpectedQuery: `"* AND NOT _exists_:\"unit.type\""`,
+		},
+	}
+
+	handler := &QueryHandler{}
+
+	c := chi.NewRouteContext()
+	c.URLParams.Add("operation", "filtered")
+	ctx := context.WithValue(context.Background(), chi.RouteCtxKey, c)
+	ctx = context.WithValue(ctx, web.ContextKeyRequestStart, time.Now())
+
+	for _, tt := range table {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			w := httptest.NewRecorder()
+			r, err := http.NewRequestWithContext(ctx, "GET", tt.Path, nil)
+			assert.NoError(t, err)
+
+			handler.getQuery(w, r)
+
+			altered := w.Body.String()
+			assert.Equal(t, tt.ExpectedQuery, altered)
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}


### PR DESCRIPTION
Including a *Missing field should only return *Missing results. Excluding a *Missing field should only return non-*Missing results. Drilling down on a *Missing field should only return *Missing fields.