### PR TITLE
GetAll now uses Options for it's Options

### DIFF
--- a/model/detection_options.go
+++ b/model/detection_options.go
@@ -1,0 +1,23 @@
+package model
+
+import "fmt"
+
+type GetAllOption func(query string, schemaPrefix string) string
+
+func WithEngine(engine EngineName) GetAllOption {
+	return func(query string, schemaPrefix string) string {
+		return fmt.Sprintf(`%s AND %sdetection.engine:"%s"`, query, schemaPrefix, engine)
+	}
+}
+
+func WithEnabled(isEnabled bool) GetAllOption {
+	return func(query string, schemaPrefix string) string {
+		return fmt.Sprintf(`%s AND %sdetection.isEnabled:"%t"`, query, schemaPrefix, isEnabled)
+	}
+}
+
+func WithCommunity(isCommunity bool) GetAllOption {
+	return func(query string, schemaPrefix string) string {
+		return fmt.Sprintf(`%s AND %sdetection.isCommunity:"%t"`, query, schemaPrefix, isCommunity)
+	}
+}

--- a/model/detection_options_test.go
+++ b/model/detection_options_test.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithEngine(t *testing.T) {
+	queryModder := WithEngine(EngineNameElastAlert)
+	query := queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.engine:"elastalert"`)
+
+	queryModder = WithEngine(EngineNameStrelka)
+	query = queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.engine:"strelka"`)
+
+	queryModder = WithEngine(EngineNameSuricata)
+	query = queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.engine:"suricata"`)
+
+	queryModder = WithEngine(EngineName("unknown"))
+	query = queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.engine:"unknown"`)
+}
+
+func TestWithEnabled(t *testing.T) {
+	queryModder := WithEnabled(true)
+	query := queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.isEnabled:"true"`)
+
+	queryModder = WithEnabled(false)
+	query = queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.isEnabled:"false"`)
+}
+
+func TestWithCommunity(t *testing.T) {
+	queryModder := WithCommunity(true)
+	query := queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.isCommunity:"true"`)
+
+	queryModder = WithCommunity(false)
+	query = queryModder("query", "schemaPrefix")
+	assert.Equal(t, query, `query AND schemaPrefixdetection.isCommunity:"false"`)
+}

--- a/server/detectionstore.go
+++ b/server/detectionstore.go
@@ -19,7 +19,7 @@ type Detectionstore interface {
 	UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error)
 	UpdateDetectionField(ctx context.Context, id string, fields map[string]interface{}) (*model.Detection, error)
 	DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error)
-	GetAllDetections(ctx context.Context, engine *model.EngineName, isEnabled *bool, isCommunity *bool) (map[string]*model.Detection, error) // map[detection.PublicId]detection
+	GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) // map[detection.PublicId]detection
 	Query(ctx context.Context, query string, max int) ([]interface{}, error)
 	GetDetectionHistory(ctx context.Context, detectID string) ([]interface{}, error)
 

--- a/server/mock/mock_detectionstore.go
+++ b/server/mock/mock_detectionstore.go
@@ -114,18 +114,23 @@ func (mr *MockDetectionstoreMockRecorder) DoesTemplateExist(arg0, arg1 any) *gom
 }
 
 // GetAllDetections mocks base method.
-func (m *MockDetectionstore) GetAllDetections(arg0 context.Context, arg1 *model.EngineName, arg2, arg3 *bool) (map[string]*model.Detection, error) {
+func (m *MockDetectionstore) GetAllDetections(arg0 context.Context, arg1 ...model.GetAllOption) (map[string]*model.Detection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllDetections", arg0, arg1, arg2, arg3)
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetAllDetections", varargs...)
 	ret0, _ := ret[0].(map[string]*model.Detection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllDetections indicates an expected call of GetAllDetections.
-func (mr *MockDetectionstoreMockRecorder) GetAllDetections(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockDetectionstoreMockRecorder) GetAllDetections(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllDetections", reflect.TypeOf((*MockDetectionstore)(nil).GetAllDetections), arg0, arg1, arg2, arg3)
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllDetections", reflect.TypeOf((*MockDetectionstore)(nil).GetAllDetections), varargs...)
 }
 
 // GetComment mocks base method.

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -990,7 +990,7 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, detects 
 		return nil, err
 	}
 
-	community, err := e.srv.Detectionstore.GetAllDetections(ctx, util.Ptr(model.EngineNameElastAlert), nil, util.Ptr(true))
+	community, err := e.srv.Detectionstore.GetAllDetections(ctx, model.WithEngine(model.EngineNameElastAlert), model.WithCommunity(true))
 	if err != nil {
 		return nil, err
 	}
@@ -1601,7 +1601,7 @@ func (e *ElastAlertEngine) IntegrityCheck(canInterrupt bool) error {
 		return detections.ErrIntCheckerStopped
 	}
 
-	ret, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, util.Ptr(model.EngineNameElastAlert), util.Ptr(true), nil)
+	ret, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameElastAlert), model.WithEnabled(true))
 	if err != nil {
 		logger.WithError(err).Error("unable to query for enabled detections")
 		return detections.ErrIntCheckFailed

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -619,19 +619,11 @@ func (store *ElasticDetectionstore) DeleteDetection(ctx context.Context, id stri
 	return detect, err
 }
 
-func (store *ElasticDetectionstore) GetAllDetections(ctx context.Context, engine *model.EngineName, isEnabled *bool, isCommunity *bool) (map[string]*model.Detection, error) {
+func (store *ElasticDetectionstore) GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) {
 	query := fmt.Sprintf(`_index:"%s" AND %skind:"%s"`, store.index, store.schemaPrefix, "detection")
 
-	if engine != nil {
-		query += fmt.Sprintf(` AND %sdetection.engine:"%s"`, store.schemaPrefix, *engine)
-	}
-
-	if isEnabled != nil {
-		query += fmt.Sprintf(` AND %sdetection.isEnabled:%t`, store.schemaPrefix, *isEnabled)
-	}
-
-	if isCommunity != nil {
-		query += fmt.Sprintf(` AND %sdetection.isCommunity:%t`, store.schemaPrefix, *isCommunity)
+	for _, opt := range opts {
+		query = opt(query, store.schemaPrefix)
 	}
 
 	all, err := store.Query(ctx, query, -1)

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -15,6 +15,7 @@ import (
 	modmock "github.com/security-onion-solutions/securityonion-soc/server/modules/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 	"github.com/security-onion-solutions/securityonion-soc/web"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 )
@@ -1091,12 +1092,12 @@ func TestGetAllCommunitySIDs(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
 
-	sids, err := store.GetAllDetections(ctx, nil, nil, nil)
+	sids, err := store.GetAllDetections(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(sids))
 	assert.NotNil(t, sids["ABC123"])
 
-	sids, err = store.GetAllDetections(ctx, util.Ptr(model.EngineName("suricata")), nil, nil)
+	sids, err = store.GetAllDetections(ctx, model.WithEngine(model.EngineNameSuricata))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(sids))
 	assert.NotNil(t, sids["ABC123"])

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -445,7 +445,7 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 			}
 		}
 
-		communityDetections, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, util.Ptr(model.EngineNameStrelka), nil, util.Ptr(true))
+		communityDetections, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameStrelka), model.WithCommunity(true))
 		if err != nil {
 			log.WithError(err).Error("Failed to get all community SIDs")
 
@@ -902,7 +902,7 @@ func buildImportChecker(pkg string) *regexp.Regexp {
 }
 
 func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]string, err error) {
-	results, err := e.srv.Detectionstore.GetAllDetections(ctx, util.Ptr(model.EngineNameStrelka), util.Ptr(true), nil)
+	results, err := e.srv.Detectionstore.GetAllDetections(ctx, model.WithEngine(model.EngineNameStrelka), model.WithEnabled(true))
 	if err != nil {
 		return nil, err
 	}
@@ -1064,7 +1064,7 @@ func (e *StrelkaEngine) IntegrityCheck(canInterrupt bool) error {
 		return detections.ErrIntCheckerStopped
 	}
 
-	ret, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, util.Ptr(model.EngineNameStrelka), util.Ptr(true), nil)
+	ret, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameStrelka), model.WithEnabled(true))
 	if err != nil {
 		logger.WithError(err).Error("unable to query for enabled detections")
 		return detections.ErrIntCheckFailed

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -17,6 +17,7 @@ import (
 	servermock "github.com/security-onion-solutions/securityonion-soc/server/mock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/strelka/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
+
 	"github.com/tj/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -272,14 +273,14 @@ func TestSyncStrelka(t *testing.T) {
 		{
 			Name: "Enable Simple Rules",
 			InitMock: func(mockDetStore *servermock.MockDetectionstore, mio *mock.MockIOManager) {
-				mockDetStore.EXPECT().GetAllDetections(gomock.Any(), util.Ptr(model.EngineNameStrelka), util.Ptr(true), nil).Return(map[string]*model.Detection{
-					"1": &model.Detection{
+				mockDetStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+					"1": {
 						PublicID:  "1",
 						Engine:    model.EngineNameStrelka,
 						Content:   simpleRule,
 						IsEnabled: true,
 					},
-					"2": &model.Detection{
+					"2": {
 						PublicID:  "2",
 						Engine:    model.EngineNameStrelka,
 						Content:   simpleRule,

--- a/server/modules/suricata/migration-2.4.70.go
+++ b/server/modules/suricata/migration-2.4.70.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
-	"github.com/security-onion-solutions/securityonion-soc/util"
+
+	"github.com/apex/log"
 	"gopkg.in/yaml.v3"
 )
 
@@ -45,7 +45,7 @@ func (e *SuricataEngine) Migration2470(statePath string) error {
 	dirty := map[string]struct{}{} // map[sid]X
 
 	// retrieve all suricata rules
-	detects, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, util.Ptr(model.EngineNameSuricata), nil, nil)
+	detects, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameSuricata))
 	if err != nil {
 		return err
 	}

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1208,7 +1208,7 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []
 		return nil, err
 	}
 
-	commSIDs, err := e.srv.Detectionstore.GetAllDetections(ctx, util.Ptr(model.EngineNameSuricata), nil, util.Ptr(true))
+	commSIDs, err := e.srv.Detectionstore.GetAllDetections(ctx, model.WithEngine(model.EngineNameSuricata), model.WithCommunity(true))
 	if err != nil {
 		return nil, err
 	}
@@ -1654,7 +1654,7 @@ func (e *SuricataEngine) IntegrityCheck(canInterrupt bool) error {
 		return detections.ErrIntCheckerStopped
 	}
 
-	ret, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, util.Ptr(model.EngineNameSuricata), util.Ptr(true), util.Ptr(true))
+	ret, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameSuricata), model.WithEnabled(true), model.WithCommunity(true))
 	if err != nil {
 		logger.WithError(err).Error("unable to query for enabled detections")
 		return detections.ErrIntCheckFailed

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -18,6 +18,7 @@ import (
 	servermock "github.com/security-onion-solutions/securityonion-soc/server/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 	"github.com/security-onion-solutions/securityonion-soc/web"
+
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -777,7 +778,7 @@ func TestSyncCommunitySuricata(t *testing.T) {
 				},
 			},
 			InitMock: func(detStore *servermock.MockDetectionstore) {
-				detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{}, nil)
+				detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{}, nil)
 				detStore.EXPECT().CreateDetection(gomock.Any(), gomock.Any()).Return(nil, nil)
 			},
 			ExpectedSettings: map[string]string{
@@ -800,7 +801,7 @@ func TestSyncCommunitySuricata(t *testing.T) {
 			},
 			ChangedByUser: true,
 			InitMock: func(detStore *servermock.MockDetectionstore) {
-				detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{}, nil)
+				detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{}, nil)
 				detStore.EXPECT().CreateDetection(gomock.Any(), gomock.Any()).Return(nil, nil)
 			},
 			ExpectedSettings: map[string]string{


### PR DESCRIPTION
Instead of always accepting engine, isEnabled, and isCommunity, GetAllDetections now accepts a variable number of options. Previous call sites have been updated to do the same thing with the new approach. Updated tests.