### PR TITLE
Suricata Modify Needs Quotes

### DIFF
--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,8 @@ import (
 	"github.com/apex/log"
 	"github.com/go-git/go-git/v5"
 )
+
+var doubleQuoteEscaper = regexp.MustCompile(`\\([\s\S])|(")`)
 
 type GetterByPublicId interface {
 	GetDetectionByPublicId(ctx context.Context, publicId string) (*model.Detection, error)
@@ -305,4 +308,8 @@ func AddUser(previous string, user *model.User, sep string) string {
 	}
 
 	return previous + author
+}
+
+func EscapeDoubleQuotes(str string) string {
+	return doubleQuoteEscaper.ReplaceAllString(str, "\\$1$2")
 }

--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -160,3 +160,55 @@ func TestAddUser(t *testing.T) {
 	user.LastName = "bar"
 	assert.Equal(t, "foo bar", AddUser("foo bar", &user, ", "))
 }
+
+func TestEscapeDoubleQuotes(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Input     string
+		ExpOutput string
+	}{
+		{
+			Name:      "Nothing to escape",
+			Input:     "ab",
+			ExpOutput: "ab",
+		},
+		{
+			Name:      "Simple",
+			Input:     `a"b`,
+			ExpOutput: `a\"b`,
+		},
+		{
+			Name:      "Pre-Escaped (No Change)",
+			Input:     `a\"b`,
+			ExpOutput: `a\"b`,
+		},
+		{
+			Name:      "Complicated",
+			Input:     `a\\"b`,
+			ExpOutput: `a\\\"b`,
+		},
+		{
+			Name:      "Complicated Pre-Escaped (No Change)",
+			Input:     `a\\\"b`,
+			ExpOutput: `a\\\"b`,
+		},
+		{
+			Name:      "Multiple Quotes",
+			Input:     `a"b"c`,
+			ExpOutput: `a\"b\"c`,
+		},
+		{
+			Name:      "Only Quotes",
+			Input:     `"""`,
+			ExpOutput: `\"\"\"`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			escaped := EscapeDoubleQuotes(test.Input)
+			assert.Equal(t, test.ExpOutput, escaped)
+		})
+	}
+}

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1058,7 +1058,10 @@ func updateModify(modifyLines []string, modifyIndex map[string]int, sid string, 
 		return modifyLines
 	}
 
-	line := fmt.Sprintf("%s %s %s", detect.PublicID, *override.Regex, *override.Value)
+	find := detections.EscapeDoubleQuotes(*override.Regex)
+	replace := detections.EscapeDoubleQuotes(*override.Value)
+
+	line := fmt.Sprintf(`%s "%s" "%s"`, detect.PublicID, find, replace)
 
 	lineNum, inModify := modifyIndex[sid]
 	if !inModify {


### PR DESCRIPTION
Disabling a flowbits rule has been the only suricata modify that's been working. That's because it wraps it's values in quotes. Now modify overrides get the same treatment. This means we now need to escape quotes in these strings. Updated tests.