### PR TITLE
dateAwareSort for v-data-tables

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1426,7 +1426,7 @@
                                 {{ i18n.save }}
                               </v-btn>
                             </div>
-                          </span>  
+                          </span>
                         </div>
                         <!-- type (threshold) -->
                         <div v-if="item.type === 'threshold'" @click="startOverrideEdit('override-threshold-type', item, 'thresholdType')" :class="{ clicktoedit: !isOverrideEdit('override-threshold-type') }" data-aid="detection_override_threshold_type_select">
@@ -1584,7 +1584,7 @@
                   <v-text-field v-model="historyTableOpts.search" clearable prepend-icon="fa-filter" :label="i18n.filterResults" single-line hide-details data-aid="detection_history_filter_input"></v-text-field>
                   <v-data-table ref="historyTable" :sort-by.sync="historyTableOpts.sortBy" :sort-desc.sync="historyTableOpts.sortDesc" :items-per-page.sync="historyTableOpts.itemsPerPage"
                     :search="historyTableOpts.search" :footer-props="historyTableOpts.footerProps" must-sort :headers="historyTableOpts.headers"
-                    :items="history" item-key="id" :loading="historyTableOpts.loading" :expanded="historyTableOpts.expanded" class="history-table">
+                    :items="history" item-key="id" :loading="historyTableOpts.loading" :expanded="historyTableOpts.expanded" class="history-table" :custom-sort="$root.dateAwareSort">
                     <template v-slot:item="{item, index, expand, isExpanded}">
                       <tr>
                         <td class="associated actions">
@@ -3084,7 +3084,7 @@
                   <v-text-field v-model="associatedTable['evidence'].search" clearable prepend-icon="fa-filter" :label="i18n.filterResults" single-line hide-details></v-text-field>
                   <v-data-table ref="evidenceTable" :sort-by.sync="associatedTable['evidence'].sortBy" :sort-desc.sync="associatedTable['evidence'].sortDesc" :items-per-page.sync="associatedTable['evidence'].itemsPerPage"
                     :search="associatedTable['evidence'].search" :footer-props="associatedTable['evidence'].footerProps" must-sort :headers="associatedTable['evidence'].headers"
-                    :items="associations['evidence']" item-key="id" :loading="associatedTable['evidence'].loading" :expanded="associatedTable['evidence'].expanded" class="case-table">
+                    :items="associations['evidence']" item-key="id" :loading="associatedTable['evidence'].loading" :expanded="associatedTable['evidence'].expanded" class="case-table" :custom-sort="$root.dateAwareSort">
                     <template v-slot:item="props">
                       <tr>
                         <td class="association actions">
@@ -3433,7 +3433,7 @@
                   <v-text-field v-model="associatedTable['history'].search" clearable prepend-icon="fa-filter" :label="i18n.filterResults" single-line hide-details data-aid="case_history_filter_input"></v-text-field>
                   <v-data-table ref="historyTable" :sort-by.sync="associatedTable['history'].sortBy" :sort-desc.sync="associatedTable['history'].sortDesc" :items-per-page.sync="associatedTable['history'].itemsPerPage"
                     :search="associatedTable['history'].search" :footer-props="associatedTable['history'].footerProps" must-sort :headers="associatedTable['history'].headers"
