### PR TITLE
Better Defaults in Detection Engines

### DIFF
--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -79,13 +79,13 @@ func (e *ElastAlertEngine) PrerequisiteModules() []string {
 func (e *ElastAlertEngine) Init(config module.ModuleConfig) error {
 	e.thread = &sync.WaitGroup{}
 
-	e.communityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", 600)
+	e.communityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", 86400)
 	e.sigmaPackageDownloadTemplate = module.GetStringDefault(config, "sigmaPackageDownloadTemplate", "https://github.com/SigmaHQ/sigma/releases/latest/download/sigma_%s.zip")
-	e.elastAlertRulesFolder = module.GetStringDefault(config, "elastAlertRulesFolder", "/opt/so/rules/elastalert")
-	e.rulesFingerprintFile = module.GetStringDefault(config, "rulesFingerprintFile", "/opt/so/conf/soc/sigma.fingerprint")
+	e.elastAlertRulesFolder = module.GetStringDefault(config, "elastAlertRulesFolder", "/opt/sensoroni/elastalert")
+	e.rulesFingerprintFile = module.GetStringDefault(config, "rulesFingerprintFile", "/opt/sensoroni/fingerprints/sigma.fingerprint")
 	e.autoUpdateEnabled = module.GetBoolDefault(config, "autoUpdateEnabled", false)
 
-	pkgs := module.GetStringArrayDefault(config, "sigmaRulePackages", []string{"core"})
+	pkgs := module.GetStringArrayDefault(config, "sigmaRulePackages", []string{"core", "emerging_threats_addon"})
 	e.parseSigmaPackages(pkgs)
 
 	allow := module.GetStringDefault(config, "allowRegex", "")

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -76,9 +76,9 @@ func (e *StrelkaEngine) PrerequisiteModules() []string {
 func (e *StrelkaEngine) Init(config module.ModuleConfig) (err error) {
 	e.thread = &sync.WaitGroup{}
 
-	e.communityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", 600)
-	e.yaraRulesFolder = module.GetStringDefault(config, "yaraRulesFolder", "/opt/so/conf/strelka/rules")
-	e.reposFolder = module.GetStringDefault(config, "reposFolder", "/opt/so/conf/strelka/repos")
+	e.communityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", 86400)
+	e.yaraRulesFolder = module.GetStringDefault(config, "yaraRulesFolder", "/opt/sensoroni/yara/rules")
+	e.reposFolder = module.GetStringDefault(config, "reposFolder", "/opt/sensoroni/yara/repos")
 	e.compileYaraPythonScriptPath = module.GetStringDefault(config, "compileYaraPythonScriptPath", "/opt/so/conf/strelka/compile_yara.py")
 	e.compileRules = module.GetBoolDefault(config, "compileRules", true)
 	e.autoUpdateEnabled = module.GetBoolDefault(config, "autoUpdateEnabled", false)
@@ -112,8 +112,13 @@ func (e *StrelkaEngine) Init(config module.ModuleConfig) (err error) {
 func getYaraRepos(cfg module.ModuleConfig) ([]*yaraRepo, error) {
 	cfgInter, ok := cfg["rulesRepos"]
 	if !ok {
-		// config doesn't have any rulesRepos, no error, but also no repos
-		return nil, nil
+		// config doesn't have any rulesRepos, no error, return defaults
+		return []*yaraRepo{
+			{
+				Repo:    "https://github.com/Security-Onion-Solutions/securityonion-yara",
+				License: "DRL",
+			},
+		}, nil
 	}
 
 	repoMaps, ok := cfgInter.([]interface{})


### PR DESCRIPTION
New default values align with the values after a fresh SO installation.

Also includes a SuricataEngine update so AllSettings are only retrieved once per sync cycle. This removes 1 redundant call.