### PR TITLE
Deleting Detection Comments and Test Anchors

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1232,10 +1232,10 @@
                     </div>
                     <div class="d-flex align-center align-self-end text-body-2 mt-2">
                       <div class="d-inline-flex justify-end">
-                        <v-btn text small color="primary" class="align-self-end" @click="resetForm()">
+                        <v-btn id="detection-comment-cancel" text small color="primary" class="align-self-end" @click="resetForm()">
                         {{ i18n.cancel }}
                         </v-btn>
-                        <v-btn :disabled="!commentsForm.valid" text small color="primary" class="align-self-end" @click="addComment()">
+                        <v-btn id="detection-comment-add" :disabled="!commentsForm.valid" text small color="primary" class="align-self-end" @click="addComment()">
                         {{ origComment ? i18n.update : i18n.add }}
                         </v-btn>
                       </div>

--- a/html/index.html
+++ b/html/index.html
@@ -1245,12 +1245,6 @@
               </v-tab-item>
               <v-tab-item value="source">
                 <div class="col" style="background-color: rgb(53, 53, 53); border-radius: 4px;">
-                  <!-- PublicID -->
-                  <v-text-field id="detection-publicId-edit" v-model="detect.publicId" :readonly="detect.isCommunity" :rules="requestRules([rules.required, rules.minLength(5)])" persistent-hint :hint="i18n.publicId" v-on:keyup.enter="stopEdit(true)" v-on:keyup.esc="stopEdit(false)">
-                    <template v-slot:append v-if="!detect.publicId && !detect.isCommunity">
-                      <v-btn id="gen-public-id" text small color="primary" @click="extractPublicID()">{{i18n.extract}}</v-btn>
-                    </template>
-                  </v-text-field>
                   <!-- Signature -->
                   <v-textarea class="config-editor mt-2" :readonly="detect.isCommunity" outlined v-model="detect.content" auto-grow rows="15" />
                 </div>

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -663,8 +663,6 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			try {
 				this.$root.startLoading();
 				await this.$root.papi.delete('/detection/' + encodeURIComponent(this.$route.params.id));
-				this.$root.stopLoading();
-
 				this.$router.push({ name: 'detections' });
 			} catch (error) {
 				this.$root.showError(error);

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -177,7 +177,10 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 
 			try {
 				const response = await this.$root.papi.get('detection/' + encodeURIComponent(this.$route.params.id));
+
 				this.detect = response.data;
+				delete this.detect.kind;
+
 				this.tagOverrides();
 				this.loadAssociations();
 			} catch (error) {
@@ -657,8 +660,17 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			this.$router.push({name: 'detection', params: {id: response.data.id}});
 		},
 		async deleteDetection() {
-			await this.$root.papi.delete('/detection/' + encodeURIComponent(this.$route.params.id));
-			this.$router.push({ name: 'detections' });
+			try {
+				this.$root.startLoading();
+				await this.$root.papi.delete('/detection/' + encodeURIComponent(this.$route.params.id));
+				this.$root.stopLoading();
+
+				this.$router.push({ name: 'detections' });
+			} catch (error) {
+				this.$root.showError(error);
+			} finally {
+				this.$root.stopLoading();
+			}
 		},
 		validateYara() {
 			return null;

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -40,7 +40,7 @@ func RegisterDetectionRoutes(srv *Server, r chi.Router, prefix string) {
 		r.Get("/{id}", h.getDetection)
 		r.Get("/public/{publicid}", h.getByPublicId)
 
-		r.Post("/", h.postDetection)
+		r.Post("/", h.createDetection)
 		r.Post("/{id}/duplicate", h.duplicateDetection)
 
 		r.Post("/{id}/comment", h.createComment)
@@ -52,7 +52,7 @@ func RegisterDetectionRoutes(srv *Server, r chi.Router, prefix string) {
 		r.Get("/{id}/history", h.getDetectionHistory)
 		r.Post("/convert", h.convertContent)
 
-		r.Put("/", h.putDetection)
+		r.Put("/", h.updateDetection)
 
 		r.Delete("/{id}", h.deleteDetection)
 
@@ -104,7 +104,7 @@ func (h *DetectionHandler) getByPublicId(w http.ResponseWriter, r *http.Request)
 	web.Respond(w, r, http.StatusOK, detections[0])
 }
 
-func (h *DetectionHandler) postDetection(w http.ResponseWriter, r *http.Request) {
+func (h *DetectionHandler) createDetection(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	detect := &model.Detection{}
@@ -222,7 +222,7 @@ func (h *DetectionHandler) duplicateDetection(w http.ResponseWriter, r *http.Req
 	web.Respond(w, r, http.StatusOK, detect)
 }
 
-func (h *DetectionHandler) putDetection(w http.ResponseWriter, r *http.Request) {
+func (h *DetectionHandler) updateDetection(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	detect := &model.Detection{}

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -249,7 +249,7 @@ func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index st
 	if err != nil {
 		log.WithFields(log.Fields{
 			"documentId": id,
-			"kind":       kind,
+			"detectionKind":       kind,
 		}).WithError(err).Error("Object deleted successfully however audit record failed to index")
 	}
 

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -880,6 +880,6 @@ func (store *ElasticDetectionstore) DeleteComment(ctx context.Context, id string
 		return err
 	}
 
-	_, err = store.deleteDocument(ctx, store.index, id)
+	_, err = store.deleteDocument(ctx, store.disableCrossClusterIndex(store.index), id)
 	return err
 }

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -655,7 +655,7 @@ func (store *ElasticDetectionstore) DeleteDetection(ctx context.Context, id stri
 		return nil, err
 	}
 
-	_, err = store.deleteDocument(ctx, store.index, detect, "detection", id)
+	_, err = store.deleteDocument(ctx, store.disableCrossClusterIndex(store.index), detect, "detection", id)
 
 	return detect, err
 }

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -222,30 +222,7 @@ func (store *ElasticDetectionstore) Index(ctx context.Context, index string, doc
 	return results, err
 }
 
-func (store *ElasticDetectionstore) Delete(ctx context.Context, index string, id string) error {
-	results := model.NewEventIndexResults()
-
-	err := store.server.CheckAuthorized(ctx, "write", "detection")
-	if err != nil {
-		return err
-	}
-
-	var response string
-	log.Debug("Sending delete request to primary Elasticsearch client")
-	response, err = store.deleteDocument(ctx, store.disableCrossClusterIndex(index), id)
-	if err == nil {
-		err = convertFromElasticIndexResults(response, results)
-		if err != nil {
-			log.WithError(err).Error("Encountered error while converting document index results")
-		}
-	} else {
-		log.WithError(err).Error("Encountered error while deleting document from elasticsearch")
-	}
-
-	return err
-}
-
-func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index string, id string) (string, error) {
+func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index string, obj interface{}, kind string, id string) (string, error) {
 	log.WithFields(log.Fields{
 		"index":     index,
 		"id":        id,
@@ -263,6 +240,19 @@ func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index st
 		return "", err
 	}
 	defer res.Body.Close()
+
+	document := convertObjectToDocumentMap(kind, obj, store.schemaPrefix)
+	document[store.schemaPrefix+AUDIT_DOC_ID] = id
+	document[store.schemaPrefix+"kind"] = kind
+	document[store.schemaPrefix+"operation"] = "delete"
+	err = store.audit(ctx, document, id)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"documentId": id,
+			"kind":       kind,
+		}).WithError(err).Error("Object deleted successfully however audit record failed to index")
+	}
+
 	json, err := readJsonFromResponse(res)
 
 	log.WithFields(log.Fields{
@@ -665,7 +655,7 @@ func (store *ElasticDetectionstore) DeleteDetection(ctx context.Context, id stri
 		return nil, err
 	}
 
-	err = store.Delete(ctx, store.index, id)
+	_, err = store.deleteDocument(ctx, store.index, detect, "detection", id)
 
 	return detect, err
 }
@@ -875,11 +865,11 @@ func (store *ElasticDetectionstore) UpdateComment(ctx context.Context, comment *
 }
 
 func (store *ElasticDetectionstore) DeleteComment(ctx context.Context, id string) error {
-	_, err := store.GetComment(ctx, id)
+	dc, err := store.GetComment(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	_, err = store.deleteDocument(ctx, store.disableCrossClusterIndex(store.index), id)
+	_, err = store.deleteDocument(ctx, store.disableCrossClusterIndex(store.index), dc, "detectioncomment", id)
 	return err
 }

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -1526,9 +1526,13 @@ func TestDeleteDetectionComment(t *testing.T) {
 	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
 
 	body1 := `{"result":"deleted", "_id":"ABC123"}`
+	body2 := `{"result":"created", "_id":"DEF456"}`
 
 	mocktrans.AddResponse(&http.Response{
 		Body: io.NopCloser(strings.NewReader(body1)),
+	})
+	mocktrans.AddResponse(&http.Response{
+		Body: io.NopCloser(strings.NewReader(body2)),
 	})
 
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
@@ -1538,7 +1542,7 @@ func TestDeleteDetectionComment(t *testing.T) {
 
 	reqs := mocktrans.GetRequests()
 
-	assert.Equal(t, 1, len(reqs))
+	assert.Equal(t, 2, len(reqs))
 	assert.Equal(t, http.MethodDelete, reqs[0].Method)
 }
 


### PR DESCRIPTION
Comments can now be deleted. We were passing in a crossclustered index when a non-remote index was expected.

In order to facilitate cypress tests, a couple IDs were added.