-                    :items="associations['history']" item-key="id" :loading="associatedTable['history'].loading" :expanded="associatedTable['history'].expanded" class="case-table">
+                    :items="associations['history']" item-key="id" :loading="associatedTable['history'].loading" :expanded="associatedTable['history'].expanded" class="case-table" :custom-sort="$root.dateAwareSort">
                     <template v-slot:item="props">
                       <tr>
                         <td class="associated actions">

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -1020,7 +1020,7 @@ $(document).ready(function() {
       },
       isDetectionsUpdating() {
         return this.currentStatus != null && this.currentStatus.detections != null &&
-          !this.isDetectionsUnhealthy() && 
+          !this.isDetectionsUnhealthy() &&
           ( this.currentStatus.detections.elastalert.importing === true ||
             this.currentStatus.detections.elastalert.migrating === true ||
             this.currentStatus.detections.elastalert.syncing === true ||
@@ -1141,6 +1141,27 @@ $(document).ready(function() {
         }
 
         return '';
+      },
+      dateAwareSort(items, index, isDesc) {
+        items.sort((a, b) => {
+          if (index[0] === 'createTime' || index[0] === 'updateTime') {
+            if (!isDesc[0]) {
+              return new Date(a[index]) - new Date(b[index]);
+            }
+
+            return new Date(b[index]) - new Date(a[index]);
+          }
+
+          if (typeof a[index] !== 'undefined') {
+            if (!isDesc[0]) {
+              return a[index].toLowerCase().localeCompare(b[index].toLowerCase());
+            }
+
+            return b[index].toLowerCase().localeCompare(a[index].toLowerCase());
+          }
+        });
+
+        return items;
       },
     },
     created() {

--- a/html/js/app.test.js
+++ b/html/js/app.test.js
@@ -534,7 +534,7 @@ test('isDetectionsUnhealthy', () => {
   verifyEngineFailureStates(false, false, false, false, false, false, true, true, true, true);
   verifyEngineFailureStates(false, false, false, false, false, false, false, true, true, true);
   verifyEngineFailureStates(false, false, false, false, false, false, false, false, true, true);
-  
+
   // Healthy
   verifyEngineFailureStates(false, false, false, false, false, false, false, false, false, false);
 
@@ -658,7 +658,7 @@ test('getDetectionEngineStatus', () => {
 
 test('isAttentionNeeded', () => {
   app.connected =  true;
-  app.currentStatus = { 
+  app.currentStatus = {
     detections: {
       elastalert: {
         integrityFailure: false,
@@ -708,3 +708,49 @@ test('isAttentionNeeded', () => {
   // Back to normal
   expect(app.isAttentionNeeded()).toBe(false);
 })
+
+test('dateAwareSort', () => {
+  let items = [
+    { string: 'May 28, 2024 10:00:00 AM', createTime: 'May 28, 2024 10:00:00 AM', strOrder: 1, dateOrder: 0 },
+    { string: 'May 28, 2024 11:00:00 AM', createTime: 'May 28, 2024 11:00:00 AM', strOrder: 2, dateOrder: 1 },
+    { string: 'May 28, 2024 12:00:00 PM', createTime: 'May 28, 2024 12:00:00 PM', strOrder: 3, dateOrder: 2 },
+    { string: 'May 28, 2024 1:00:00 PM', createTime: 'May 28, 2024 1:00:00 PM', strOrder: 0, dateOrder: 3 },
+    { string: 'May 28, 2024 2:00:00 PM', createTime: 'May 28, 2024 2:00:00 PM', strOrder: 4, dateOrder: 4 },
+  ];
+  let index = ["string"];
+  let isDesc = [false];
+
+  app.dateAwareSort(items, index, isDesc);
+
+  for (let i = 0; i < items.length; i++) {
+    expect(items[i].strOrder).toBe(i);
+  }
+
+  // Reverse the sort
+  isDesc = [true];
+
+  app.dateAwareSort(items, index, isDesc);
+
+  for (let i = 0; i < items.length; i++) {
+    expect(items[i].strOrder).toBe(items.length - i - 1);
+  }
+
+  // revert order, change sortby
+  index = ["createTime"];
+  isDesc = [false];
+
+  app.dateAwareSort(items, index, isDesc);
+
+  for (let i = 0; i < items.length; i++) {
+    expect(items[i].dateOrder).toBe(i);
+  }
+
+  // Reverse the sort
+  isDesc = [true];
+
+  app.dateAwareSort(items, index, isDesc);
+
+  for (let i = 0; i < items.length; i++) {
+    expect(items[i].dateOrder).toBe(items.length - i - 1);
+  }
+});


### PR DESCRIPTION
Some cypress tests fail because the newly added item wasn't added to the top or bottom of a table as expected. This is because those tables aren't sorting their dates as dates, but as strings. This new date aware sort fixes that. It's not actually aware that the data contains a date, it flags off the field being sorted to determine if it should be converted to date before sorting. Currently sorting by "createTime" and "updateTime" will treat their values as dates, everything else is converted to strings.

The new sort has been applied to Case Observables, Case History, and Detection History.

Hunt seems to use a different format for it's timestamps such that when sorted as a string it will sort it chronologically. Leaving that table untouched for now.

Added test. Cypress tests already assume sorts work so they don't need updating.