### PR TITLE
Updated Broadcast Permissions

### DIFF
--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -410,7 +410,7 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 			"totalTime":  totalTime.Seconds(),
 		}).Error("bulk update Detections finished")
 
-		h.server.Host.Broadcast("detections:bulkUpdate", "detection", map[string]interface{}{
+		h.server.Host.Broadcast("detections:bulkUpdate", "detections", map[string]interface{}{
 			"error":    len(errMap),
 			"total":    len(IDs),
 			"modified": len(modified),

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -459,7 +459,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 				log.WithError(err).Error("unable to check for detection index template")
 
 				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 						Engine: model.EngineNameElastAlert,
 						Status: "error",
 					})
@@ -472,7 +472,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 				log.Warn("detection index template does not exist, skipping import")
 
 				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 						Engine: model.EngineNameElastAlert,
 						Status: "error",
 					})
@@ -502,7 +502,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 			log.WithField("errorMap", errMap).Error("something went wrong loading sigma packages")
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameElastAlert,
 					Status: "error",
 				})
@@ -522,7 +522,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 			log.WithError(err).Error("unable to update Sigma repos")
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameElastAlert,
 					Status: "error",
 				})
@@ -572,7 +572,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 					lastSyncSuccess = util.Ptr(true)
 
 					if e.notify {
-						e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+						e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 							Engine: model.EngineNameElastAlert,
 							Status: "success",
 						})
@@ -617,7 +617,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 			log.WithError(err).Error("unable to sync elastalert community detections")
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameElastAlert,
 					Status: "error",
 				})
@@ -637,7 +637,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 			}).Error("unable to sync all ElastAlert community detections")
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameElastAlert,
 					Status: "partial",
 				})
@@ -654,7 +654,7 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 			}
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameElastAlert,
 					Status: "success",
 				})

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -300,7 +300,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 				log.WithError(err).Error("unable to check for detection index template")
 
 				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 						Engine: model.EngineNameStrelka,
 						Status: "error",
 					})
@@ -313,7 +313,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 				log.Warn("detection index template does not exist, skipping import")
 
 				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 						Engine: model.EngineNameStrelka,
 						Status: "error",
 					})
@@ -347,7 +347,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 			lastSyncSuccess = util.Ptr(true)
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameStrelka,
 					Status: "success",
 				})
@@ -367,7 +367,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 			log.WithError(err).Error("Failed to get all community SIDs")
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameStrelka,
 					Status: "error",
 				})
@@ -506,7 +506,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 			log.WithError(err).Error("unable to sync YARA community detections")
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameStrelka,
 					Status: "error",
 				})
@@ -520,12 +520,12 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 
 		if e.notify {
 			if len(errMap) > 0 {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameStrelka,
 					Status: "partial",
 				})
 			} else {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameStrelka,
 					Status: "success",
 				})

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -311,7 +311,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 				log.WithError(err).Error("unable to check for detection index template")
 
 				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 						Engine: model.EngineNameSuricata,
 						Status: "error",
 					})
@@ -324,7 +324,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 				log.Warn("detection index template does not exist, skipping import")
 
 				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 						Engine: model.EngineNameSuricata,
 						Status: "error",
 					})
@@ -339,7 +339,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 		rules, hash, err := readAndHash(e.communityRulesFile)
 		if err != nil {
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameSuricata,
 					Status: "error",
 				})
@@ -370,7 +370,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 				lastSyncSuccess = util.Ptr(true)
 
 				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 						Engine: model.EngineNameSuricata,
 						Status: "success",
 					})
@@ -383,7 +383,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 		allSettings, err := e.srv.Configstore.GetSettings(ctx)
 		if err != nil {
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameSuricata,
 					Status: "error",
 				})
@@ -403,7 +403,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 		commDetections, err := e.ParseRules(rules, ruleset.Value)
 		if err != nil {
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameSuricata,
 					Status: "error",
 				})
@@ -426,7 +426,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 			}
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameSuricata,
 					Status: "error",
 				})
@@ -448,7 +448,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 			}).Error("unable to sync all community detections")
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameSuricata,
 					Status: "partial",
 				})
@@ -460,7 +460,7 @@ func (e *SuricataEngine) watchCommunityRules() {
 			}
 
 			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detection", server.SyncStatus{
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameSuricata,
 					Status: "success",
 				})


### PR DESCRIPTION
After the RBAC update for permissions we udpated CheckAuthorized calls but not Broadcast calls that work on the same permissions. These broadcasts weren't going out because it was impossible for someone to be authorized for "detection" when the check should be "detections"