### PR TITLE
Populate User Details in Detections History

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -21,6 +21,8 @@ const USER_PASSWORD_LENGTH_MIN = 8;
 const USER_PASSWORD_LENGTH_MAX = 72;
 const USER_PASSWORD_INVALID_RX = /["'$&!]/;
 
+const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+
 if (typeof global !== 'undefined') global.routes = routes;
 
 $(document).ready(function() {
@@ -930,7 +932,13 @@ $(document).ready(function() {
       },
       async populateUserDetails(obj, idField, outputField) {
         if (obj[idField] && obj[idField].length > 0) {
-          const user = await this.$root.getUserById(obj[idField]);
+          const id = obj[idField];
+          if (id === SYSTEM_USER_ID) {
+            Vue.set(obj, outputField, this.i18n.systemUser);
+            return
+          }
+
+          const user = await this.$root.getUserById(id);
           if (user) {
             Vue.set(obj, outputField, user.email);
           }

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -812,6 +812,7 @@ const i18n = {
       syncSuccess: 'Synchronized {engine} community rules successfully.',
       syncPartialSuccess: 'Synchronized {engine} community rules with some errors. Check SOC logs for details.',
       syncFailure: 'Something went wrong attempting to synchronize {engine} community rules. Check SOC logs for details.',
+      systemUser: "System",
       tags: 'Tags',
       thresholdType: 'Threshold Type',
       throttledLogin: 'Excessive login requests detected. Login requests can resume momentarily.',

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -470,11 +470,15 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			this.extractedUpdated = yaml['modified'];
 		},
 		async loadHistory() {
-			const route = this;
-			const id = route.$route.params.id;
+			const id = this.$route.params.id;
+
 			const response = await this.$root.papi.get(`detection/${id}/history`);
 			if (response && response.data) {
 				this.history = response.data;
+
+				for (var i = 0; i < this.history.length; i++) {
+					this.$root.populateUserDetails(this.history[i], "userId", "owner");
+				}
 			}
 		},
 		getDefaultPreset(preset) {

--- a/server/modules/statickeyauth/statickeyauthimpl_test.go
+++ b/server/modules/statickeyauth/statickeyauthimpl_test.go
@@ -83,8 +83,8 @@ func TestPreprocess(tester *testing.T) {
 			if assert.NotNil(tester, requestor) {
 				sensorUser := requestor.(*model.User)
 				assert.NotNil(tester, sensorUser)
-				assert.Equal(tester, "agent", sensorUser.Id)
-				assert.Equal(tester, "agent", sensorUser.Email)
+				assert.Equal(tester, "00000000-0000-0000-0000-000000000000", sensorUser.Id)
+				assert.Equal(tester, "00000000-0000-0000-0000-000000000000", sensorUser.Email)
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,7 @@ import (
 	"github.com/apex/log"
 )
 
-const AGENT_ID = "agent"
+const AGENT_ID = "00000000-0000-0000-0000-000000000000"
 
 type Server struct {
 	Config           *config.ServerConfig


### PR DESCRIPTION
Added a set of calls to populateUserDetails so detection history users are filled in correctly.

Because this is one of the first instances of SOC creating a model, I modified populateUserDetails to watch for the new system user id of 00000000-0000-0000-0000-000000000000 and report is as "System" when seen.

Note that the system user id was also changed in the backend this commit so any existing detections will continue to report N/A as they have a userId of "agent"