### PR TITLE
Write but No Read

### DIFF
--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -2,7 +2,6 @@ package strelka
 
 import (
 	"context"
-	"errors"
 	"io/fs"
 	"os/exec"
 	"regexp"
@@ -659,35 +658,4 @@ func TestAddMissingImports(t *testing.T) {
 			assert.Equal(t, test.ExpectedImports, test.Input.Imports)
 		})
 	}
-}
-
-func TestCheckWriteNoRead(t *testing.T) {
-	t.Parallel()
-
-	eng := &StrelkaEngine{}
-
-	shouldFail := eng.checkWriteNoRead(nil)
-	assert.False(t, shouldFail)
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	id := util.Ptr("99999")
-
-	mio := servermock.NewMockDetectionstore(ctrl)
-
-	mio.EXPECT().GetDetectionByPublicId(gomock.Any(), *id).Return(nil, errors.New("Object not found"))
-
-	eng.srv = &server.Server{
-		Detectionstore: mio,
-		Context:        context.Background(),
-	}
-
-	shouldFail = eng.checkWriteNoRead(id)
-	assert.True(t, shouldFail)
-
-	mio.EXPECT().GetDetectionByPublicId(gomock.Any(), *id).Return(&model.Detection{}, nil)
-
-	shouldFail = eng.checkWriteNoRead(id)
-	assert.False(t, shouldFail)
 }

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -2,6 +2,7 @@ package strelka
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"os/exec"
 	"regexp"
@@ -658,4 +659,35 @@ func TestAddMissingImports(t *testing.T) {
 			assert.Equal(t, test.ExpectedImports, test.Input.Imports)
 		})
 	}
+}
+
+func TestCheckWriteNoRead(t *testing.T) {
+	t.Parallel()
+
+	eng := &StrelkaEngine{}
+
+	shouldFail := eng.checkWriteNoRead(nil)
+	assert.False(t, shouldFail)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	id := util.Ptr("99999")
+
+	mio := servermock.NewMockDetectionstore(ctrl)
+
+	mio.EXPECT().GetDetectionByPublicId(gomock.Any(), *id).Return(nil, errors.New("Object not found"))
+
+	eng.srv = &server.Server{
+		Detectionstore: mio,
+		Context:        context.Background(),
+	}
+
+	shouldFail = eng.checkWriteNoRead(id)
+	assert.True(t, shouldFail)
+
+	mio.EXPECT().GetDetectionByPublicId(gomock.Any(), *id).Return(&model.Detection{}, nil)
+
+	shouldFail = eng.checkWriteNoRead(id)
+	assert.False(t, shouldFail)
 }


### PR DESCRIPTION
Sometimes after writing to ElasticSearch, we attempt to read back the document but get back an "Object not found" error. Something is causing the ES refresh to take a long time and we should stop syncing detections until ES fixes itself.

When this happens, we now fail the currently executing sync and save the publicId. On next sync, we check if we can find the detection by the publicId. If we can't, we fail the sync again and try again on next sync. If we succeed in retrieving the detection, we clear the flag and continue syncing like normal.