### PR TITLE
Give Strelka a similar performance boost that both suricata and elast…

### DIFF
--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -518,13 +518,13 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 
 					comRule, exists := communityDetections[det.PublicID]
 					if exists {
-						// pre-existing detection, update it
-						det.IsEnabled = comRule.IsEnabled
-						det.Id = comRule.Id
-						det.Overrides = comRule.Overrides
-						det.CreateTime = comRule.CreateTime
-
 						if comRule.Content != det.Content || comRule.Ruleset != det.Ruleset || len(det.Overrides) != 0 {
+							// pre-existing detection, update it
+							det.IsEnabled = comRule.IsEnabled
+							det.Id = comRule.Id
+							det.Overrides = comRule.Overrides
+							det.CreateTime = comRule.CreateTime
+
 							log.WithFields(log.Fields{
 								"rule.uuid": det.PublicID,
 								"rule.name": det.Title,

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -524,29 +524,31 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 						det.Overrides = comRule.Overrides
 						det.CreateTime = comRule.CreateTime
 
-						log.WithFields(log.Fields{
-							"rule.uuid": det.PublicID,
-							"rule.name": det.Title,
-						}).Info("Updating Yara detection")
+						if comRule.Content != det.Content || comRule.Ruleset != det.Ruleset || len(det.Overrides) != 0 {
+							log.WithFields(log.Fields{
+								"rule.uuid": det.PublicID,
+								"rule.name": det.Title,
+							}).Info("Updating Yara detection")
 
-						_, err = e.srv.Detectionstore.UpdateDetection(e.srv.Context, det)
-						if err != nil && err.Error() == "Object not found" {
-							log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
+							_, err = e.srv.Detectionstore.UpdateDetection(e.srv.Context, det)
+							if err != nil && err.Error() == "Object not found" {
+								log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
 
-							writeNoRead = util.Ptr(det.PublicID)
-							failSync = true
+								writeNoRead = util.Ptr(det.PublicID)
+								failSync = true
 
-							return err
-						}
+								return err
+							}
 
-						eterr := et.AddError(err)
-						if eterr != nil {
-							return eterr
-						}
+							eterr := et.AddError(err)
+							if eterr != nil {
+								return eterr
+							}
 
-						if err != nil {
-							log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to update detection")
-							continue
+							if err != nil {
+								log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to update detection")
+								continue
+							}
 						}
 
 						delete(toDelete, det.PublicID)


### PR DESCRIPTION
…alert have

When a community detection needs to update, only update if there was a change in content, ruleset, or if there are overrides (hard to detect if there's a change so we always update them). This improvement is already present in suricata and elastalert.