### PR TITLE
Fix for Whitespace

### DIFF
--- a/server/modules/suricata/validate.go
+++ b/server/modules/suricata/validate.go
@@ -46,6 +46,7 @@ const (
 )
 
 func ParseSuricataRule(rule string) (*SuricataRule, error) {
+	rule = strings.TrimSpace(rule)
 	r := strings.NewReader(rule)
 	curState := stateAction
 	buf := strings.Builder{}

--- a/server/modules/suricata/validate_test.go
+++ b/server/modules/suricata/validate_test.go
@@ -101,7 +101,7 @@ func TestParseSuricata(t *testing.T) {
 }
 
 func TestSuricataRule(t *testing.T) {
-	input := `a b source port <> destination port (msg:"\\\""; noalert; sid:12345; rev: "9"; )`
+	input := `a b source port <> destination port (msg:"\\\""; noalert; sid:12345; rev: "9"; ) 	`
 
 	rule, err := ParseSuricataRule(input)
 	assert.NoError(t, err)


### PR DESCRIPTION
Whitespace was triggering "invalid rule, expected end of rule, got X more bytes" when present at the end of a rule's source. Trimming it before parsing ensured the error on line validate.go:113 only returns when there's non-whitespace left.

Updated a test to check for it.