### PR TITLE
Small Tweaks for a Better Experience

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -1034,6 +1034,8 @@ const huntComponent = {
           return true;
         });
 
+        this.quickActionDetId = null;
+
         if (alert) {
           // don't slow down the UI with this call
           const id = alert["rule.uuid"] || '';

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -90,7 +90,7 @@ func (h *DetectionHandler) getByPublicId(w http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 
 	publicId := chi.URLParam(r, "publicid")
-	q := fmt.Sprintf(`so_detection.publicId:"%s" _index:"*:so-detection"`, publicId)
+	q := fmt.Sprintf(`so_detection.publicId:"%s" AND _index:"*:so-detection"`, publicId)
 
 	detections, err := h.server.Detectionstore.Query(ctx, q, 1)
 	if err != nil {


### PR DESCRIPTION
Clear the detection ID var before looking up the detection. This prevents the URL from linking to a previously clicked on detection.

Fixed the query in the backend that actually looks up a detection by publicId so it works.