### PR TITLE
Always Run CompileYARA Script

### DIFF
--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -818,25 +818,21 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]s
 	}
 
 	if e.compileRules {
-		if len(enabledDetections) != 0 {
-			// compile yara rules
-			cmd := exec.CommandContext(ctx, "python3", e.compileYaraPythonScriptPath, e.yaraRulesFolder)
+		// compile yara rules, call even if no yara rules
+		cmd := exec.CommandContext(ctx, "python3", e.compileYaraPythonScriptPath, e.yaraRulesFolder)
 
-			raw, code, dur, err := e.ExecCommand(cmd)
+		raw, code, dur, err := e.ExecCommand(cmd)
 
-			log.WithFields(log.Fields{
-				"command":  cmd.String(),
-				"output":   string(raw),
-				"code":     code,
-				"execTime": dur.Seconds(),
-				"error":    err,
-			}).Info("yara compilation results")
+		log.WithFields(log.Fields{
+			"command":  cmd.String(),
+			"output":   string(raw),
+			"code":     code,
+			"execTime": dur.Seconds(),
+			"error":    err,
+		}).Info("yara compilation results")
 
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			log.Info("no detections to compile, skipping compilation step of strelka sync")
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Compiled rules have moved. Instead of hardcoding the path, we will uncondtionally call the script because it will now cleanup if there's no rules.