### PR TITLE
Overrides Enabled

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1361,13 +1361,13 @@
                     </div>
                   </v-col>
                   <v-data-table :sort-by.sync="sortBy" :expanded.sync="expanded" :sort-desc.sync="sortDesc" must-sort :headers="overrideHeaders"
-                    :items="detect.overrides" item-key="index" show-expand single-expand :custom-sort="sortOverrides" hide-default-footer="true">
-                    <template v-slot:item="{ item, index }">
+                    :items="detect.overrides" show-expand single-expand :custom-sort="sortOverrides" hide-default-footer="true">
+                    <template v-slot:item="{ item, index, expand, isExpanded }">
                       <tr>
                         <td>
-                          <v-btn id="expandOverrideArrow" icon small @click="expand(item)">
-                            <v-icon v-if="isExpanded(item)" :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_overrides_collapse">fa-angle-down</v-icon>
-                            <v-icon v-if="!isExpanded(item)" :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_overrides_expand">fa-angle-right</v-icon>
+                          <v-btn id="expandOverrideArrow" icon small @click="expand(!isExpanded)">
+                            <v-icon v-if="isExpanded" :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_overrides_collapse">fa-angle-down</v-icon>
+                            <v-icon v-else :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_overrides_expand">fa-angle-right</v-icon>
                           </v-btn>
                         </td>
                         <td v-for="field in overrideHeaders" :key="field.value" data-aid="detection_overrides_headers_display">
@@ -1543,32 +1543,32 @@
                   <v-data-table ref="historyTable" :sort-by.sync="historyTableOpts.sortBy" :sort-desc.sync="historyTableOpts.sortDesc" :items-per-page.sync="historyTableOpts.itemsPerPage"
                     :search="historyTableOpts.search" :footer-props="historyTableOpts.footerProps" must-sort :headers="historyTableOpts.headers"
                     :items="history" item-key="id" :loading="historyTableOpts.loading" :expanded="historyTableOpts.expanded" class="history-table">
-                    <template v-slot:item="props">
+                    <template v-slot:item="{item, index, expand, isExpanded}">
                       <tr>
                         <td class="associated actions">
-                          <v-btn :id="`history-${props.index}-expand`" icon small @click="expandRow(props.item)">
-                            <v-icon v-if="isExpanded(props.item)" :alt="i18n.expand" :title="i18n.expandHelp" data-aid="detection_history_collapse">fa-angle-down</v-icon>
-                            <v-icon v-if="!isExpanded(props.item)" :alt="i18n.expand" :title="i18n.expandHelp" data-aid="detection_history_expand">fa-angle-right</v-icon>
+                          <v-btn :id="`history-${index}-expand`" icon small @click="expand(!isExpanded)">
+                            <v-icon v-if="isExpanded" :alt="i18n.expand" :title="i18n.expandHelp" data-aid="detection_history_collapse">fa-angle-down</v-icon>
+                            <v-icon v-else :alt="i18n.expand" :title="i18n.expandHelp" data-aid="detection_history_expand">fa-angle-right</v-icon>
                           </v-btn>
                         </td>
                         <td class="associated" data-aid="detection_history_owner_display">
                           <v-avatar color="primary" class="mr-2 white--text" size="28" data-aid="detection_history_avatar_display">
-                            <div class="font-weight-bold" :title="props.item.owner">
-                              {{ $root.getAvatar(props.item.owner) }}
+                            <div class="font-weight-bold" :title="item.owner">
+                              {{ $root.getAvatar(item.owner) }}
                             </div>
                           </v-avatar>
-                          {{ props.item.owner }}
+                          {{ item.owner }}
                         </td>
-                        <td class="associated" data-aid="detection_history_timestamp_display">{{ props.item.updateTime | formatDateTime }}</td>
+                        <td class="associated" data-aid="detection_history_timestamp_display">{{ item.updateTime | formatDateTime }}</td>
                         <td class="associated" data-aid="detection_history_kind_display">
                           <v-icon>fa-magnifying-glass</v-icon>
-                          <span class="rounded ml-2">{{ props.item.kind }}</span>
+                          <span class="rounded ml-2">{{ item.kind }}</span>
                         </td>
                         <td class="associated" data-aid="detection_history_operation_display">
