### PR TITLE
Allow for idstoolsYaml to not have enabled or disabled entries

### DIFF
--- a/server/modules/suricata/migration-2.4.70.go
+++ b/server/modules/suricata/migration-2.4.70.go
@@ -1,7 +1,6 @@
 package suricata
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -15,11 +14,6 @@ import (
 const (
 	idstoolsYaml = "/nsm/backup/detections-migration/idstools/soc_idstools.sls"       // enabled/disabled
 	sidsYaml     = "/nsm/backup/detections-migration/suricata/thresholding/sids.yaml" // thresholds
-)
-
-var (
-	errUnknownYamlLayoutIdstools = errors.New("unknown yaml layout: couldn't find idstools field")
-	errUnknownYamlLayoutSids     = errors.New("unknown yaml layout: couldn't find sids field")
 )
 
 func (e *SuricataEngine) Migration2470(statePath string) error {
@@ -168,12 +162,12 @@ func (e *SuricataEngine) m2470LoadEnabledDisabled() (enabled []string, disabled 
 
 	idstools, ok := root["idstools"].(map[string]interface{})
 	if !ok {
-		return nil, nil, errUnknownYamlLayoutIdstools
+		return nil, nil, nil
 	}
 
 	sids, ok := idstools["sids"].(map[string]interface{})
 	if !ok {
-		return nil, nil, errUnknownYamlLayoutSids
+		return nil, nil, nil
 	}
 
 	en, ok := sids["enabled"].([]interface{})

--- a/server/modules/suricata/migration-2.4.70_test.go
+++ b/server/modules/suricata/migration-2.4.70_test.go
@@ -92,6 +92,22 @@ func TestM2470LoadEnabledDisabled(t *testing.T) {
 
 	assert.Equal(t, []string{"1", "2", "3"}, enabled)
 	assert.Equal(t, []string{"4", "5", "6"}, disabled)
+
+	mio.EXPECT().ReadFile(idstoolsYaml).Return([]byte(`{}`), nil)
+
+	enabled, disabled, err = e.m2470LoadEnabledDisabled()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, len(enabled))
+	assert.Equal(t, 0, len(disabled))
+
+	mio.EXPECT().ReadFile(idstoolsYaml).Return([]byte(`{ "idstools": {}}`), nil)
+
+	enabled, disabled, err = e.m2470LoadEnabledDisabled()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, len(enabled))
+	assert.Equal(t, 0, len(disabled))
 }
 
 func TestM2470ApplyList(t *testing.T) {


### PR DESCRIPTION
When idstoolsYaml doesn't have an `idstools` field or the `sids` field under that then don't error, instead return that there are no enabled or disabled from the file. Allow the migration to continue.

Updated tests.