### PR TITLE
Updated Tests to Include License Checks

### DIFF
--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -351,6 +351,7 @@ level: high
 		Engine:      model.EngineNameElastAlert,
 		Language:    model.SigLangSigma,
 		Ruleset:     util.Ptr("all_rules"),
+		License:     model.LicenseDRL,
 	}
 
 	dets, errMap := engine.parseRules(pkgZips)

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -305,7 +305,7 @@ func TestParse(t *testing.T) {
 		ExpectedError      *string
 	}{
 		{
-			Name: "Sunny Day Path w/ Edge Cases",
+			Name: "Sunny Day Path with Edge Cases",
 			Lines: []string{
 				"# Comment",
 				SimpleRule,
@@ -323,6 +323,7 @@ func TestParse(t *testing.T) {
 					Engine:      model.EngineNameSuricata,
 					Language:    model.SigLangSuricata,
 					Ruleset:     ruleset,
+					License:     "Unknown",
 				},
 				{
 					PublicID:    "20000",
@@ -333,6 +334,7 @@ func TestParse(t *testing.T) {
 					Engine:      model.EngineNameSuricata,
 					Language:    model.SigLangSuricata,
 					Ruleset:     ruleset,
+					License:     "Unknown",
 				},
 			},
 		},


### PR DESCRIPTION
Added license data when importing rules but forgot to update the tests to look for the new data. Fixed.