### PR TITLE
Misc Fixes To Overrides

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1489,13 +1489,10 @@
                           <!-- isEnabled -->
                           <div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }" data-aid="detection_override_enabled_toggle">
                             <div class="font-weight-bold mt-2">
-                              {{i18n.enabled}}:
+                              {{i18n.enabled}}: {{item.isEnabled}}
                             </div>
-                            <span id="override-enabled" v-if="!isOverrideEdit('override-enabled')" data-aid="detection_override_enabled_display">
-                              {{item.isEnabled}}
-                            </span>
-                            <v-checkbox v-else id="override-enabled-edit" ref="override-enabled" hide-details="auto" outlined v-model="item.isEnabled"
-                              persistent-hint :hint="i18n.enabled" v-on:change="stopOverrideEdit(true)"></v-checkbox>
+                            <v-switch id="override-enabled-edit" ref="override-enabled" hide-details="auto" v-model="item.isEnabled"
+                              inset @change="saveDetection(false)"></v-switch>
                           </div>
                           <!-- custom filter -->
                           <div @click="startOverrideEdit('override-custom-filter', item, 'customFilter')" :class="{ clicktoedit: !isOverrideEdit('override-custom-filter') }">

--- a/model/detection.go
+++ b/model/detection.go
@@ -215,20 +215,10 @@ func (detect *Detection) Validate() error {
 		return ErrUnsupportedEngine
 	}
 
-	customs := 0
-
 	for _, o := range detect.Overrides {
 		if err := o.Validate(detect.Engine); err != nil {
 			return err
 		}
-
-		if o.Type == OverrideTypeCustomFilter {
-			customs++
-		}
-	}
-
-	if detect.Engine == EngineNameElastAlert && customs > 1 {
-		return errors.New("only one custom filter override is allowed per ElastAlert detection")
 	}
 
 	return nil

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -828,6 +828,16 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, detectio
 		}
 	}
 
+	// carry forward existing overrides
+	for i := range detections {
+		det := detections[i]
+
+		comDet, exists := community[det.PublicID]
+		if exists {
+			det.Overrides = comDet.Overrides
+		}
+	}
+
 	results := struct {
 		Added     int
 		Updated   int
@@ -1233,14 +1243,6 @@ func wrapRule(det *model.Detection, rule string) (string, error) {
 	}
 
 	sevNum := severities[det.Severity]
-
-	// apply the first (should only have 1) CustomFilter override if any
-	for _, o := range det.Overrides {
-		if o.IsEnabled && o.Type == model.OverrideTypeCustomFilter && o.CustomFilter != nil {
-			rule = fmt.Sprintf("(%s) and %s", rule, *o.CustomFilter)
-			break
-		}
-	}
 
 	wrapper := &CustomWrapper{
 		PlayTitle:     det.Title,

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -443,6 +443,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 					if exists {
 						det.Id = comRule.Id
 						det.IsEnabled = comRule.IsEnabled
+						det.Overrides = comRule.Overrides
 					}
 
 					if exists {
@@ -592,7 +593,7 @@ func (e *StrelkaEngine) parseYaraRules(data []byte, filter bool) ([]*YaraRule, e
 				if buf != "" {
 					rule.Identifier = buf
 				} else {
-					return nil, errors.New(fmt.Sprintf("expected rule identifier at %d", i))
+					return nil, fmt.Errorf("expected rule identifier at %d", i)
 				}
 
 				buffer.Reset()
@@ -610,7 +611,7 @@ func (e *StrelkaEngine) parseYaraRules(data []byte, filter bool) ([]*YaraRule, e
 				if curHeader != "meta" &&
 					curHeader != "strings" &&
 					curHeader != "condition" {
-					return nil, errors.New(fmt.Sprintf("unexpected header at %d: %s", i, curHeader))
+					return nil, fmt.Errorf("unexpected header at %d: %s", i, curHeader)
 				}
 
 				state = parseStateInSection
@@ -630,7 +631,7 @@ func (e *StrelkaEngine) parseYaraRules(data []byte, filter bool) ([]*YaraRule, e
 						case "meta":
 							parts := strings.SplitN(buf, "=", 2)
 							if len(parts) != 2 {
-								return nil, errors.New(fmt.Sprintf("invalid meta line at %d: %s", i, buf))
+								return nil, fmt.Errorf("invalid meta line at %d: %s", i, buf)
 							}
 
 							key := strings.TrimSpace(parts[0])


### PR DESCRIPTION
Duplicate the UI improvements of the Status field for elastalert and not just suricata.

Removed a validation step that prevented elastalert detections from having multiple custom filter overrides.

Removed the old way of applying overrides to elastalert rules (inside wrapRule).

Fixed an issue in multiple engines where Overrides weren't being carried forward if a community rule was updated.

Some simple linting.