### PR TITLE
Better Behavior around Ctrl+C

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1412,6 +1412,8 @@
                             <span id="override-enabled" v-if="!isOverrideEdit('override-enabled')" data-aid="detection_override_enabled_display">
                               {{item.isEnabled}}
                             </span>
+                            <v-checkbox v-else id="override-enabled-edit" ref="override-enabled" hide-details="auto" outlined v-model="item.isEnabled"
+                              persistent-hint :hint="i18n.enabled" v-on:change="stopOverrideEdit(true)" data-aid="detection_override_enabled_toggle"></v-checkbox>
                           </div>
                           <!-- regex -->
                           <div v-if="item.type === 'modify'" @click="startOverrideEdit('override-regex', item, 'regex')" :class="{ clicktoedit: !isOverrideEdit('override-regex') }">
@@ -1501,16 +1503,18 @@
                         </td>
                         <td :colspan="headers.length" class="pa-4" v-else-if="detect.engine === 'elastalert'">
                           <!-- isEnabled -->
-                          <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" class="clicktoedit">
+                          <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }">
                             <div class="font-weight-bold mt-2">
                               {{i18n.enabled}}:
                             </div>
                             <span id="override-enabled" v-if="!isOverrideEdit('override-enabled')" data-aid="detection_override_enabled_display">
                               {{item.isEnabled}}
                             </span>
+                            <v-checkbox v-else id="override-enabled-edit" ref="override-enabled" hide-details="auto" outlined v-model="item.isEnabled"
+                              persistent-hint :hint="i18n.enabled" v-on:change="stopOverrideEdit(true)" data-aid="detection_override_enabled_toggle"></v-checkbox>
                           </div>
                           <!-- custom filter -->
-                          <div @click="startOverrideEdit('override-custom-filter', item, 'customFilter')" class="clicktoedit">
+                          <div @click="startOverrideEdit('override-custom-filter', item, 'customFilter')" :class="{ clicktoedit: !isOverrideEdit('override-custom-filter') }">
                             <div class="font-weight-bold mt-2">
                               {{i18n.customFilter}}:
                             </div>
@@ -1736,23 +1740,17 @@
                   <h3>{{ i18n.operations }}</h3>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
-                  <span class="clicktoedit">
+                  <span @click="startEdit('detection-enabled', 'isEnabled')" :class="{ clicktoedit: !isEdit('detection-enabled') }">
                     <div class="ops-header">
                       {{ i18n.status }}:
                     </div>
                     <div class="ops-value" data-aid="detection_metadata_enabled_toggle">
-                      <span @click="startEdit('detection-enabled', 'isEnabled')" v-if="!isEdit('detection-enabled')">
+                      <span v-if="!isEdit('detection-enabled')">
                         {{ detect.isEnabled ? i18n.enabled : i18n.disabled }}
                       </span>
                       <v-checkbox id="detection-enabled-edit" v-model="detect.isEnabled" v-else @change="stopEdit(true)" />
                     </div>
                   </span>
-                  <!-- <div class="ops-header">
-                    Related Playbooks:
-                  </div>
-                  <div class="ops-value">
-                    TODO
-                  </div> -->
                   <div id="ops-buttons">
                     <v-btn id="detection-duplicate" color="primary" @click="duplicateDetection()" data-aid="detection_metadata_duplicate">
                       {{i18n.duplicate}}
@@ -1764,7 +1762,7 @@
                 </v-expansion-panel-content>
               </v-expansion-panel>
               <v-expansion-panel v-if="!isNew()" data-aid="detection_metadata_details">
-                <v-expansion-panel-header id="detection-related-playbooks">
+                <v-expansion-panel-header id="detection-extracted-details">
                   <h3>{{ i18n.details }}</h3>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>

--- a/html/index.html
+++ b/html/index.html
@@ -1501,9 +1501,9 @@
                             </div>
                           </div>
                         </td>
-                        <td :colspan="headers.length" class="pa-4" v-else-if="detect.engine === 'elastalert'" data-aid="detection_override_enabled_toggle">
+                        <td :colspan="headers.length" class="pa-4" v-else-if="detect.engine === 'elastalert'">
                           <!-- isEnabled -->
-                          <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }">
+                          <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }" data-aid="detection_override_enabled_toggle">
                             <div class="font-weight-bold mt-2">
                               {{i18n.enabled}}:
                             </div>

