### PR TITLE
Enable QuickActions in Detections

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -950,7 +950,7 @@
                 </v-list-item-title>
               </v-list-item>
             </v-list-group>
-            <v-list-group dense @click.stop color="white" :data-aid="'context_menu_quickaction_' + category">
+            <v-list-group dense @click.stop color="white" :data-aid="'context_menu_quickaction_' + category" v-if="!!actions && actions.length">
               <template v-slot:activator>
                 <v-list-item-icon>
                   <v-icon color="white">fa-external-link-alt</v-icon>

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -251,7 +251,7 @@ const huntComponent = {
       if (this.queries != null && this.queries.length > 0) {
         this.query = this.queries[0].query;
       }
-      this.actions = params["actions"];
+      this.actions = params["actions"] || [];
       this.zone = moment.tz.guess();
 
       this.loadLocalSettings();


### PR DESCRIPTION
The main thing preventing the quickAction menu from appearing before was `this.actions` not receiving anything from the parameters. Being undefined, it threw an error when iterating over it and the thrown error prevented the quickAction menu from appearing. By allowing the menu to appear even when there are no actions, the menu can appear and seems to function.