### PR TITLE
Visual Glitch Fixed

### DIFF
--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -568,7 +568,7 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 		isEdit(target) {
 			return this.curEditTarget === target;
 		},
-		async stopEdit(commit) {
+		stopEdit(commit) {
 			if (!commit) {
 				this.detect[this.editField] = this.origValue;
 			}
@@ -578,7 +578,10 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			this.editField = null;
 
 			if (commit && !this.isNew()) {
-				this.saveDetection(false);
+				this.$nextTick(async () => {
+					await this.saveDetection(false);
+					this.curEditTarget = null;
+				});
 			}
 		},
 		async saveDetection(createNew) {
@@ -983,13 +986,16 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 		isOverrideEdit(target) {
 			return this.curOverrideEditTarget === target;
 		},
-		async stopOverrideEdit(commit) {
+		stopOverrideEdit(commit) {
 			if (commit && this.$refs[this.curOverrideEditTarget].hasError) return;
 
 			if (!commit) {
 				this.editOverride[this.overrideEditField] = this.origOverrideValue;
 			} else {
-				this.saveDetection(false);
+				this.$nextTick(async () => {
+					await this.saveDetection(false);
+					this.curOverrideEditTarget = null;
+				});
 			}
 
 			this.curOverrideEditTarget = null;


### PR DESCRIPTION
It seems like a corner case of Vue change detection. The change wasn't being detected but by moving the async call to the next tick and reminding it that the field that indicates editing is null reliably gets the UI to change back to hiding the checkbox.