### PR TITLE
Remove Disabled Suricata Rules From Local File

### DIFF
--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -991,11 +991,22 @@ func removeBlankLines(lines []string) []string {
 func updateLocal(localLines []string, localIndex map[string]int, sid string, detect *model.Detection) []string {
 	lineNum, inLocal := localIndex[sid]
 	if !inLocal {
-		localLines = append(localLines, detect.Content)
-		lineNum = len(localLines) - 1
-		localIndex[sid] = lineNum
+		if detect.IsEnabled {
+			// not in local, but should be
+			localLines = append(localLines, detect.Content)
+			lineNum = len(localLines) - 1
+			localIndex[sid] = lineNum
+		}
 	} else {
-		localLines[lineNum] = detect.Content
+		// in local...
+		if detect.IsEnabled {
+			// and should be, update it
+			localLines[lineNum] = detect.Content
+		} else {
+			// and shouldn't be, remove it
+			localLines[lineNum] = ""
+			delete(localIndex, sid)
+		}
 	}
 
 	return localLines

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -967,3 +967,52 @@ func TestConslidateEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateLocal(t *testing.T) {
+	localLines := []string{
+		"100000",
+		"200000",
+		"300000",
+	}
+
+	localIndex := map[string]int{
+		"100000": 0,
+		"200000": 1,
+		"300000": 2,
+	}
+
+	sid := "400000"
+
+	det := &model.Detection{
+		IsEnabled: true,
+		Content:   sid,
+	}
+
+	// is enabled, not present
+	localLines = updateLocal(localLines, localIndex, sid, det)
+
+	assert.Equal(t, 4, len(localLines))
+	assert.Equal(t, "400000", localLines[3])
+	assert.Equal(t, 4, len(localIndex))
+	assert.Equal(t, 3, localIndex["400000"])
+
+	det.Content = "400000!"
+
+	// is enabled, present, different content
+	localLines = updateLocal(localLines, localIndex, sid, det)
+
+	assert.Equal(t, 4, len(localLines))
+	assert.Equal(t, "400000!", localLines[3])
+	assert.Equal(t, 4, len(localIndex))
+	assert.Equal(t, 3, localIndex["400000"])
+
+	det.IsEnabled = false
+
+	// is disabled, present, should be removed
+	localLines = updateLocal(localLines, localIndex, sid, det)
+
+	assert.Equal(t, 4, len(localLines))
+	assert.Equal(t, "", localLines[3])
+	assert.Equal(t, 3, len(localIndex))
+	assert.NotContains(t, localIndex, "400000")
+}


### PR DESCRIPTION
Noticed that deleted custom rules were still showing up in the integrity check. Updated updateLocal to remove the rule if the detection is disabled. Added a test.