### PR TITLE
IsEnabled=false when syncing after delete

### DIFF
--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -348,6 +348,8 @@ func (h *DetectionHandler) deleteDetection(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	old.IsEnabled = false
+
 	errMap, err := SyncLocalDetections(ctx, h.server, []*model.Detection{old})
 	if err != nil {
 		web.Respond(w, r, http.StatusInternalServerError, err)


### PR DESCRIPTION
The integrity checkers highlighted that local rules that were enabled at the time they were deleted would occasionally still be present in the system long after the successful delete. Explicitly setting the detection as disabled before the final sync should clear the tubes of it.