### PR TITLE
Cogburn/advanced suricata

### DIFF
--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -310,23 +310,24 @@ func TestParse(t *testing.T) {
 				"# Comment",
 				SimpleRule, // allowRegex has the SID, should allow
 				"",
-				` alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \\\"tricky\"\;\\ msg";)`, // allowRegex has the SID, should allow
+				`# alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \\\"tricky\"\;\\ msg";)`, // allowRegex has the SID, should allow
 				" # " + FlowbitsRuleA,
 				FlowbitsRuleB, // denyRegex will prevent this from being parsed
 				"alert http any any -> any any (msg:\"This rule doesn't have a SID\";)", // doesn't match either regex, will be left out
 			},
 			ExpectedDetections: []*model.Detection{
 				{
-					Author:   "__soc_import__",
-					PublicID: SimpleRuleSID,
-					Title:    `GPL ATTACK_RESPONSE id check returned root`,
-					Category: `GPL ATTACK_RESPONSE`,
-					Severity: model.SeverityUnknown,
-					Content:  SimpleRule,
-					Engine:   model.EngineNameSuricata,
-					Language: model.SigLangSuricata,
-					Ruleset:  ruleset,
-					License:  "Unknown",
+					Author:    "__soc_import__",
+					PublicID:  SimpleRuleSID,
+					Title:     `GPL ATTACK_RESPONSE id check returned root`,
+					Category:  `GPL ATTACK_RESPONSE`,
+					Severity:  model.SeverityUnknown,
+					Content:   SimpleRule,
+					IsEnabled: true,
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+					Ruleset:   ruleset,
+					License:   "Unknown",
 				},
 				{
 					Author:   "__soc_import__",
@@ -334,7 +335,7 @@ func TestParse(t *testing.T) {
 					Title:    `a \"tricky";\ msg`,
 					Category: ``,
 					Severity: model.SeverityInformational,
-					Content:  `alert http any any <> any any (metadata:signature_severity Informational; sid:"20000"; msg:"a \\\"tricky\"\;\\ msg";)`,
+					Content:  `alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \\\"tricky\"\;\\ msg";)`,
 					Engine:   model.EngineNameSuricata,
 					Language: model.SigLangSuricata,
 					Ruleset:  ruleset,

--- a/server/modules/suricata/validate.go
+++ b/server/modules/suricata/validate.go
@@ -134,7 +134,7 @@ func ParseSuricataRule(rule string) (*SuricataRule, error) {
 						// is the current option a regular expression?
 						// if so, only end the quotes if the next character is a semicolon
 						next, _, _ := r.ReadRune()
-						r.UnreadRune()
+						_ = r.UnreadRune()
 
 						if next == ';' {
 							inQuotes = false


### PR DESCRIPTION
We were processing every non-commented line in the suricata rules file. Now we're processing every rule and using the comments to indicate if it's enabled or not (not commented = enabled).

Some new complexity was added that's unique to Suricata. Because we manipulate the rules through pillars, we now take advantage of a unique opportunity that will let the ruleset determine if a detection is enabled UNTIL a user modifies the detection at which point the user's preference will forever override the ruleset. The new logic is: if a community rule's sid is not in the enabled pillar or the disabled pillar at the time of import then the sid is left out of the pillars, conversely if the sid is found in a pillar then it should be updated. When not specified in either pillar, the status of a suricata detection will be determined by whether it's commented out or not in the original rule file.

De-linted a line. Readers only throw errors when unreading a non-seekable stream. The stream in use here is always seekable and will never return an error.
