### PR TITLE
Disable QuickAction Item Until Ready

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -626,3 +626,8 @@ td {
 #convert-button-container > * {
   margin-left: 12px;
 }
+
+#actionTuneDetection-disabled {
+  color: gray;
+  cursor: pointer;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -812,6 +812,14 @@
                 {{ i18n.tuneDetection }}
               </v-list-item-title>
             </v-list-item>
+            <v-list-item id="actionTuneDetection-disabled" v-else dense :title="i18n.tuneDetectionHelp">
+              <v-list-item-icon>
+                <v-icon :alt="i18n.tuneDetection" color="grey">fa-wrench</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>
+                {{ i18n.tuneDetection }}
+              </v-list-item-title>
+            </v-list-item>
             <v-list-item id="actionGroupBy" dense :to="groupByRoute" :title="i18n.groupIncludeHelp">
               <v-list-item-icon>
                 <v-icon :alt="i18n.groupInclude" color="white">fa-layer-group</v-icon>


### PR DESCRIPTION
Show a stud in the QuickAction menu until the web request returns. Although the menu item is not a link, it's styled to appear as a disabled link.