-                          <v-icon v-if="props.item.operation.toLowerCase() == i18n.create.toLowerCase()">fa-plus</v-icon>
-                          <v-icon v-if="props.item.operation.toLowerCase() == i18n.delete.toLowerCase()">fa-circle-xmark</v-icon>
-                          <v-icon v-if="props.item.operation.toLowerCase() == i18n.update.toLowerCase()">fa-pencil-alt</v-icon>
-                          <span class="rounded ml-2">{{ props.item.operation }}</span>
+                          <v-icon v-if="item.operation.toLowerCase() == i18n.create.toLowerCase()">fa-plus</v-icon>
+                          <v-icon v-if="item.operation.toLowerCase() == i18n.delete.toLowerCase()">fa-circle-xmark</v-icon>
+                          <v-icon v-if="item.operation.toLowerCase() == i18n.update.toLowerCase()">fa-pencil-alt</v-icon>
+                          <span class="rounded ml-2">{{ item.operation }}</span>
                         </td>
                       </tr>
                     </template>

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -862,16 +862,6 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			}
 			return b < a ? -1 : 1;
 		},
-		expand(item) {
-			if (this.isExpanded(item)) {
-				this.expanded = [];
-			} else {
-				this.expanded = [item];
-			}
-		},
-		isExpanded(item) {
-			return (this.expanded.length > 0 && this.expanded[0] === item);
-		},
 		createNewOverride() {
 			this.newOverride = {
 				type: null,
@@ -966,6 +956,8 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 				this.detect.overrides = [];
 			}
 
+			this.newOverride.isEnabled = true;
+
 			this.detect.overrides.push(this.newOverride);
 
 			this.saveDetection(false);
@@ -1013,21 +1005,7 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			this.saveDetection(false);
 		},
 		canAddOverride() {
-			if (this.detect.engine === 'elastalert') {
-				if (this.detect.overrides && this.detect.overrides.length > 0) {
-					for (let i = 0; i < this.detect.overrides.length; i++) {
-						if (this.detect.overrides[i].type === 'custom filter') {
-							// elastalert detections that already have a custom filter
-							// cannot have any other custom filter overrides
-							return false;
-						}
-					}
-				}
-			} else if (this.detect.engine === 'strelka') {
-				return false;
-			}
-
-			return true;
+			return this.detect.engine !== 'strelka';
 		},
 		tagOverrides() {
 			if (this.detect.overrides) {
@@ -1037,26 +1015,6 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			} else {
 				this.detect.overrides = [];
 			}
-		},
-		isExpanded(row) {
-			const expanded = this.historyTableOpts.expanded;
-			for (var i = 0; i < expanded.length; i++) {
-				if (expanded[i].id == row.id) {
-					return true;
-				}
-			}
-			return false;
-		},
-		async expandRow(row) {
-			const expanded = this.historyTableOpts.expanded;
-			for (var i = 0; i < expanded.length; i++) {
-				if (expanded[i].id == row.id) {
-					expanded.splice(i, 1);
-					return;
-				}
-			}
-
-			expanded.push(row);
 		},
 		prepareForInput(id) {
 			const el = document.getElementById(id)

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -275,7 +275,7 @@ test('canAddOverride elastalert', () => {
 
 	comp.detect.overrides = [
 		{
-			type: 'custom filter',
+			type: 'customFilter',
 			isEnabled: 'isEnabled',
 			createdAt: 'createdAt',
 			updatedAt: 'updatedAt',
@@ -290,7 +290,7 @@ test('canAddOverride elastalert', () => {
 		},
 	];
 
-	expect(comp.canAddOverride()).toBe(false);
+	expect(comp.canAddOverride()).toBe(true);
 });
 
 test('tagOverrides', () => {
@@ -305,6 +305,6 @@ test('tagOverrides', () => {
 	comp.tagOverrides();
 
 	for (let i = 0; i < comp.detect.overrides.length; i++) {
-		expect(comp.detect.overrides[0]).toStrictEqual({ index: 0 });
+		expect(comp.detect.overrides[i]).toStrictEqual({ index: i });
 	}
 });


### PR DESCRIPTION
Overrides are enabled by default.

Figured out the secret behind v-data-table and it's expanding rows. We were manually tracking something that's done for us automatically. Removed expand, isExpanded, another isExpanded, and expandRow as they are all unnecessary.

Simplified canAddOverride. This allows Sigma rules to have multiple overrides.

Updated some existing tests.