### PR TITLE
Add lastImport status

### DIFF
--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -33,8 +33,8 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/util"
 
 	"github.com/apex/log"
-	"gopkg.in/yaml.v3"
 	"github.com/kennygrant/sanitize"
+	"gopkg.in/yaml.v3"
 )
 
 var errModuleStopped = fmt.Errorf("elastalert module has stopped running")
@@ -373,7 +373,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 	ctx := e.srv.Context
 	templateFound := false
 
-	timerDur := mutil.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Duration(e.communityRulesImportFrequencySeconds)*time.Second)
+	lastImport, timerDur := mutil.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Duration(e.communityRulesImportFrequencySeconds)*time.Second)
 
 	for e.isRunning {
 		e.resetInterrupt()
@@ -487,6 +487,11 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 		for pkg, data := range zips {
 			h := sha256.Sum256(data)
 			zipHashes[pkg] = base64.StdEncoding.EncodeToString(h[:])
+		}
+
+		// If no import has been completed, then do a full sync
+		if lastImport == nil {
+			forceSync = true
 		}
 
 		if !forceSync {

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -225,7 +225,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 
 	templateFound := false
 
-	timerDur := mutil.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Second*time.Duration(e.communityRulesImportFrequencySeconds))
+	lastImport, timerDur := mutil.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Second*time.Duration(e.communityRulesImportFrequencySeconds))
 
 	for e.isRunning {
 		e.resetInterrupt()
@@ -292,6 +292,12 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 					break
 				}
 			}
+
+			// If no import has been completed, then do a full sync
+			if lastImport == nil {
+				forceSync = true
+			}
+
 			if !anythingNew && !forceSync {
 				// no updates, skip
 				log.Info("Strelka sync found no changes")

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -239,7 +239,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 
 	templateFound := false
 
-	timerDur := mutil.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Second*time.Duration(e.communityRulesImportFrequencySeconds))
+	lastImport, timerDur := mutil.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Second*time.Duration(e.communityRulesImportFrequencySeconds))
 
 	for e.isRunning {
 		e.resetInterrupt()
@@ -309,6 +309,11 @@ func (e *SuricataEngine) watchCommunityRules() {
 			log.WithError(err).Error("unable to read community rules file")
 
 			continue
+		}
+
+		// If no import has been completed, then do a full sync
+		if lastImport == nil {
+			forceSync = true
 		}
 
 		if !forceSync {

--- a/server/modules/util/detengine_helpers_test.go
+++ b/server/modules/util/detengine_helpers_test.go
@@ -44,8 +44,10 @@ func TestDetermineWaitTimeNoState(t *testing.T) {
 
 	mio.EXPECT().ReadFile("state").Return(nil, fs.ErrNotExist)
 
-	dur := DetermineWaitTime(mio, "state", time.Minute)
-	assert.Equal(t, time.Duration(time.Minute*20), dur)
+	lastImport, dur := DetermineWaitTime(mio, "state", time.Minute)
+
+	assert.Nil(t, lastImport, "Expected lastImport to be nil")
+	assert.Equal(t, time.Minute*20, dur, "Expected duration to be 20 minutes")
 }
 
 func TestDetermineWaitTime(t *testing.T) {
@@ -57,7 +59,8 @@ func TestDetermineWaitTime(t *testing.T) {
 
 	mio.EXPECT().ReadFile("state").Return([]byte(tenSecAgoStr), nil)
 
-	dur := DetermineWaitTime(mio, "state", time.Minute)
+	lastImport, dur := DetermineWaitTime(mio, "state", time.Minute)
+	assert.NotNil(t, lastImport, "Expected lastImport not to be nil")
 	assert.InEpsilon(t, time.Duration(time.Second*50), dur, 1)
 }
 
@@ -68,7 +71,8 @@ func TestDetermineWaitTimeBadRead(t *testing.T) {
 	mio.EXPECT().ReadFile("state").Return(nil, errors.New("bad read"))
 	mio.EXPECT().DeleteFile("state").Return(nil)
 
-	dur := DetermineWaitTime(mio, "state", time.Minute)
+	lastImport, dur := DetermineWaitTime(mio, "state", time.Minute)
+	assert.Nil(t, lastImport, "Expected lastImport to be nil")
 	assert.Equal(t, time.Duration(time.Minute*20), dur)
 }
 
@@ -79,7 +83,8 @@ func TestDetermineWaitTimeBadValue(t *testing.T) {
 	mio.EXPECT().ReadFile("state").Return([]byte("bad"), nil)
 	mio.EXPECT().DeleteFile("state").Return(nil)
 
-	dur := DetermineWaitTime(mio, "state", time.Minute)
+	lastImport, dur := DetermineWaitTime(mio, "state", time.Minute)
+	assert.Nil(t, lastImport, "Expected lastImport to be nil")
 	assert.Equal(t, time.Duration(time.Minute*20), dur)
 }
 


### PR DESCRIPTION
YARA rules were not being imported on a new install because the securityonion-yara repo already existed on disk (as part of Airgap). So when it checked to see if there is any updates to the repo, (there arent) it doesnt actually sync the rules. This PR adds functionality to check to see if there has ever been a last import (based on the state file). If there hasnt, then forceSync is set to true.