### PR TITLE
Update Test

### DIFF
--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -657,7 +657,7 @@ func TestSyncLocalSuricata(t *testing.T) {
 				"idstools.rules.local__rules":      SimpleRule,
 				"idstools.sids.enabled":            SimpleRuleSID,
 				"idstools.sids.disabled":           "",
-				"idstools.sids.modify":             SimpleRuleSID + " rev:7; rev:8;",
+				"idstools.sids.modify":             SimpleRuleSID + ` "rev:7;" "rev:8;"`,
 				"suricata.thresholding.sids__yaml": "\"10000\":\n    - modify:\n        regex: rev:7;\n        value: rev:8;\n",
 			},
 		},


### PR DESCRIPTION
When modifying suricata rules, the regex and replacement value are both double quoted. The test now reflects that.