### PR TITLE
Salt Options for Longer Timeout

### DIFF
--- a/server/gridmembershandler.go
+++ b/server/gridmembershandler.go
@@ -19,7 +19,6 @@ import (
 	"unicode"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
-	"github.com/security-onion-solutions/securityonion-soc/server/modules/salt/options"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 
 	"github.com/go-chi/chi"
@@ -219,9 +218,7 @@ func (h *GridMembersHandler) postImport(w http.ResponseWriter, r *http.Request) 
 			baseTargetDir += "/"
 		}
 
-		ctxTimeout := options.WithTimeoutMs(ctx, 120000)
-
-		err = h.server.GridMembersstore.SendFile(ctxTimeout, id, targetFile, baseTargetDir, true)
+		err = h.server.GridMembersstore.SendFile(ctx, id, targetFile, baseTargetDir, true)
 		if err != nil {
 			needsCleanup = true
 			web.Respond(nil, r, http.StatusInternalServerError, err)
@@ -231,7 +228,7 @@ func (h *GridMembersHandler) postImport(w http.ResponseWriter, r *http.Request) 
 
 		targetFile = filepath.Join(baseTargetDir, filename)
 
-		dashboardURL, err := h.server.GridMembersstore.Import(ctxTimeout, id, targetFile, ext)
+		dashboardURL, err := h.server.GridMembersstore.Import(ctx, id, targetFile, ext)
 		if err != nil {
 			web.Respond(nil, r, http.StatusInternalServerError, err)
 			return

--- a/server/gridmembershandler.go
+++ b/server/gridmembershandler.go
@@ -19,6 +19,7 @@ import (
 	"unicode"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/salt/options"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 
 	"github.com/go-chi/chi"
@@ -218,7 +219,9 @@ func (h *GridMembersHandler) postImport(w http.ResponseWriter, r *http.Request) 
 			baseTargetDir += "/"
 		}
 
-		err = h.server.GridMembersstore.SendFile(ctx, id, targetFile, baseTargetDir, true)
+		ctxTimeout := options.WithTimeoutMs(ctx, 120000)
+
+		err = h.server.GridMembersstore.SendFile(ctxTimeout, id, targetFile, baseTargetDir, true)
 		if err != nil {
 			needsCleanup = true
 			web.Respond(nil, r, http.StatusInternalServerError, err)
@@ -228,7 +231,7 @@ func (h *GridMembersHandler) postImport(w http.ResponseWriter, r *http.Request) 
 
 		targetFile = filepath.Join(baseTargetDir, filename)
 
-		dashboardURL, err := h.server.GridMembersstore.Import(ctx, id, targetFile, ext)
+		dashboardURL, err := h.server.GridMembersstore.Import(ctxTimeout, id, targetFile, ext)
 		if err != nil {
 			web.Respond(nil, r, http.StatusInternalServerError, err)
 			return

--- a/server/modules/salt/options/context.go
+++ b/server/modules/salt/options/context.go
@@ -1,0 +1,29 @@
+package options
+
+import "context"
+
+type ContextKey string
+
+const (
+	ContextKeySaltExecTimeoutMs ContextKey = "timeoutMs"
+)
+
+func WithTimeoutMs(ctx context.Context, timeoutMs int) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return context.WithValue(ctx, ContextKeySaltExecTimeoutMs, timeoutMs)
+}
+
+func GetTimeoutMs(ctx context.Context) int {
+	if ctx == nil {
+		return 0
+	}
+
+	if timeoutMs, ok := ctx.Value(ContextKeySaltExecTimeoutMs).(int); ok {
+		return timeoutMs
+	}
+
+	return 0
+}

--- a/server/modules/salt/options/context_test.go
+++ b/server/modules/salt/options/context_test.go
@@ -1,0 +1,24 @@
+package options
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// nolint: staticcheck // test file
+func TestTimeout(t *testing.T) {
+	ctx := WithTimeoutMs(nil, 100)
+	assert.NotNil(t, ctx)
+
+	timeout := GetTimeoutMs(ctx)
+	assert.Equal(t, 100, timeout)
+
+	timeout = GetTimeoutMs(nil)
+	assert.Equal(t, 0, timeout)
+
+	bg := context.Background()
+	timeout = GetTimeoutMs(bg)
+	assert.Equal(t, 0, timeout)
+}

--- a/server/modules/salt/salt.go
+++ b/server/modules/salt/salt.go
@@ -12,6 +12,7 @@ import (
 )
 
 const DEFAULT_TIMEOUT_MS = 30000
+const LONG_TIMEOUT_MS = 120000
 const DEFAULT_SALTSTACK_DIR = "/opt/so/saltstack"
 const DEFAULT_QUEUE_DIR = "/opt/so/conf/soc/queue"
 const DEFAULT_BYPASS_ERRORS = false
@@ -36,10 +37,11 @@ func (mod *Salt) PrerequisiteModules() []string {
 func (mod *Salt) Init(cfg module.ModuleConfig) error {
 	mod.config = cfg
 	timeoutMs := module.GetIntDefault(cfg, "timeoutMs", DEFAULT_TIMEOUT_MS)
+	longRelayTimeoutMs := module.GetIntDefault(cfg, "longRelayTimeoutMs", LONG_TIMEOUT_MS)
 	saltstackDir := module.GetStringDefault(cfg, "saltstackDir", DEFAULT_SALTSTACK_DIR)
 	queueDir := module.GetStringDefault(cfg, "queueDir", DEFAULT_QUEUE_DIR)
 	bypassErrors := module.GetBoolDefault(cfg, "bypassErrors", DEFAULT_BYPASS_ERRORS)
-	err := mod.impl.Init(timeoutMs, saltstackDir, queueDir, bypassErrors)
+	err := mod.impl.Init(timeoutMs, longRelayTimeoutMs, saltstackDir, queueDir, bypassErrors)
 	if err == nil {
 		mod.server.Configstore = mod.impl
 		mod.server.GridMembersstore = mod.impl

--- a/server/modules/salt/saltstore.go
+++ b/server/modules/salt/saltstore.go
@@ -21,6 +21,7 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/json"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/salt/options"
 	"github.com/security-onion-solutions/securityonion-soc/syntax"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 	"gopkg.in/yaml.v3"
@@ -75,8 +76,15 @@ func (store *Saltstore) execCommand(ctx context.Context, args map[string]string)
 		"timeoutMs":        store.timeoutMs,
 	}).Info("Waiting for response")
 
+	timeoutMs := store.timeoutMs
+	optTimeoutMs := options.GetTimeoutMs(ctx)
+
+	if optTimeoutMs > timeoutMs {
+		timeoutMs = optTimeoutMs
+	}
+
 	var response string
-	expiration := time.Duration(store.timeoutMs) * time.Millisecond
+	expiration := time.Duration(timeoutMs) * time.Millisecond
 	for timeoutTime := time.Now().Add(expiration); time.Now().Before(timeoutTime); {
 		if _, err = os.Stat(responseFilename); err == nil {
 			var data []byte


### PR DESCRIPTION
The salt relay has a default timeout of 30s. This is not long enough to process the default file size limit of pcap/evtx imports (25MB). Instead of enlarging the timeout for all salt operations, salt now respects a variable on the passed in context. If that variable holds a longer timeout than the currently configured one, the new timeout is used instead.

Sending files and importing files now request a 2 minute timeout.