### PR TITLE
Fix for Multiple Rows Opening in Detection Overrides

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1361,7 +1361,7 @@
                     </div>
                   </v-col>
                   <v-data-table :sort-by.sync="sortBy" :expanded.sync="expanded" :sort-desc.sync="sortDesc" must-sort :headers="overrideHeaders"
-                    :items="detect.overrides" show-expand single-expand :custom-sort="sortOverrides" hide-default-footer="true">
+                    :items="detect.overrides" item-key="index" show-expand single-expand :custom-sort="sortOverrides" hide-default-footer="true">
                     <template v-slot:item="{ item, index, expand, isExpanded }">
                       <tr>
                         <td>


### PR DESCRIPTION
The expand functionality as we're using it now needs an `item-key` property or else it can't tell the expanded items apart from the collapsed items resulting in every item expanding or collapsing together.