### PR TITLE
Sigma pivot fix

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -1040,14 +1040,9 @@ const huntComponent = {
           // don't slow down the UI with this call
           const id = alert["rule.uuid"] || '';
           if (id) {
-            const module = alert["event.module"] || '';
-            if (module.toLowerCase() === 'sigma') {
-              this.quickActionDetId = id;
-            } else {
               this.$root.papi.get(`detection/public/${id}`).then(response => {
                 this.quickActionDetId = response.data.id;
               });
-            }
           }
         }
       }

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1045,23 +1045,22 @@ func (e *ElastAlertEngine) sigmaToElastAlert(ctx context.Context, det *model.Det
 }
 
 type CustomWrapper struct {
-	PlayTitle     string   `yaml:"play_title"`
-	PlayID        string   `yaml:"play_id"`
-	EventModule   string   `yaml:"event.module"`
-	EventDataset  string   `yaml:"event.dataset"`
-	EventSeverity int      `yaml:"event.severity"`
-	RuleCategory  string   `yaml:"rule.category"`
-	SigmaLevel    string   `yaml:"sigma_level"`
-	Alert         []string `yaml:"alert"`
+	DetectionTitle    string   `yaml:"detection_title"`
+	DetectionPublicId string   `yaml:"detection_public_id"`
+	SigmaCategory     string   `yaml:"sigma_category,omitempty"`
+	SigmaProduct      string   `yaml:"sigma_product,omitempty"`
+	SigmaService      string   `yaml:"sigma_service,omitempty"`
+	EventModule       string   `yaml:"event.module"`
+	EventDataset      string   `yaml:"event.dataset"`
+	EventSeverity     int      `yaml:"event.severity"`
+	SigmaLevel        string   `yaml:"sigma_level"`
+	Alert             []string `yaml:"alert"`
 
-	Index       string                   `yaml:"index"`
-	Name        string                   `yaml:"name"`
-	Realert     *TimeFrame               `yaml:"realert,omitempty"` // or 0
-	Type        string                   `yaml:"type"`
-	Filter      []map[string]interface{} `yaml:"filter"`
-	PlayUrl     string                   `yaml:"play_url"`
-	KibanaPivot string                   `yaml:"kibana_pivot"`
-	SocPivot    string                   `yaml:"soc_pivot"`
+	Index   string                   `yaml:"index"`
+	Name    string                   `yaml:"name"`
+	Realert *TimeFrame               `yaml:"realert,omitempty"` // or 0
+	Type    string                   `yaml:"type"`
+	Filter  []map[string]interface{} `yaml:"filter"`
 }
 
 type TimeFrame struct {
@@ -1194,26 +1193,21 @@ func wrapRule(det *model.Detection, rule string) (string, error) {
 	sevNum := severities[det.Severity]
 
 	wrapper := &CustomWrapper{
-		PlayTitle:     det.Title,
-		PlayID:        det.Id,
-		EventModule:   "sigma",
-		EventDataset:  "sigma.alert",
-		EventSeverity: sevNum,
-		RuleCategory:  "", // TODO: what should this be?
-		SigmaLevel:    string(det.Severity),
-		Alert:         []string{"modules.so.playbook-es.PlaybookESAlerter"},
-		Index:         ".ds-logs-*",
-		Name:          fmt.Sprintf("%s - %s", det.Title, det.Id),
-		Realert:       nil,
-		Type:          "any",
-		Filter: []map[string]interface{}{
-			{
-				"eql": rule,
-			},
-		},
-		PlayUrl:     "play_url",
-		KibanaPivot: "kibana_pivot",
-		SocPivot:    "soc_pivot",
+		DetectionTitle:    det.Title,
+		DetectionPublicId: det.PublicID,
+		EventModule:       "sigma",
+		EventDataset:      "sigma.alert",
+		EventSeverity:     sevNum,
+		SigmaCategory:     det.Category,
+		SigmaService:      det.Service,
+		SigmaProduct:      det.Product,
+		SigmaLevel:        string(det.Severity),
+		Alert:             []string{"modules.so.securityonion-es.SecurityOnionESAlerter"},
+		Index:             ".ds-logs-*",
+		Name:              fmt.Sprintf("%s -- %s", det.Title, det.PublicID),
+		Realert:           nil,
+		Type:              "any",
+		Filter:            []map[string]interface{}{{"eql": rule}},
 	}
 
 	rawYaml, err := yaml.Marshal(wrapper)

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -260,9 +260,7 @@ func TestSigmaToElastAlertSunnyDay(t *testing.T) {
 	}
 
 	det := &model.Detection{
-		Auditable: model.Auditable{
-			Id: "00000000-0000-0000-0000-000000000000",
-		},
+		PublicID: "00000000-0000-0000-0000-000000000000",
 		Content:  "totally good sigma",
 		Title:    "Test Detection",
 		Severity: model.SeverityHigh,
@@ -274,23 +272,19 @@ func TestSigmaToElastAlertSunnyDay(t *testing.T) {
 	wrappedRule, err := wrapRule(det, query)
 	assert.NoError(t, err)
 
-	expected := `play_title: Test Detection
-play_id: 00000000-0000-0000-0000-000000000000
+	expected := `detection_title: Test Detection
+detection_public_id: 00000000-0000-0000-0000-000000000000
 event.module: sigma
 event.dataset: sigma.alert
 event.severity: 4
-rule.category: ""
 sigma_level: high
 alert:
-    - modules.so.playbook-es.PlaybookESAlerter
+    - modules.so.securityonion-es.SecurityOnionESAlerter
 index: .ds-logs-*
-name: Test Detection - 00000000-0000-0000-0000-000000000000
+name: Test Detection -- 00000000-0000-0000-0000-000000000000
 type: any
 filter:
     - eql: <eql>
-play_url: play_url
-kibana_pivot: kibana_pivot
-soc_pivot: soc_pivot
 `
 	assert.YAMLEq(t, expected, wrappedRule)
 }
@@ -659,10 +653,7 @@ func TestSyncElastAlert(t *testing.T) {
 					Content:   SimpleRule,
 					IsEnabled: true,
 					Title:     "TEST",
-					Auditable: model.Auditable{
-						Id: SimpleRuleSID,
-					},
-					Severity: model.SeverityMedium,
+					Severity:  model.SeverityMedium,
 				},
 			},
 			InitMock: func(mod *ElastAlertEngine, m *mock.MockIOManager) {
@@ -671,7 +662,7 @@ func TestSyncElastAlert(t *testing.T) {
 				// sigmaToElastAlert
 				m.EXPECT().ExecCommand(gomock.Any()).Return([]byte("[sigma rule]"), 0, time.Duration(0), nil)
 				// WriteFile when enabling
-				m.EXPECT().WriteFile(SimpleRuleSID+".yml", []byte("play_title: TEST\nplay_id: "+SimpleRuleSID+"\nevent.module: sigma\nevent.dataset: sigma.alert\nevent.severity: 3\nrule.category: \"\"\nsigma_level: medium\nalert:\n    - modules.so.playbook-es.PlaybookESAlerter\nindex: .ds-logs-*\nname: TEST - "+SimpleRuleSID+"\ntype: any\nfilter:\n    - eql: '[sigma rule]'\nplay_url: play_url\nkibana_pivot: kibana_pivot\nsoc_pivot: soc_pivot\n"), fs.FileMode(0644)).Return(nil)
+				m.EXPECT().WriteFile(SimpleRuleSID+".yml", []byte("detection_title: TEST\ndetection_public_id: "+SimpleRuleSID+"\nevent.module: sigma\nevent.dataset: sigma.alert\nevent.severity: 3\nsigma_level: medium\nalert:\n    - modules.so.securityonion-es.SecurityOnionESAlerter\nindex: .ds-logs-*\nname: TEST -- "+SimpleRuleSID+"\ntype: any\nfilter:\n    - eql: '[sigma rule]'\n"), fs.FileMode(0644)).Return(nil)
 			},
 		},
 		{
@@ -709,10 +700,7 @@ func TestSyncElastAlert(t *testing.T) {
 					Content:   SimpleRule,
 					IsEnabled: true,
 					Title:     "TEST",
-					Auditable: model.Auditable{
-						Id: SimpleRuleSID,
-					},
-					Severity: model.SeverityMedium,
+					Severity:  model.SeverityMedium,
 					Overrides: []*model.Override{
 						{
 							Type:      model.OverrideTypeCustomFilter,
@@ -735,7 +723,7 @@ sofilter_hosts:
 				// sigmaToElastAlert
 				m.EXPECT().ExecCommand(gomock.Any()).Return([]byte(`any where process.command_line:"*\\local\\temp\\*" and process.command_line:"*//b /e:jscript*" and process.command_line:"*.txt*"`), 0, time.Duration(0), nil)
 				// WriteFile when enabling
-				m.EXPECT().WriteFile(SimpleRuleSID+".yml", []byte("play_title: TEST\nplay_id: "+SimpleRuleSID+"\nevent.module: sigma\nevent.dataset: sigma.alert\nevent.severity: 3\nrule.category: \"\"\nsigma_level: medium\nalert:\n    - modules.so.playbook-es.PlaybookESAlerter\nindex: .ds-logs-*\nname: TEST - "+SimpleRuleSID+"\ntype: any\nfilter:\n    - eql: any where process.command_line:\"*\\\\local\\\\temp\\\\*\" and process.command_line:\"*//b /e:jscript*\" and process.command_line:\"*.txt*\"\nplay_url: play_url\nkibana_pivot: kibana_pivot\nsoc_pivot: soc_pivot\n"), fs.FileMode(0644)).Return(nil)
+				m.EXPECT().WriteFile(SimpleRuleSID+".yml", []byte("detection_title: TEST\ndetection_public_id: "+SimpleRuleSID+"\nevent.module: sigma\nevent.dataset: sigma.alert\nevent.severity: 3\nsigma_level: medium\nalert:\n    - modules.so.securityonion-es.SecurityOnionESAlerter\nindex: .ds-logs-*\nname: TEST -- "+SimpleRuleSID+"\ntype: any\nfilter:\n    - eql: any where process.command_line:\"*\\\\local\\\\temp\\\\*\" and process.command_line:\"*//b /e:jscript*\" and process.command_line:\"*.txt*\"\n"), fs.FileMode(0644)).Return(nil)
 			},
 		},
 	}


### PR DESCRIPTION
These changes fix the Sigma Alert pivot, so that it uses the same mechanism as the other engines. Also cleans up old redmine playbook code.