### PR TITLE
New Alert Quick Action: Tune Detection

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -804,6 +804,14 @@
                 {{ i18n.filterDrilldown }}
               </v-list-item-title>
             </v-list-item>
+            <v-list-item id="actionTuneDetection" v-if="quickActionDetId" dense :to='{ name: "detection", params: { id: quickActionDetId }, query: { tab: "tuning" } }' :title="i18n.tuneDetectionHelp">
+              <v-list-item-icon>
+                <v-icon :alt="i18n.tuneDetection" color="white">fa-wrench</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title class="white--text">
+                {{ i18n.tuneDetection }}
+              </v-list-item-title>
+            </v-list-item>
             <v-list-item id="actionGroupBy" dense :to="groupByRoute" :title="i18n.groupIncludeHelp">
               <v-list-item-icon>
                 <v-icon :alt="i18n.groupInclude" color="white">fa-layer-group</v-icon>

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -828,6 +828,8 @@ const i18n = {
       trafficManOutAbbr: 'Mgmt Out',
       transcriptCyberChefHelp: 'Send the transcript to CyberChef',
       ttr: 'Time Tracking',
+      tuneDetection: 'Tune Detection',
+      tuneDetectionHelp: 'Tune the Detection That Triggered This Event',
       tuning: 'Tuning',
       type: 'Type',
       unaccepted: 'Pending',

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -829,7 +829,7 @@ const i18n = {
       transcriptCyberChefHelp: 'Send the transcript to CyberChef',
       ttr: 'Time Tracking',
       tuneDetection: 'Tune Detection',
-      tuneDetectionHelp: 'Tune the Detection That Triggered This Event',
+      tuneDetectionHelp: 'Tune the detection that triggered this alert',
       tuning: 'Tuning',
       type: 'Type',
       unaccepted: 'Pending',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -147,6 +147,7 @@ const huntComponent = {
       { text: this.$root.i18n.enable, value: 'enable' },
       { text: this.$root.i18n.disable, value: 'disable' },
     ],
+    quickActionDetId: null,
   }},
   created() {
     this.$root.initializeCharts();
@@ -1068,6 +1069,25 @@ const huntComponent = {
         this.quickActionVisible = false;
         this.escalationMenuVisible = false;
         return;
+      }
+
+      if (this.isCategory('alerts')) {
+        const alert = this.eventData.find(item => {
+          for (const key in event) {
+            if (key !== "count" && item[key] !== event[key]) {
+              return false;
+            }
+          }
+          return true;
+        });
+
+        if (alert) {
+          // don't slow down the UI with this call
+          const publicId = alert["rule.uuid"];
+          this.$root.papi.get(`detection/public/${publicId}`).then(response => {
+            this.quickActionDetId = response.data.id;
+          });
+        }
       }
 
       this.quickActionIsNumeric = this.isNumeric(value);

--- a/server/detectionstore.go
+++ b/server/detectionstore.go
@@ -15,6 +15,7 @@ import (
 type Detectionstore interface {
 	CreateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error)
 	GetDetection(ctx context.Context, detectId string) (*model.Detection, error)
+	GetDetectionByPublicId(ctx context.Context, publicId string) (*model.Detection, error)
 	UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error)
 	UpdateDetectionField(ctx context.Context, id string, fields map[string]interface{}) (*model.Detection, error)
 	DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error)

--- a/server/mock/mock_detectionstore.go
+++ b/server/mock/mock_detectionstore.go
@@ -173,6 +173,21 @@ func (mr *MockDetectionstoreMockRecorder) GetDetection(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDetection", reflect.TypeOf((*MockDetectionstore)(nil).GetDetection), arg0, arg1)
 }
 
+// GetDetectionByPublicId mocks base method.
+func (m *MockDetectionstore) GetDetectionByPublicId(arg0 context.Context, arg1 string) (*model.Detection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDetectionByPublicId", arg0, arg1)
+	ret0, _ := ret[0].(*model.Detection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDetectionByPublicId indicates an expected call of GetDetectionByPublicId.
+func (mr *MockDetectionstoreMockRecorder) GetDetectionByPublicId(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDetectionByPublicId", reflect.TypeOf((*MockDetectionstore)(nil).GetDetectionByPublicId), arg0, arg1)
+}
+
 // GetDetectionHistory mocks base method.
 func (m *MockDetectionstore) GetDetectionHistory(arg0 context.Context, arg1 string) ([]any, error) {
 	m.ctrl.T.Helper()

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -410,6 +410,20 @@ func (store *ElasticDetectionstore) GetDetection(ctx context.Context, detectId s
 	return detect, err
 }
 
+func (store *ElasticDetectionstore) GetDetectionByPublicId(ctx context.Context, publicId string) (detect *model.Detection, err error) {
+	err = store.validateId(publicId, "publicId")
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := store.Query(ctx, fmt.Sprintf(`_index:"%s" AND %skind:"detection" AND %sdetection.publicId:"%s"`, store.index, store.schemaPrefix, store.schemaPrefix, publicId), 1)
+	if err == nil && len(obj) > 0 {
+		detect = obj[0].(*model.Detection)
+	}
+
+	return detect, err
+}
+
 func (store *ElasticDetectionstore) UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
 	err := store.validateDetection(detect)
 	if err != nil {


### PR DESCRIPTION
When you click to toggle the QuickAction menu, an API call is sent out to look up the Detection's ID using the PublicID. When the ID comes back, the new Tune Detection option will be visible in the menu. This option opens up that Detection's page to the Tuning tab.