### PR TITLE
Respect User Input

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -20,6 +20,12 @@ import (
 	"github.com/apex/log"
 )
 
+type contextKey string
+
+const (
+	ContextKeyChangedByUser contextKey = "changedByUser"
+)
+
 func Middleware(host *Host, isWS bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -193,4 +199,21 @@ func isNil(i interface{}) bool {
 		return reflect.ValueOf(i).IsNil()
 	}
 	return false
+}
+
+func MarkChangedByUser(ctx context.Context, value bool) context.Context {
+	return context.WithValue(ctx, ContextKeyChangedByUser, value)
+}
+
+func IsChangedByUser(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+
+	v := ctx.Value(ContextKeyChangedByUser)
+	if v == nil {
+		return false
+	}
+
+	return v.(bool)
 }

--- a/web/middleware_test.go
+++ b/web/middleware_test.go
@@ -192,3 +192,17 @@ func compareJSON(jsn1 []byte, jsn2 []byte) (success bool, err error) {
 
 	return reflect.DeepEqual(one, two), nil
 }
+
+func TestChangedByUser(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsChangedByUser(nil))
+
+	assert.False(t, IsChangedByUser(context.Background()))
+
+	ctx := MarkChangedByUser(context.Background(), true)
+	assert.True(t, IsChangedByUser(ctx))
+
+	ctx = MarkChangedByUser(context.Background(), false)
+	assert.False(t, IsChangedByUser(ctx))
+}


### PR DESCRIPTION
When I added the new logic for a suricata detection to only update the enabled/disabled pillars if the sid is present in those pillars I forgot to add a way to breakthrough when it's present. Now we mark on the context if the change originated from a user action (incoming web requests are user actions, syncing community rules is not) and the suricata engine respects that flag.

Also found a TODO in bulk update about permissions. Added the permission check.

Updated tests.