### PR TITLE
Proper Validation During GetDetectionByPublicId

### DIFF
--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -492,7 +492,7 @@ func (store *ElasticDetectionstore) GetDetection(ctx context.Context, detectId s
 }
 
 func (store *ElasticDetectionstore) GetDetectionByPublicId(ctx context.Context, publicId string) (detect *model.Detection, err error) {
-	err = store.validateId(publicId, "publicId")
+	err = store.validatePublicId(publicId, "publicId")
 	if err != nil {
 		return nil, err
 	}

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -959,6 +959,11 @@ func TestGetDetectionById(t *testing.T) {
 
 	assert.Equal(t, 1, len(fakeStore.InputSearchCriterias))
 	assert.Contains(t, fakeStore.InputSearchCriterias[0].RawQuery, `so_detection.publicId:"123456"`)
+
+	// large (up to 128) public Ids should not cause an error
+	bigId := strings.Repeat("1234567890", 12) // length = 120
+	_, err = store.GetDetectionByPublicId(ctx, bigId)
+	assert.NoError(t, err)
 }
 
 func TestUpdateDetectionFieldValid(t *testing.T) {


### PR DESCRIPTION
We should validate publicIds with the specific validatePublicId function to allow for YARA's long publicIds. Updated test.