### PR TITLE
Sync Without Engine Selection Fixed

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -319,7 +319,7 @@ const i18n = {
       endTime: 'Filter End',
       endTimeHelp: 'Filter end time in RFC 3339 format (Ex: 2020-10-16 15:30:00.230-04:00). Unused for imported PCAPs.',
       engine: 'Engine',
-      engineSelect: 'Please select an Engine to sync',
+      engineSelect: 'Please select an engine to synchronize.',
       eps: 'EPS',
       epsProduction: 'Production EPS:',
       epsConsumption: 'Consumption EPS:',

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -319,6 +319,7 @@ const i18n = {
       endTime: 'Filter End',
       endTimeHelp: 'Filter end time in RFC 3339 format (Ex: 2020-10-16 15:30:00.230-04:00). Unused for imported PCAPs.',
       engine: 'Engine',
+      engineSelect: 'Please select an Engine to sync',
       eps: 'EPS',
       epsProduction: 'Production EPS:',
       epsConsumption: 'Consumption EPS:',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -248,6 +248,7 @@ const huntComponent = {
       this.chartLabelOtherLimit = params["chartLabelOtherLimit"]
       this.chartLabelFieldSeparator = params["chartLabelFieldSeparator"]
       this.presets = params["presets"];
+      this.manualSyncTargetEngine = this.getPresets("manualSync")[0];
       if (this.queries != null && this.queries.length > 0) {
         this.query = this.queries[0].query;
       }
@@ -2260,6 +2261,10 @@ const huntComponent = {
       }
     },
     startManualSync(engine, type) {
+      if (!engine) {
+        this.$root.showTip(this.i18n.engineSelect);
+        return;
+      }
       try {
         this.$root.papi.post(`detection/sync/${engine}/${type}`);
 


### PR DESCRIPTION
Once the client parameters come in, the model is updated to preselect the first engine. If you somehow still manage to click the button without an engine, you'll get a tip asking to select an engine.