### PR TITLE
Sanitize Strings

### DIFF
--- a/server/gridmembershandler.go
+++ b/server/gridmembershandler.go
@@ -16,12 +16,12 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"unicode"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/kennygrant/sanitize"
 	"github.com/samber/lo"
 )
 
@@ -165,7 +165,7 @@ func (h *GridMembersHandler) postImport(w http.ResponseWriter, r *http.Request) 
 	}
 
 	filename := path.Base(header.Filename)
-	filename = sanitize(filename)
+	filename = sanitize.Name(filename)
 
 	targetFile := filepath.Join(targetDir, filename)
 
@@ -309,15 +309,4 @@ func canUploadEvtx(node string) bool {
 	}
 
 	return lo.Contains(keywords, "manager")
-}
-
-func sanitize(filename string) string {
-	return string(lo.Map([]rune(filename), func(r rune, _ int) rune {
-		switch {
-		case strings.ContainsRune(`._-`, r), unicode.IsLetter(r), unicode.IsDigit(r):
-			return r
-		}
-
-		return '_'
-	}))
 }

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/apex/log"
 	"gopkg.in/yaml.v3"
+	"github.com/kennygrant/sanitize"
 )
 
 var errModuleStopped = fmt.Errorf("elastalert module has stopped running")
@@ -326,7 +327,8 @@ func (e *ElastAlertEngine) SyncLocalDetections(ctx context.Context, detections [
 	for _, det := range detections {
 		path := index[det.PublicID]
 		if path == "" {
-			path = filepath.Join(e.elastAlertRulesFolder, fmt.Sprintf("%s.yml", det.PublicID))
+			name := sanitize.Name(det.PublicID)
+			path = filepath.Join(e.elastAlertRulesFolder, fmt.Sprintf("%s.yml", name))
 		}
 
 		if det.IsEnabled {
@@ -844,7 +846,8 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, detectio
 
 			// 3. put query in elastAlertRulesFolder for salt to pick up
 			if path == "" {
-				path = filepath.Join(e.elastAlertRulesFolder, fmt.Sprintf("%s.yml", det.PublicID))
+				name := sanitize.Name(det.PublicID)
+				path = filepath.Join(e.elastAlertRulesFolder, fmt.Sprintf("%s.yml", name))
 			}
 
 			err = e.WriteFile(path, []byte(rule), 0644)

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -95,6 +95,21 @@ func TestDetectionValidateIdInvalid(t *testing.T) {
 
 	err = store.validateId("123456789012345678901234567890123456789012345678901", "test")
 	assert.Error(t, err)
+
+	err = store.validateId("../../etc/passwd", "test")
+	assert.Error(t, err)
+
+	err = store.validateId(`..\..\etc\passwd`, "test")
+	assert.Error(t, err)
+
+	err = store.validateId("......", "test")
+	assert.Error(t, err)
+
+	err = store.validateId("//////", "test")
+	assert.Error(t, err)
+
+	err = store.validateId(`\\\\\\`, "test")
+	assert.Error(t, err)
 }
 
 func TestDetectionValidateStringValid(t *testing.T) {

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -28,6 +28,7 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/util"
 
 	"github.com/apex/log"
+	"github.com/kennygrant/sanitize"
 )
 
 var errModuleStopped = fmt.Errorf("strelka module has stopped running")
@@ -727,7 +728,9 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]s
 
 	// Process and write new .yar files
 	for publicId, det := range enabledDetections {
-		filename := filepath.Join(e.yaraRulesFolder, fmt.Sprintf("%s.yar", publicId))
+		name := sanitize.Name(publicId)
+		filename := filepath.Join(e.yaraRulesFolder, fmt.Sprintf("%s.yar", name))
+
 		err := e.WriteFile(filename, []byte(det.Content), 0644)
 		if err != nil {
 			return nil, fmt.Errorf("failed to write file for detection %s: %v", publicId, err)


### PR DESCRIPTION
Gridmembershandler.go had a custom implemented sanitize function, replaced it with the sanitize library of choice we use else where in the project.

PublicIds are used in a few places to name files being written to disk so some extra care was taken to be sure we validate them more stringently and sanitize them before use. They are, after all, externally provided content.

More test cases for validateId to ensure file paths or even the characters used in file paths aren't acceptable regardless of slash direction. This is used upstream of where we use PublicIds for file names.