--- a/html/index.html
+++ b/html/index.html
@@ -1405,7 +1405,7 @@
                             7. Custom Filter - engine:elastalert
                           -->
                           <!-- isEnabled -->
-                          <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }">
+                          <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }" data-aid="detection_override_enabled_toggle">
                             <div class="font-weight-bold mt-4">
                               {{i18n.enabled}}:
                             </div>
@@ -1413,7 +1413,7 @@
                               {{item.isEnabled}}
                             </span>
                             <v-checkbox v-else id="override-enabled-edit" ref="override-enabled" hide-details="auto" outlined v-model="item.isEnabled"
-                              persistent-hint :hint="i18n.enabled" v-on:change="stopOverrideEdit(true)" data-aid="detection_override_enabled_toggle"></v-checkbox>
+                              persistent-hint :hint="i18n.enabled" v-on:change="stopOverrideEdit(true)"></v-checkbox>
                           </div>
                           <!-- regex -->
                           <div v-if="item.type === 'modify'" @click="startOverrideEdit('override-regex', item, 'regex')" :class="{ clicktoedit: !isOverrideEdit('override-regex') }">
@@ -1501,7 +1501,7 @@
                             </div>
                           </div>
                         </td>
-                        <td :colspan="headers.length" class="pa-4" v-else-if="detect.engine === 'elastalert'">
+                        <td :colspan="headers.length" class="pa-4" v-else-if="detect.engine === 'elastalert'" data-aid="detection_override_enabled_toggle">
                           <!-- isEnabled -->
                           <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }">
                             <div class="font-weight-bold mt-2">
@@ -1511,7 +1511,7 @@
                               {{item.isEnabled}}
                             </span>
                             <v-checkbox v-else id="override-enabled-edit" ref="override-enabled" hide-details="auto" outlined v-model="item.isEnabled"
-                              persistent-hint :hint="i18n.enabled" v-on:change="stopOverrideEdit(true)" data-aid="detection_override_enabled_toggle"></v-checkbox>
+                              persistent-hint :hint="i18n.enabled" v-on:change="stopOverrideEdit(true)"></v-checkbox>
                           </div>
                           <!-- custom filter -->
                           <div @click="startOverrideEdit('override-custom-filter', item, 'customFilter')" :class="{ clicktoedit: !isOverrideEdit('override-custom-filter') }">

--- a/server/detectionengine.go
+++ b/server/detectionengine.go
@@ -16,4 +16,5 @@ type DetectionEngine interface {
 	SyncLocalDetections(ctx context.Context, detections []*model.Detection) (errMap map[string]string, err error)
 	ConvertRule(ctx context.Context, detect *model.Detection) (string, error)
 	ExtractDetails(detect *model.Detection) error
+	InterruptSleep()
 }

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -363,7 +363,9 @@ level: high
 		"all_rules": buf.Bytes(),
 	}
 
-	engine := ElastAlertEngine{}
+	engine := ElastAlertEngine{
+		isRunning: true,
+	}
 	engine.allowRegex = regexp.MustCompile("00000000-0000-0000-0000-00000000")
 	engine.denyRegex = regexp.MustCompile("deny")
 
@@ -424,6 +426,7 @@ level: high
 	mio.EXPECT().ReadFile(gomock.Eq("rules/so_soc_failed_login.yml")).Return([]byte(data), nil)
 
 	engine := ElastAlertEngine{
+		isRunning: true,
 		IOManager: mio,
 	}
 	engine.allowRegex = regexp.MustCompile("bf86ef21-41e6-417b-9a05-b9ea6bf28a38")

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -272,6 +272,7 @@ func TestSyncSuricata(t *testing.T) {
 				DetectionEngines: map[model.EngineName]server.DetectionEngine{},
 				Detectionstore:   mockDetStore,
 			})
+			mod.isRunning = true
 			mod.srv.DetectionEngines[model.EngineNameSuricata] = mod
 			mod.IOManager = mio
 			mod.compileRules = true

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -345,6 +345,8 @@ func TestParse(t *testing.T) {
 	mod.allowRegex = regexp.MustCompile("[12]0000")
 	mod.denyRegex = regexp.MustCompile("flowbits")
 
+	mod.isRunning = true
+
 	for _, test := range table {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
When modules are shutting down, their sleeps are now interrupted in the detection engines. Also, more checks have been added so the engines can exit during any step of processing.

Also has a small tweak to the clicktoedit styling added so the styles are only active when not editing those controls.

Put the checkboxes back in overrides.