### PR TITLE
Watch for the correct error

### DIFF
--- a/web/client.go
+++ b/web/client.go
@@ -82,7 +82,7 @@ func (client *Client) SendObject(method string, path string, obj interface{}, re
 				err = json.NewDecoder(resp.Body).Decode(returnedObj)
 				if err == nil {
 					objectAvailable = true
-				} else if err == io.ErrUnexpectedEOF {
+				} else if err == io.EOF {
 					// No object returned
 					err = nil
 				}


### PR DESCRIPTION
When parsing an empty string, the json package returns io.EOF and not io.ErrUnexpectedEOF. This should cut down on the erroneous log spam.

Playground entry showing which error it is: https://go.dev/play/p/BhpMEotf2xV