### PR TITLE
Control When Allow/Deny Regexes Are Applied

### DIFF
--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -362,7 +362,7 @@ func TestParse(t *testing.T) {
 
 			data := strings.Join(test.Lines, "\n")
 
-			detections, err := mod.ParseRules(data, ruleset)
+			detections, err := mod.ParseRules(data, ruleset, true)
 			if test.ExpectedError == nil {
 				assert.NoError(t, err)
 				assert.Equal(t, test.ExpectedDetections, detections)


### PR DESCRIPTION
We want to filter the rules as close to the source as possible but we also need to parse arbitrary rules that don't need the filters applied. This was causing duplicated detections to be filtered out and error.