### PR TITLE
Simplify Sigma

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -1036,10 +1036,17 @@ const huntComponent = {
 
         if (alert) {
           // don't slow down the UI with this call
-          const publicId = alert["rule.uuid"];
-          this.$root.papi.get(`detection/public/${publicId}`).then(response => {
-            this.quickActionDetId = response.data.id;
-          });
+          const id = alert["rule.uuid"] || '';
+          if (id) {
+            const module = alert["event.module"] || '';
+            if (module.toLowerCase() === 'sigma') {
+              this.quickActionDetId = id;
+            } else {
+              this.$root.papi.get(`detection/public/${id}`).then(response => {
+                this.quickActionDetId = response.data.id;
+              });
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Sigma's rule.uuid on it's alerts is the PublicId of the detection. No call to make, just use the value as is. Everybody else still needs to be looked up by their PublicId.