### PR TITLE
YARA Parsing Fix

### DIFF
--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -63,7 +63,7 @@ test('extract strelka', () => {
 test('extract elastalert', () => {
 	comp.detect = {
 		engine: 'elastalert',
-		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://twitter.com/DrunkBinary/status/redacted\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
+		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://redacted.com\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
 		title: 'Title',
 	};
 	comp.$route = { params: { id: '123' } };
@@ -75,7 +75,7 @@ test('extract elastalert', () => {
 
 	expect(comp.extractedSummary).toBe('Title');
 	expect(comp.extractedReferences).toEqual([
-		{ type: 'url', text: 'https://twitter.com/DrunkBinary/status/redacted', link: 'https://twitter.com/DrunkBinary/status/redacted' },
+		{ type: 'url', text: 'https://redacted.com', link: 'https://redacted.com' },
 		{ type: 'url', text: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign', link: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign' },
 	]);
 	expect(comp.extractedLogic).toBe('logsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - ds7002.lnk\n      - ds7002.pdf\n      - ds7002.zip\n    condition: selection');

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -63,7 +63,7 @@ test('extract strelka', () => {
 test('extract elastalert', () => {
 	comp.detect = {
 		engine: 'elastalert',
-		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://hidden.com\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
+		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://twitter.com/DrunkBinary/status/1063075530180886529\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
 		title: 'Title',
 	};
 	comp.$route = { params: { id: '123' } };
@@ -75,7 +75,7 @@ test('extract elastalert', () => {
 
 	expect(comp.extractedSummary).toBe('Title');
 	expect(comp.extractedReferences).toEqual([
-		{ type: 'url', text: 'https://hidden.com', link: 'https://hidden.com' },
+		{ type: 'url', text: 'https://twitter.com/DrunkBinary/status/1063075530180886529', link: 'https://twitter.com/DrunkBinary/status/1063075530180886529' },
 		{ type: 'url', text: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign', link: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign' },
 	]);
 	expect(comp.extractedLogic).toBe('logsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - ds7002.lnk\n      - ds7002.pdf\n      - ds7002.zip\n    condition: selection');

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -63,7 +63,7 @@ test('extract strelka', () => {
 test('extract elastalert', () => {
 	comp.detect = {
 		engine: 'elastalert',
-		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://twitter.com/DrunkBinary/status/1063075530180886529\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
+		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://twitter.com/DrunkBinary/status/redacted\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
 		title: 'Title',
 	};
 	comp.$route = { params: { id: '123' } };
@@ -75,7 +75,7 @@ test('extract elastalert', () => {
 
 	expect(comp.extractedSummary).toBe('Title');
 	expect(comp.extractedReferences).toEqual([
-		{ type: 'url', text: 'https://twitter.com/DrunkBinary/status/1063075530180886529', link: 'https://twitter.com/DrunkBinary/status/1063075530180886529' },
+		{ type: 'url', text: 'https://twitter.com/DrunkBinary/status/redacted', link: 'https://twitter.com/DrunkBinary/status/redacted' },
 		{ type: 'url', text: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign', link: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign' },
 	]);
 	expect(comp.extractedLogic).toBe('logsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - ds7002.lnk\n      - ds7002.pdf\n      - ds7002.zip\n    condition: selection');

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -63,7 +63,7 @@ test('extract strelka', () => {
 test('extract elastalert', () => {
 	comp.detect = {
 		engine: 'elastalert',
-		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://redacted.com\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
+		content: `title: APT29 2018 Phishing Campaign File Indicators\nid: 3a3f81ca-652c-482b-adeb-b1c804727f74\nrelated:\n  - id: 7453575c-a747-40b9-839b-125a0aae324b # ProcessCreation\n    type: derived\nstatus: stable\ndescription: Detects indicators of APT 29 (Cozy Bear) phishing-campaign as reported by mandiant\nreferences:\n  - https://hidden.com\n  - https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign\nauthor: '@41thexplorer'\ndate: 2018/11/20\nmodified: 2023/02/20\ntags:\n  - attack.defense_evasion\n  - attack.t1218.011\n  - detection.emerging_threats\nlogsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - 'ds7002.lnk'\n      - 'ds7002.pdf'\n      - 'ds7002.zip'\n    condition: selection\nfalsepositives:\n  - Unlikely\nlevel: critical`,
 		title: 'Title',
 	};
 	comp.$route = { params: { id: '123' } };
@@ -75,7 +75,7 @@ test('extract elastalert', () => {
 
 	expect(comp.extractedSummary).toBe('Title');
 	expect(comp.extractedReferences).toEqual([
-		{ type: 'url', text: 'https://redacted.com', link: 'https://redacted.com' },
+		{ type: 'url', text: 'https://hidden.com', link: 'https://hidden.com' },
 		{ type: 'url', text: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign', link: 'https://www.mandiant.com/resources/blog/not-so-cozy-an-uncomfortable-examination-of-a-suspected-apt29-phishing-campaign' },
 	]);
 	expect(comp.extractedLogic).toBe('logsource:\n  product: windows\n  category: file_event\ndetection:\n  selection:\n    TargetFilename|contains:\n      - ds7002.lnk\n      - ds7002.pdf\n      - ds7002.zip\n    condition: selection');

--- a/server/modules/elastic/elasticcasestore.go
+++ b/server/modules/elastic/elasticcasestore.go
@@ -23,6 +23,7 @@ import (
 
 const AUDIT_DOC_ID = "audit_doc_id"
 const SHORT_STRING_MAX = 100
+const MAX_AUTHOR_LENGTH = 250
 const LONG_STRING_MAX = 1000000
 const MAX_ARRAY_ELEMENTS = 50
 

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -118,7 +118,7 @@ func (store *ElasticDetectionstore) validateDetection(detect *model.Detection) e
 	}
 
 	if err == nil && detect.Author != "" {
-		err = store.validateString(detect.Author, 250, "author")
+		err = store.validateString(detect.Author, MAX_AUTHOR_LENGTH, "author")
 	}
 
 	if err == nil && detect.Description != "" {

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -118,7 +118,7 @@ func (store *ElasticDetectionstore) validateDetection(detect *model.Detection) e
 	}
 
 	if err == nil && detect.Author != "" {
-		err = store.validateString(detect.Author, SHORT_STRING_MAX, "author")
+		err = store.validateString(detect.Author, 250, "author")
 	}
 
 	if err == nil && detect.Description != "" {

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -258,9 +258,9 @@ func TestValidateDetectionInvalid(t *testing.T) {
 	assert.EqualError(t, err, "severity is too long (101/100)")
 	det.Severity = ""
 
-	det.Author = strings.Repeat("a", SHORT_STRING_MAX+1)
+	det.Author = strings.Repeat("a", 251)
 	err = store.validateDetection(det)
-	assert.EqualError(t, err, "author is too long (101/100)")
+	assert.EqualError(t, err, "author is too long (251/250)")
 	det.Author = ""
 
 	det.Content = strings.Repeat("a", LONG_STRING_MAX+1)

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -173,7 +173,7 @@ const problematicRule = `rule my_Methodology_Contains_Shortcut_OtherURIhandlers
     author = "@itsreallynick (Nick Carr)"
     description = "Noisy rule for .URL shortcuts containing unique URI handlers"
     description = "Detects possible shortcut usage for .URL persistence"
-    reference = "hidden"
+    reference = "https://twitter.com/cglyer/status/1176184798248919044"
     score = 35
     date = "27.09.2019"
   strings:
@@ -494,7 +494,7 @@ func TestParseRule(t *testing.T) {
 					Meta: Metadata{
 						Author:      util.Ptr("@itsreallynick (Nick Carr)"),
 						Date:        util.Ptr("27.09.2019"),
-						Reference:   util.Ptr("hidden"),
+						Reference:   util.Ptr("https://twitter.com/cglyer/status/1176184798248919044"),
 						Description: util.Ptr("Detects possible shortcut usage for .URL persistence"),
 						Rest: map[string]string{
 							"score": "35",

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -173,7 +173,7 @@ const problematicRule = `rule my_Methodology_Contains_Shortcut_OtherURIhandlers
     author = "@itsreallynick (Nick Carr)"
     description = "Noisy rule for .URL shortcuts containing unique URI handlers"
     description = "Detects possible shortcut usage for .URL persistence"
-    reference = "https://twitter.com/cglyer/status/redacted"
+    reference = "redacted"
     score = 35
     date = "27.09.2019"
   strings:
@@ -494,7 +494,7 @@ func TestParseRule(t *testing.T) {
 					Meta: Metadata{
 						Author:      util.Ptr("@itsreallynick (Nick Carr)"),
 						Date:        util.Ptr("27.09.2019"),
-						Reference:   util.Ptr("https://twitter.com/cglyer/status/redacted"),
+						Reference:   util.Ptr("redacted"),
 						Description: util.Ptr("Detects possible shortcut usage for .URL persistence"),
 						Rest: map[string]string{
 							"score": "35",

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -173,7 +173,7 @@ const problematicRule = `rule my_Methodology_Contains_Shortcut_OtherURIhandlers
     author = "@itsreallynick (Nick Carr)"
     description = "Noisy rule for .URL shortcuts containing unique URI handlers"
     description = "Detects possible shortcut usage for .URL persistence"
-    reference = "https://twitter.com/cglyer/status/1176184798248919044"
+    reference = "https://twitter.com/cglyer/status/redacted"
     score = 35
     date = "27.09.2019"
   strings:
@@ -494,7 +494,7 @@ func TestParseRule(t *testing.T) {
 					Meta: Metadata{
 						Author:      util.Ptr("@itsreallynick (Nick Carr)"),
 						Date:        util.Ptr("27.09.2019"),
-						Reference:   util.Ptr("https://twitter.com/cglyer/status/1176184798248919044"),
+						Reference:   util.Ptr("https://twitter.com/cglyer/status/redacted"),
 						Description: util.Ptr("Detects possible shortcut usage for .URL persistence"),
 						Rest: map[string]string{
 							"score": "35",

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -173,7 +173,7 @@ const problematicRule = `rule my_Methodology_Contains_Shortcut_OtherURIhandlers
     author = "@itsreallynick (Nick Carr)"
     description = "Noisy rule for .URL shortcuts containing unique URI handlers"
     description = "Detects possible shortcut usage for .URL persistence"
-    reference = "redacted"
+    reference = "hidden"
     score = 35
     date = "27.09.2019"
   strings:
@@ -494,7 +494,7 @@ func TestParseRule(t *testing.T) {
 					Meta: Metadata{
 						Author:      util.Ptr("@itsreallynick (Nick Carr)"),
 						Date:        util.Ptr("27.09.2019"),
-						Reference:   util.Ptr("redacted"),
+						Reference:   util.Ptr("hidden"),
 						Description: util.Ptr("Detects possible shortcut usage for .URL persistence"),
 						Rest: map[string]string{
 							"score": "35",

--- a/server/modules/strelka/validate.go
+++ b/server/modules/strelka/validate.go
@@ -6,10 +6,8 @@
 package strelka
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -97,79 +95,6 @@ func stringToUUID(s string) string {
 		hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15])
 }
 
-func (r *YaraRule) String() string {
-	buffer := bytes.NewBuffer([]byte{})
-
-	// imports
-	for _, i := range r.Imports {
-		line := fmt.Sprintf("import \"%s\"\n", i)
-		buffer.WriteString(line)
-	}
-
-	if len(r.Imports) > 0 {
-		buffer.WriteString("\n")
-	}
-
-	if r.IsPrivate {
-		buffer.WriteString("private ")
-	}
-
-	// identifier
-	buffer.WriteString(fmt.Sprintf("rule %s {\n", r.Identifier))
-
-	// meta
-	if !r.Meta.IsEmpty() {
-		buffer.WriteString("\tmeta:\n")
-
-		if r.Meta.Author != nil {
-			buffer.WriteString(fmt.Sprintf("\t\tauthor = \"%s\"\n", *r.Meta.Author))
-		}
-
-		if r.Meta.Date != nil {
-			buffer.WriteString(fmt.Sprintf("\t\tdate = \"%s\"\n", *r.Meta.Date))
-		}
-
-		if r.Meta.Version != nil {
-			buffer.WriteString(fmt.Sprintf("\t\tversion = \"%s\"\n", *r.Meta.Version))
-		}
-
-		if r.Meta.Reference != nil {
-			buffer.WriteString(fmt.Sprintf("\t\treference = \"%s\"\n", *r.Meta.Reference))
-		}
-
-		if r.Meta.Description != nil {
-			buffer.WriteString(fmt.Sprintf("\t\tdescription = \"%s\"\n", *r.Meta.Description))
-		}
-
-		keys := []string{}
-		for k := range r.Meta.Rest {
-			keys = append(keys, k)
-		}
-
-		sort.Strings(keys)
-
-		for _, k := range keys {
-			buffer.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", k, r.Meta.Rest[k]))
-		}
-
-		buffer.WriteString("\n")
-	}
-
-	// strings
-	if len(r.Strings) > 0 {
-		buffer.WriteString("\tstrings:\n")
-
-		for _, s := range r.Strings {
-			buffer.WriteString(fmt.Sprintf("\t\t%s\n", s))
-		}
-	}
-
-	// condition and closing bracket
-	buffer.WriteString(fmt.Sprintf("\n\tcondition:\n\t\t%s\n}", r.Condition))
-
-	return buffer.String()
-}
-
 func (r *YaraRule) Validate() error {
 	missing := []string{}
 
@@ -219,7 +144,7 @@ func (r *YaraRule) ToDetection(license string, ruleset string, isCommunity bool)
 		PublicID:    r.GetID(),
 		Title:       r.Identifier,
 		Severity:    sev,
-		Content:     r.String(),
+		Content:     r.Src,
 		IsCommunity: isCommunity,
 		Language:    model.SigLangYara,
 		Ruleset:     ruleset,


### PR DESCRIPTION
Expanded YARA parser to treat regex as a string.

Removed YaraRule.String() as it was not recreating rules byte for byte. Removed test that accompanied it. Updated DuplicateDetection to stop using it. YARA rules now retain their exact source during parsing resulting in better integrity of the source that's deployed.

A regex is now used to update the identifier in the source.

Cleaned up code.