### PR TITLE
Validate YAML in Detection Validation

### DIFF
--- a/model/detection.go
+++ b/model/detection.go
@@ -7,6 +7,7 @@ package model
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -84,7 +85,8 @@ var (
 		SigLangYara:     {},
 	}
 
-	ErrUnsupportedEngine = errors.New("unsupported engine")
+	ErrUnsupportedEngine   = errors.New("unsupported engine")
+	ErrInvalidOverrideType = errors.New("invalid override type")
 )
 
 type DetectionEngine struct {
@@ -287,7 +289,19 @@ func (o *Override) Validate(engine EngineName) error {
 				o.Seconds != nil {
 				return errors.New("unnecessary fields in override")
 			}
+
+			*o.CustomFilter = util.TabsToSpaces(*o.CustomFilter)
+			fauxDoc := map[string]interface{}{}
+
+			err := yaml.Unmarshal([]byte(*o.CustomFilter), fauxDoc)
+			if err != nil {
+				return fmt.Errorf("custom filter override has invalid YAML: %w", err)
+			}
+		default:
+			return ErrInvalidOverrideType
 		}
+	} else {
+		return ErrInvalidOverrideType
 	}
 
 	return nil

--- a/model/detection_test.go
+++ b/model/detection_test.go
@@ -1,0 +1,273 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/util"
+	"github.com/tj/assert"
+)
+
+func TestDetectionOverrideValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name          string
+		Detect        *Detection
+		ExpectedError *string
+	}{
+		{
+			Name: "Valid Suricata Detection",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+			},
+		},
+		{
+			Name: "Valid ElastAlert Detection",
+			Detect: &Detection{
+				Engine: EngineNameElastAlert,
+			},
+		},
+		{
+			Name: "Valid Strelka Detection",
+			Detect: &Detection{
+				Engine: EngineNameStrelka,
+			},
+		},
+		{
+			Name: "Invalid Detection Engine",
+			Detect: &Detection{
+				Engine: "invalid",
+			},
+			ExpectedError: util.Ptr("unsupported engine"),
+		},
+		{
+			Name: "Valid Suricata Override",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeModify,
+						OverrideParameters: OverrideParameters{
+							Regex: util.Ptr(".*"),
+							Value: util.Ptr("test"),
+						},
+					},
+					{
+						Type: OverrideTypeSuppress,
+						OverrideParameters: OverrideParameters{
+							IP:    util.Ptr("0.0.0.0"),
+							Track: util.Ptr("by_src"),
+						},
+					},
+					{
+						Type: OverrideTypeThreshold,
+						OverrideParameters: OverrideParameters{
+							ThresholdType: util.Ptr("limit"),
+							Track:         util.Ptr("by_src"),
+							Count:         util.Ptr(1),
+							Seconds:       util.Ptr(60),
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Invalid Suricata Modify Override (Missing)",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{
+						Type:               OverrideTypeModify,
+						OverrideParameters: OverrideParameters{},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("missing required parameter(s)"),
+		},
+		{
+			Name: "Invalid Suricata Modify Override (Extra)",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeModify,
+						OverrideParameters: OverrideParameters{
+							Regex: util.Ptr(".*"),
+							Value: util.Ptr("test"),
+							GenID: util.Ptr(1),
+						},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("unnecessary fields in override"),
+		},
+		{
+			Name: "Invalid Suricata Suppress Override (Missing)",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{
+						Type:               OverrideTypeSuppress,
+						OverrideParameters: OverrideParameters{},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("missing required parameter(s)"),
+		},
+		{
+			Name: "Invalid Suricata Suppress Override (Extra)",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeSuppress,
+						OverrideParameters: OverrideParameters{
+							IP:    util.Ptr("0.0.0.0"),
+							Track: util.Ptr("by_src"),
+							GenID: util.Ptr(1),
+						},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("unnecessary fields in override"),
+		},
+		{
+			Name: "Invalid Suricata Threshold Override (Missing)",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{
+						Type:               OverrideTypeThreshold,
+						OverrideParameters: OverrideParameters{},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("missing required parameter(s)"),
+		},
+		{
+			Name: "Invalid Suricata Threshold Override (Extra)",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeThreshold,
+						OverrideParameters: OverrideParameters{
+							ThresholdType: util.Ptr("limit"),
+							Track:         util.Ptr("by_src"),
+							Count:         util.Ptr(1),
+							Seconds:       util.Ptr(60),
+							Regex:         util.Ptr(".*"),
+						},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("unnecessary fields in override"),
+		},
+		{
+			Name: "Valid ElastAlert Override",
+			Detect: &Detection{
+				Engine: EngineNameElastAlert,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeCustomFilter,
+						OverrideParameters: OverrideParameters{
+							CustomFilter: util.Ptr("k: v"),
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Invalid ElastAlert Custom Filter (Missing)",
+			Detect: &Detection{
+				Engine: EngineNameElastAlert,
+				Overrides: []*Override{
+					{
+						Type:               OverrideTypeCustomFilter,
+						OverrideParameters: OverrideParameters{},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("missing required parameter(s)"),
+		},
+		{
+			Name: "Invalid ElastAlert CustomFilter (Extra)",
+			Detect: &Detection{
+				Engine: EngineNameElastAlert,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeCustomFilter,
+						OverrideParameters: OverrideParameters{
+							CustomFilter: util.Ptr("k: v"),
+							GenID:        util.Ptr(1),
+						},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("unnecessary fields in override"),
+		},
+		{
+			Name: "Invalid ElastAlert CustomFilter (Bad YAML)",
+			Detect: &Detection{
+				Engine: EngineNameElastAlert,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeCustomFilter,
+						OverrideParameters: OverrideParameters{
+							CustomFilter: util.Ptr("not valid yaml"),
+						},
+					},
+				},
+			},
+			ExpectedError: util.Ptr("custom filter override has invalid YAML"),
+		},
+		{
+			Name: "Invalid ElastAlert Override Type",
+			Detect: &Detection{
+				Engine: EngineNameElastAlert,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeSuppress,
+					},
+				},
+			},
+			ExpectedError: util.Ptr("invalid override type"),
+		},
+		{
+			Name: "Invalid Strelka Override Type",
+			Detect: &Detection{
+				Engine: EngineNameStrelka,
+				Overrides: []*Override{
+					{
+						Type: OverrideTypeModify,
+					},
+				},
+			},
+			ExpectedError: util.Ptr("invalid override type"),
+		},
+		{
+			Name: "Invalid Override Type",
+			Detect: &Detection{
+				Engine: EngineNameSuricata,
+				Overrides: []*Override{
+					{},
+				},
+			},
+			ExpectedError: util.Ptr("override type is required"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.Detect.Validate()
+			if test.ExpectedError != nil {
+				assert.Contains(t, err.Error(), *test.ExpectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Tighter Override validation. Check for invalid types of overrides for the engine they're attached to. Check that the Custom Filter provided in ElastAlert Overrides looks like real YAML.

Added tests to validation.