### PR TITLE
Suricata Sync Deletion

### DIFF
--- a/model/detection.go
+++ b/model/detection.go
@@ -99,22 +99,23 @@ type DetectionEngine struct {
 
 type Detection struct {
 	Auditable
-	PublicID    string      `json:"publicId"`
-	Title       string      `json:"title"`
-	Severity    Severity    `json:"severity"`
-	Author      string      `json:"author"`
-	Category    string      `json:"category,omitempty"`
-	Description string      `json:"description"`
-	Content     string      `json:"content"`
-	IsEnabled   bool        `json:"isEnabled"`
-	IsReporting bool        `json:"isReporting"`
-	IsCommunity bool        `json:"isCommunity"`
-	Engine      EngineName  `json:"engine"`
-	Language    SigLanguage `json:"language"`
-	Overrides   []*Override `json:"overrides"` // Tuning
-	Tags        []string    `json:"tags"`
-	Ruleset     string      `json:"ruleset"`
-	License     string      `json:"license"`
+	PublicID      string      `json:"publicId"`
+	Title         string      `json:"title"`
+	Severity      Severity    `json:"severity"`
+	Author        string      `json:"author"`
+	Category      string      `json:"category,omitempty"`
+	Description   string      `json:"description"`
+	Content       string      `json:"content"`
+	IsEnabled     bool        `json:"isEnabled"`
+	IsReporting   bool        `json:"isReporting"`
+	IsCommunity   bool        `json:"isCommunity"`
+	Engine        EngineName  `json:"engine"`
+	Language      SigLanguage `json:"language"`
+	Overrides     []*Override `json:"overrides"` // Tuning
+	Tags          []string    `json:"tags"`
+	Ruleset       string      `json:"ruleset"`
+	License       string      `json:"license"`
+	PendingDelete bool        `json:"-"` // this is a transient field, not stored in the database
 
 	// elastalert - sigma only
 	Product string `json:"product,omitempty"`

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -349,6 +349,7 @@ func (h *DetectionHandler) deleteDetection(w http.ResponseWriter, r *http.Reques
 	}
 
 	old.IsEnabled = false
+	old.PendingDelete = true
 
 	errMap, err := SyncLocalDetections(ctx, h.server, []*model.Detection{old})
 	if err != nil {


### PR DESCRIPTION
New non-persistent (never stored in the DB, and never sent to the UI) field PendingDelete helps the suricata sync process know exactly what it needs to do with the detection.

Added extensive tests to every helper func that modifies pillars. Long overdue.