### PR TITLE
"Tune Detections" Only in Alerts

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -804,7 +804,7 @@
                 {{ i18n.filterDrilldown }}
               </v-list-item-title>
             </v-list-item>
-            <v-list-item id="actionTuneDetection" v-if="quickActionDetId && $root.detectionsEnabled" dense :to='{ name: "detection", params: { id: quickActionDetId }, query: { tab: "tuning" } }' :title="i18n.tuneDetectionHelp">
+            <v-list-item id="actionTuneDetection" v-if="quickActionDetId && $root.detectionsEnabled && isCategory('alerts')" dense :to='{ name: "detection", params: { id: quickActionDetId }, query: { tab: "tuning" } }' :title="i18n.tuneDetectionHelp">
               <v-list-item-icon>
                 <v-icon :alt="i18n.tuneDetection" color="white">fa-wrench</v-icon>
               </v-list-item-icon>
@@ -812,7 +812,7 @@
                 {{ i18n.tuneDetection }}
               </v-list-item-title>
             </v-list-item>
-            <v-list-item id="actionTuneDetection-disabled" v-if="!quickActionDetId && $root.detectionsEnabled" dense :title="i18n.tuneDetectionHelp">
+            <v-list-item id="actionTuneDetection-disabled" v-if="!quickActionDetId && $root.detectionsEnabled && isCategory('alerts')" dense :title="i18n.tuneDetectionHelp">
               <v-list-item-icon>
                 <v-icon :alt="i18n.tuneDetection" color="grey">fa-wrench</v-icon>
               </v-list-item-icon>


### PR DESCRIPTION
Be absolutely show that both the ready and standby versions of the "Tune Detection" quick action are only visible in Alerts.