### PR TITLE
Fix 2 Tests

### DIFF
--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1110,6 +1110,7 @@ func updateModifyForDisabledFlowbits(modifyLines []string, modifyIndex map[strin
 
 	if detect.PendingDelete {
 		line = ""
+		delete(modifyIndex, sid)
 	}
 
 	if !inModify {

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -658,7 +658,7 @@ func TestSyncLocalSuricata(t *testing.T) {
 				"idstools.sids.enabled":            SimpleRuleSID,
 				"idstools.sids.disabled":           "",
 				"idstools.sids.modify":             SimpleRuleSID + ` "rev:7;" "rev:8;"`,
-				"suricata.thresholding.sids__yaml": "\"10000\":\n    - modify:\n        regex: rev:7;\n        value: rev:8;\n",
+				"suricata.thresholding.sids__yaml": "{}\n",
 			},
 		},
 		{


### PR DESCRIPTION
One expected modify overrides to show up in the thresholding pillar and the other was a simple oversight highlighted by the test.