### PR TITLE
Cleanup for Cypress Tests

### DIFF
--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -578,10 +578,9 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			this.editField = null;
 
 			if (commit && !this.isNew()) {
-				this.$nextTick(async () => {
-					await this.saveDetection(false);
-					this.curEditTarget = null;
-				});
+					this.saveDetection(false).then(() => {
+						this.curEditTarget = null;
+					});
 			}
 		},
 		async saveDetection(createNew) {
@@ -627,10 +626,6 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 					});
 				}
 
-				if (response.status === 206) {
-					this.$root.showWarning(this.i18n.disabledFailedSync);
-				}
-
 				// get any expanded overrides before updating this.detect
 				let index = -1;
 				if (this.expanded && this.expanded.length) {
@@ -649,7 +644,11 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 					this.expand(this.detect.overrides[index]);
 				}
 
-				this.$root.showTip(this.i18n.saveSuccess);
+				if (response.status === 206) {
+					this.$root.showWarning(this.i18n.disabledFailedSync);
+				} else {
+					this.$root.showTip(this.i18n.saveSuccess);
+				}
 
 				if (createNew) {
 					this.$router.push({ name: 'detection', params: { id: response.data.id } });

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -131,6 +131,8 @@ func (h *DetectionHandler) createDetection(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	detect.Language = model.SigLanguage(strings.ToLower(string(detect.Language)))
+
 	switch detect.Language {
 	case "sigma":
 		detect.Engine = model.EngineNameElastAlert


### PR DESCRIPTION
The way the visual glitch was fixed used an async function. Cypress and async functions don't always play well together, occasionally causing the function to be called twice. Handling the async with the Promise approach solves the visual glitch while allowing cypress to behave more predictably.

Some casing changes in the UI tripped up the backend, the backend now normalizes the data it assumed was normalized.

Moved the check for 206 when saving a detection down so we are either showing the warning or the successful popup, not both.