### PR TITLE
Use Better Unquote Function For Suricata Titles

### DIFF
--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -532,10 +532,7 @@ func (e *SuricataEngine) ParseRules(content string, ruleset *string) ([]*model.D
 
 		msg = strings.ReplaceAll(msg, `\;`, `;`)
 
-		title, err := strconv.Unquote(msg)
-		if err != nil {
-			title = msg
-		}
+		title := util.Unquote(msg)
 
 		title = strings.ReplaceAll(title, `\"`, `"`)
 		title = strings.ReplaceAll(title, `\\`, `\`)

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -310,7 +310,7 @@ func TestParse(t *testing.T) {
 				"# Comment",
 				SimpleRule, // allowRegex has the SID, should allow
 				"",
-				` alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \"tricky\"\;\\ msg";)`, // allowRegex has the SID, should allow
+				` alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \\\"tricky\"\;\\ msg";)`, // allowRegex has the SID, should allow
 				" # " + FlowbitsRuleA,
 				FlowbitsRuleB, // denyRegex will prevent this from being parsed
 				"alert http any any -> any any (msg:\"This rule doesn't have a SID\";)", // doesn't match either regex, will be left out
@@ -331,10 +331,10 @@ func TestParse(t *testing.T) {
 				{
 					Author:   "__soc_import__",
 					PublicID: "20000",
-					Title:    `a "tricky";\ msg`,
+					Title:    `a \"tricky";\ msg`,
 					Category: ``,
 					Severity: model.SeverityInformational,
-					Content:  `alert http any any <> any any (metadata:signature_severity Informational; sid:"20000"; msg:"a \"tricky\"\;\\ msg";)`,
+					Content:  `alert http any any <> any any (metadata:signature_severity Informational; sid:"20000"; msg:"a \\\"tricky\"\;\\ msg";)`,
 					Engine:   model.EngineNameSuricata,
 					Language: model.SigLangSuricata,
 					Ruleset:  ruleset,


### PR DESCRIPTION
strconv.Unquote seems to be geared towards how the Go language parses strings when parsing Go code such as only removing single quotes if they're around a single char. Updated to use a more thorough, hand-written function that also doesn't throw an error.