### PR TITLE
Details Tweaks

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -591,6 +591,10 @@ td {
   margin-top: 16px;
 }
 
+.ops-value::after {
+  content: "\00a0";
+}
+
 .ops-value > .v-input--selection-controls {
   margin-top: 0 !important;
   padding-top: 0 !important;

--- a/html/index.html
+++ b/html/index.html
@@ -1776,22 +1776,22 @@
                   <div class="ops-value" data-aid="detection_metadata_public_license_display">
                     {{ detect.license }}
                   </div>
-                  <div class="ops-header" v-if="extractedCreated">
+                  <div class="ops-header">
                     {{ i18n.dateCreated }}:
                   </div>
-                  <div class="ops-value" v-if="extractedCreated" data-aid="detection_metadata_public_created_time_display">
+                  <div class="ops-value" data-aid="detection_metadata_public_created_time_display">
                     {{ extractedCreated }}
                   </div>
-                  <div class="ops-header" v-if="extractedUpdated">
+                  <div class="ops-header">
                     {{ i18n.dateModified }}:
                   </div>
-                  <div class="ops-value"  v-if="extractedUpdated" data-aid="detection_metadata_public_updated_time_display">
+                  <div class="ops-value" data-aid="detection_metadata_public_updated_time_display">
                     {{ extractedUpdated }}
                   </div>
-                  <div class="ops-header" v-if="extractedAuthor">
+                  <div class="ops-header">
                     {{ i18n.author }}:
                   </div>
-                  <div class="ops-value"  v-if="extractedAuthor" data-aid="detection_metadata_public_author_display">
+                  <div class="ops-value" data-aid="detection_metadata_public_author_display">
                     {{ extractedAuthor }}
                   </div>
                   <!-- <div class="ops-header">

--- a/html/index.html
+++ b/html/index.html
@@ -1820,12 +1820,7 @@
                   {{ i18n.author }}:
                 </div>
                 <div class="value" data-aid="detection_metadata_author_display">
-                  <span v-if="!detect.isCommunity">
-                    {{ detect.author }}
-                  </span>
-                  <span v-else>
-                    {{ detect.ruleset }}
-                  </span>
+                  {{ detect.author }}
                 </div>
               </div>
               <div>

--- a/html/index.html
+++ b/html/index.html
@@ -762,8 +762,9 @@
                       </td>
                       <td v-for="field in eventHeaders" :key="field.value">
                         <div :id="'events_quick_action_' + category + '_' + field.value" class="quick-action-trigger d-inline-block" @click="toggleQuickAction($event, item, field.value, item[field.value])" :data-aid="'events_quick_action_' + category">
-                          <span v-if="field.value != 'soc_timestamp'">{{ $root.correctCasing(item[field.value]) }}<span class="resolved-host" v-if="$root.pickHostname(item[field.value])"><br/>- {{ $root.pickHostname(item[field.value]) }}</span></span>
+                          <span v-if="field.value != 'soc_timestamp' && !field.value.endsWith('detection.author')">{{ $root.correctCasing(item[field.value]) }}<span class="resolved-host" v-if="$root.pickHostname(item[field.value])"><br/>- {{ $root.pickHostname(item[field.value]) }}</span></span>
                           <span v-if="field.value == 'soc_timestamp'" v-text="$root.formatLocalTimestamp(item[field.value], zone)"/>
+                          <span v-if="field.value.endsWith('detection.author')" v-text="$root.tryLocalize(item[field.value])"/>
                         </div>
                       </td>
                     </tr>
@@ -786,7 +787,7 @@
                                 <div :id="'events_fields_' + category + '_' + item.key" class="d-inline-block expansion" v-text="item.key" :data-aid="'events_field_name_' + category"></div>
                               </td>
                               <td class="expansion" :data-aid="'events_field_value_' + category">
-                                <div class="quick-action-trigger d-inline-block expansion hardwrap" @click="toggleQuickAction($event, expanded[0], item.key, item.value)">{{item.value}}<span class="resolved-host" v-if="$root.pickHostname(item.value)"> - {{ $root.pickHostname(item.value) }}</span></div>
+                                <div class="quick-action-trigger d-inline-block expansion hardwrap" @click="toggleQuickAction($event, expanded[0], item.key, item.value)">{{item.key.endsWith('detection.author') ? $root.tryLocalize(item.value) : item.value}}<span class="resolved-host" v-if="$root.pickHostname(item.value)"> - {{ $root.pickHostname(item.value) }}</span></div>
                               </td>
                             </tr>
                           </template>
@@ -1619,7 +1620,7 @@
                           <div>
                             <v-row no-gutters class="py-1 case tabular-row">
                               <v-col cols="4"><span class="case tabular-label">{{ i18n.author }}:</span></v-col>
-                              <v-col cols="8"><span class="case">{{ props.item.author }}</span></v-col>
+                              <v-col cols="8"><span class="case">{{ $root.tryLocalize(props.item.author) }}</span></v-col>
                             </v-row>
                           </div>
                           <div>
@@ -1820,7 +1821,7 @@
                   {{ i18n.author }}:
                 </div>
                 <div class="value" data-aid="detection_metadata_author_display">
-                  {{ detect.author }}
+                  {{ $root.tryLocalize(detect.author) }}
                 </div>
               </div>
               <div>

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -629,6 +629,14 @@ $(document).ready(function() {
         }
         return localized;
       },
+      tryLocalize(msg) {
+        const localized = this.localizeMessage(msg);
+        if (localized) {
+          return localized;
+        }
+
+        return msg;
+      },
       correctCasing(origMsg) {
         const msg = (origMsg+'').toLowerCase();
         var localized = this.i18n['cc_'+msg];

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -8,7 +8,7 @@ const i18n = {
   translations: {
     "en-US": {
       __missing__: '*Missing', // This should be sufficiently unique to avoid collisions with actual values
-      __SOC_IMPORT__: 'SOC Import',
+      __soc_import__: 'SOC Import',
       accept: 'Accept',
       accepted: 'Accepted',
       acceptingMinionsTakesTime: 'Accepting new minions can take 1-2 minutes to complete.',

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -8,6 +8,7 @@ const i18n = {
   translations: {
     "en-US": {
       __missing__: '*Missing', // This should be sufficiently unique to avoid collisions with actual values
+      __SOC_IMPORT__: 'SOC Import',
       accept: 'Accept',
       accepted: 'Accepted',
       acceptingMinionsTakesTime: 'Accepting new minions can take 1-2 minutes to complete.',

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -44,7 +44,7 @@ var acceptedExtensions = map[string]bool{
 	".yaml": true,
 }
 
-var socAuthor = "__SOC_IMPORT__"
+var socAuthor = "__soc_import__"
 
 type IOManager interface {
 	ReadFile(path string) ([]byte, error)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -44,7 +44,7 @@ var acceptedExtensions = map[string]bool{
 	".yaml": true,
 }
 
-var socAuthor = "SOC Import"
+var socAuthor = "__SOC_IMPORT__"
 
 type IOManager interface {
 	ReadFile(path string) ([]byte, error)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -44,6 +44,8 @@ var acceptedExtensions = map[string]bool{
 	".yaml": true,
 }
 
+var socAuthor = "SOC Import"
+
 type IOManager interface {
 	ReadFile(path string) ([]byte, error)
 	WriteFile(path string, contents []byte, perm fs.FileMode) error

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -370,7 +370,7 @@ level: high
 	engine.denyRegex = regexp.MustCompile("deny")
 
 	expected := &model.Detection{
-		Author:      "SOC Import",
+		Author:      "__SOC_IMPORT__",
 		PublicID:    "00000000-0000-0000-0000-00000000",
 		Title:       "Always Alert",
 		Severity:    model.SeverityHigh,
@@ -434,6 +434,7 @@ level: high
 	engine.denyRegex = regexp.MustCompile("deny")
 
 	expected := &model.Detection{
+		Author:      "__SOC_IMPORT__",
 		PublicID:    "bf86ef21-41e6-417b-9a05-b9ea6bf28a38",
 		Title:       "Security Onion - SOC Login Failure",
 		Severity:    model.SeverityHigh,

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -370,6 +370,7 @@ level: high
 	engine.denyRegex = regexp.MustCompile("deny")
 
 	expected := &model.Detection{
+		Author:      "SOC Import",
 		PublicID:    "00000000-0000-0000-0000-00000000",
 		Title:       "Always Alert",
 		Severity:    model.SeverityHigh,

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -370,7 +370,7 @@ level: high
 	engine.denyRegex = regexp.MustCompile("deny")
 
 	expected := &model.Detection{
-		Author:      "__SOC_IMPORT__",
+		Author:      "__soc_import__",
 		PublicID:    "00000000-0000-0000-0000-00000000",
 		Title:       "Always Alert",
 		Severity:    model.SeverityHigh,
@@ -434,7 +434,7 @@ level: high
 	engine.denyRegex = regexp.MustCompile("deny")
 
 	expected := &model.Detection{
-		Author:      "__SOC_IMPORT__",
+		Author:      "__soc_import__",
 		PublicID:    "bf86ef21-41e6-417b-9a05-b9ea6bf28a38",
 		Title:       "Security Onion - SOC Login Failure",
 		Severity:    model.SeverityHigh,

--- a/server/modules/elastalert/validate.go
+++ b/server/modules/elastalert/validate.go
@@ -146,6 +146,7 @@ func (r *SigmaRule) ToDetection(content string, ruleset string, license string) 
 	}
 
 	det := &model.Detection{
+		Author:      socAuthor,
 		Engine:      model.EngineNameElastAlert,
 		PublicID:    id,
 		Title:       r.Title,

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -34,7 +34,7 @@ import (
 
 var errModuleStopped = fmt.Errorf("strelka module has stopped running")
 
-var socAuthor = "SOC Import"
+var socAuthor = "__SOC_IMPORT__"
 
 type IOManager interface {
 	ReadFile(path string) ([]byte, error)

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -34,7 +34,7 @@ import (
 
 var errModuleStopped = fmt.Errorf("strelka module has stopped running")
 
-var socAuthor = "__SOC_IMPORT__"
+var socAuthor = "__soc_import__"
 
 type IOManager interface {
 	ReadFile(path string) ([]byte, error)

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -34,6 +34,8 @@ import (
 
 var errModuleStopped = fmt.Errorf("strelka module has stopped running")
 
+var socAuthor = "SOC Import"
+
 type IOManager interface {
 	ReadFile(path string) ([]byte, error)
 	WriteFile(path string, contents []byte, perm fs.FileMode) error
@@ -454,6 +456,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 					ruleset := filepath.Base(repopath)
 
 					det := &model.Detection{
+						Author:      socAuthor,
 						Engine:      model.EngineNameStrelka,
 						PublicID:    rule.GetID(),
 						Title:       rule.Identifier,

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -39,6 +39,8 @@ var licenseBySource = map[string]string{
 	"etpro":  model.LicenseCommercial,
 }
 
+var socAuthor = "SOC Import"
+
 type SuricataEngine struct {
 	srv                                  *server.Server
 	communityRulesFile                   string
@@ -513,6 +515,7 @@ func (s *SuricataEngine) ParseRules(content string, ruleset *string) ([]*model.D
 		}
 
 		d := &model.Detection{
+			Author:   socAuthor,
 			PublicID: sid,
 			Title:    title,
 			Severity: severity,

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -39,7 +39,7 @@ var licenseBySource = map[string]string{
 	"etpro":  model.LicenseCommercial,
 }
 
-var socAuthor = "SOC Import"
+var socAuthor = "__SOC_IMPORT__"
 
 type SuricataEngine struct {
 	srv                                  *server.Server

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -39,7 +39,7 @@ var licenseBySource = map[string]string{
 	"etpro":  model.LicenseCommercial,
 }
 
-var socAuthor = "__SOC_IMPORT__"
+var socAuthor = "__soc_import__"
 
 type SuricataEngine struct {
 	srv                                  *server.Server

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -318,7 +318,7 @@ func TestParse(t *testing.T) {
 			},
 			ExpectedDetections: []*model.Detection{
 				{
-					Author:   "__SOC_IMPORT__",
+					Author:   "__soc_import__",
 					PublicID: SimpleRuleSID,
 					Title:    `GPL ATTACK_RESPONSE id check returned root`,
 					Severity: model.SeverityUnknown,
@@ -329,7 +329,7 @@ func TestParse(t *testing.T) {
 					License:  "Unknown",
 				},
 				{
-					Author:   "__SOC_IMPORT__",
+					Author:   "__soc_import__",
 					PublicID: "20000",
 					Title:    `a "tricky";\ msg`,
 					Severity: model.SeverityInformational,

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -318,7 +318,7 @@ func TestParse(t *testing.T) {
 			},
 			ExpectedDetections: []*model.Detection{
 				{
-					Author:   "SOC Import",
+					Author:   "__SOC_IMPORT__",
 					PublicID: SimpleRuleSID,
 					Title:    `GPL ATTACK_RESPONSE id check returned root`,
 					Severity: model.SeverityUnknown,
@@ -329,7 +329,7 @@ func TestParse(t *testing.T) {
 					License:  "Unknown",
 				},
 				{
-					Author:   "SOC Import",
+					Author:   "__SOC_IMPORT__",
 					PublicID: "20000",
 					Title:    `a "tricky";\ msg`,
 					Severity: model.SeverityInformational,

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -318,6 +318,7 @@ func TestParse(t *testing.T) {
 			},
 			ExpectedDetections: []*model.Detection{
 				{
+					Author:   "SOC Import",
 					PublicID: SimpleRuleSID,
 					Title:    `GPL ATTACK_RESPONSE id check returned root`,
 					Severity: model.SeverityUnknown,
@@ -328,6 +329,7 @@ func TestParse(t *testing.T) {
 					License:  "Unknown",
 				},
 				{
+					Author:   "SOC Import",
 					PublicID: "20000",
 					Title:    `a "tricky";\ msg`,
 					Severity: model.SeverityInformational,


### PR DESCRIPTION
Extracted Author, Created Time, and Updated Time now all show up unconditionally.

SOC Author: if the rule is a community rule, this will be the community source that the rule came from. If the rule is not a community rule, it'll be the author who saved the custom detection (specifically their SOC user's First Name + Last Name or if no name is present Email). If SOC Author shows up empty again, it's something upstream.