### PR TITLE
Strelka PublicId Change

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -455,8 +455,8 @@ const huntComponent = {
         }
       }
 
-      // Check for special params that force a re-route. This is needed when async functions will handle the hunt themselves. 
-      // So setting reroute=true tells the current thread not to perform the hunt, because the async thread will be doing it momentarily. 
+      // Check for special params that force a re-route. This is needed when async functions will handle the hunt themselves.
+      // So setting reroute=true tells the current thread not to perform the hunt, because the async thread will be doing it momentarily.
       var reRoute = false;
       if (this.$route.query.filterValue) {
         this.filterQuery(this.$route.query.filterField, this.$route.query.filterValue, this.$route.query.filterMode, undefined, this.$route.query.scalar === 'true');
@@ -1024,25 +1024,14 @@ const huntComponent = {
       }
 
       if (this.isCategory('alerts')) {
-        const alert = this.eventData.find(item => {
-          for (const key in event) {
-            if (key !== "count" && item[key] !== event[key]) {
-              return false;
-            }
-          }
-          return true;
-        });
-
+        const id = event["rule.uuid"];
         this.quickActionDetId = null;
 
-        if (alert) {
-          // don't slow down the UI with this call
-          const id = alert["rule.uuid"] || '';
-          if (id) {
-              this.$root.papi.get(`detection/public/${id}`).then(response => {
-                this.quickActionDetId = response.data.id;
-              });
-          }
+        // don't slow down the UI with this call
+        if (id) {
+          this.$root.papi.get(`detection/public/${id}`).then(response => {
+            this.quickActionDetId = response.data.id;
+          });
         }
       }
 

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -65,6 +65,17 @@ func (store *ElasticDetectionstore) validateId(id string, label string) error {
 	return err
 }
 
+func (store *ElasticDetectionstore) validatePublicId(id string, label string) error {
+	var err error
+
+	isValidId := regexp.MustCompile(`^[A-Za-z0-9-_]{5,128}$`).MatchString
+	if !isValidId(id) {
+		err = fmt.Errorf("invalid ID for %s", label)
+	}
+
+	return err
+}
+
 func (store *ElasticDetectionstore) validateString(str string, max int, label string) error {
 	return store.validateStringRequired(str, 0, max, label)
 }
@@ -106,7 +117,7 @@ func (store *ElasticDetectionstore) validateDetection(detect *model.Detection) e
 	}
 
 	if err == nil && detect.PublicID != "" {
-		err = store.validateId(detect.PublicID, "publicId")
+		err = store.validatePublicId(detect.PublicID, "publicId")
 	}
 
 	if err == nil && detect.Title != "" {

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -112,6 +112,77 @@ func TestDetectionValidateIdInvalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDetectionValidatePublicIdValid(t *testing.T) {
+	t.Parallel()
+
+	store := NewElasticDetectionstore(server.NewFakeAuthorizedServer(nil), nil, 100)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+
+	err := store.validatePublicId("12345", "test")
+	assert.NoError(t, err)
+
+	err = store.validatePublicId("123456", "test")
+	assert.NoError(t, err)
+
+	err = store.validatePublicId("1-2-A-b", "test")
+	assert.NoError(t, err)
+
+	err = store.validatePublicId("1-2-a-b_2klj", "test")
+	assert.NoError(t, err)
+
+	err = store.validatePublicId("12345678901234567890123456789012345678901234567890", "test")
+	assert.NoError(t, err)
+
+	err = store.validatePublicId(strings.Repeat("1234567890", 12), "test")
+	assert.NoError(t, err)
+}
+
+func TestDetectionValidatePublicIdInvalid(t *testing.T) {
+	t.Parallel()
+
+	store := NewElasticDetectionstore(server.NewFakeAuthorizedServer(nil), nil, 100)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX)
+
+	err := store.validatePublicId("", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("1", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("a", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("this is invalid since it has spaces", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("'quotes'", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("\"dblquotes\"", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId(strings.Repeat("1234567890", 13), "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("../../etc/passwd", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId(`..\..\etc\passwd`, "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("......", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId("//////", "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId(`\\\\\\`, "test")
+	assert.Error(t, err)
+
+	err = store.validatePublicId(`123456!`, "test")
+	assert.Error(t, err)
+}
+
 func TestDetectionValidateStringValid(t *testing.T) {
 	t.Parallel()
 

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -900,7 +900,7 @@ func buildImportChecker(pkg string) *regexp.Regexp {
 }
 
 func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]string, err error) {
-	results, err := e.srv.Detectionstore.GetAllDetections(ctx, util.Ptr(model.EngineNameStrelka), util.Ptr(true), nil) // e.srv.Detectionstore.Query(ctx, `so_detection.engine:strelka AND so_detection.isEnabled:true AND _index:"*:so-detection"`, -1)
+	results, err := e.srv.Detectionstore.GetAllDetections(ctx, util.Ptr(model.EngineNameStrelka), util.Ptr(true), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/google/uuid"
-	"github.com/kennygrant/sanitize"
 )
 
 const (
@@ -54,6 +53,7 @@ const (
 
 var errModuleStopped = fmt.Errorf("strelka module has stopped running")
 var titleUpdater = regexp.MustCompile(`(?i)rule\s+(\w+)(\s+:(\s*[^{]+))?(\s+){`)
+var nameValidator = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,127}$`) // alphanumeric + underscore, can't start with a number
 
 type IOManager interface {
 	ReadFile(path string) ([]byte, error)
@@ -257,7 +257,7 @@ func (s *StrelkaEngine) ExtractDetails(detect *model.Detection) error {
 	}
 
 	detect.Severity = model.SeverityUnknown
-	detect.PublicID = rule.GetID()
+	detect.PublicID = detect.Title
 	if rule.Meta.Author != nil {
 		detect.Author = *rule.Meta.Author
 	}
@@ -753,6 +753,10 @@ func (e *StrelkaEngine) parseYaraRules(data []byte, filter bool) ([]*YaraRule, e
 					buf = strings.TrimSpace(parts[0])
 				}
 
+				if !nameValidator.MatchString(buf) {
+					return nil, fmt.Errorf("unexpected character in rule identifier around %d", i)
+				}
+
 				if buf != "" {
 					rule.Identifier = buf
 				} else {
@@ -896,23 +900,22 @@ func buildImportChecker(pkg string) *regexp.Regexp {
 }
 
 func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]string, err error) {
-	results, err := e.srv.Detectionstore.Query(ctx, `so_detection.engine:strelka AND so_detection.isEnabled:true AND _index:"*:so-detection"`, -1)
+	results, err := e.srv.Detectionstore.GetAllDetections(ctx, util.Ptr(model.EngineNameStrelka), util.Ptr(true), nil) // e.srv.Detectionstore.Query(ctx, `so_detection.engine:strelka AND so_detection.isEnabled:true AND _index:"*:so-detection"`, -1)
 	if err != nil {
 		return nil, err
 	}
 
 	enabledDetections := map[string]*model.Detection{}
-	for _, det := range results {
+	for pid, det := range results {
 		if !e.isRunning {
 			return nil, errModuleStopped
 		}
 
-		d := det.(*model.Detection)
-		_, exists := enabledDetections[d.PublicID]
+		_, exists := enabledDetections[pid]
 		if exists {
-			return nil, fmt.Errorf("duplicate detection with public ID %s", d.PublicID)
+			return nil, fmt.Errorf("duplicate detection with public ID %s", pid)
 		}
-		enabledDetections[d.PublicID] = d
+		enabledDetections[pid] = det
 	}
 
 	// Clear existing .yar files in the directory
@@ -938,8 +941,7 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]s
 
 	// Process and write new .yar files
 	for publicId, det := range enabledDetections {
-		name := sanitize.Name(publicId)
-		filename := filepath.Join(e.yaraRulesFolder, fmt.Sprintf("%s.yar", name))
+		filename := filepath.Join(e.yaraRulesFolder, fmt.Sprintf("%s.yar", publicId))
 
 		err := e.WriteFile(filename, []byte(det.Content), 0644)
 		if err != nil {

--- a/server/modules/strelka/validate.go
+++ b/server/modules/strelka/validate.go
@@ -6,7 +6,6 @@
 package strelka
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"strconv"
 	"strings"
@@ -73,28 +72,6 @@ func (md *Metadata) Set(key, value string) {
 	}
 }
 
-func (rule *YaraRule) GetID() string {
-	if rule.Meta.ID != nil {
-		return util.Unquote(*rule.Meta.ID)
-	}
-
-	id := stringToUUID(rule.Identifier)
-
-	rule.Meta.ID = util.Ptr(id)
-
-	return id
-}
-
-func stringToUUID(s string) string {
-	hash := sha256.Sum256([]byte(s))
-
-	hash[6] = 0x40 | (hash[6] & 0x0f)
-	hash[8] = 0x80 | (hash[8] & 0x3f)
-	return fmt.Sprintf("%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-		hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7], hash[8],
-		hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15])
-}
-
 func (r *YaraRule) Validate() error {
 	missing := []string{}
 
@@ -141,7 +118,7 @@ func (r *YaraRule) ToDetection(license string, ruleset string, isCommunity bool)
 
 	det := &model.Detection{
 		Engine:      model.EngineNameStrelka,
-		PublicID:    r.GetID(),
+		PublicID:    r.Identifier,
 		Title:       r.Identifier,
 		Severity:    sev,
 		Content:     r.Src,

--- a/server/modules/strelka/validate_test.go
+++ b/server/modules/strelka/validate_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/server/mock"
@@ -169,17 +168,4 @@ func TestDuplicateDetection(t *testing.T) {
 	assert.Equal(t, det.License, dupe.License)
 	assert.Empty(t, dupe.Overrides)
 	assert.Empty(t, dupe.Tags)
-}
-
-func TestStringToUUID(t *testing.T) {
-	one := "Hello World"
-	two := "Hello, World!"
-
-	uuidOne := stringToUUID(one)
-	uuidTwo := stringToUUID(two)
-
-	assert.NotEqual(t, uuidOne, uuidTwo)
-
-	assert.NoError(t, uuid.Validate(uuidOne))
-	assert.NoError(t, uuid.Validate(uuidTwo))
 }


### PR DESCRIPTION
Strelka used to generate a public ID based on a hash of the rule identifier. To make this easier elsewhere in the system, the new publicId will be the identifier.

We used to sanitize the UUID publicIds before saving the rules to disk but sanitization resulted in duplicate names. Instead, the strelka parser has been updated to be stricter about unacceptable names.

ValidateDetection is updated to call the new ValidatePublicID which contains a regex that should pass any publicID for any engine, including strelka's new potentially 128 character long publicIds.

Tune Detections in Alerts now expects a column called `rule.uuid` in the groupby clauses. This ID is used to look up the SOC ID the same way for all detections regardless of engine.

Updated tests.