### PR TITLE
Detection Templates

### DIFF
--- a/config/clientparameters.go
+++ b/config/clientparameters.go
@@ -16,27 +16,27 @@ const DEFAULT_CHART_LABEL_OTHER_LIMIT = 10
 const DEFAULT_CHART_LABEL_FIELD_SEPARATOR = ", "
 
 type ClientParameters struct {
-	HuntingParams       HuntingParameters   `json:"hunt"`
-	AlertingParams      HuntingParameters   `json:"alerts"`
-	CasesParams         HuntingParameters   `json:"cases"`
-	CaseParams          CaseParameters      `json:"case"`
-	DashboardsParams    HuntingParameters   `json:"dashboards"`
-	JobParams           HuntingParameters   `json:"job"`
-	DetectionsParams    DetectionParameters `json:"detections"`
-	DetectionParams     DetectionParameters `json:"detection"`
-	DocsUrl             string              `json:"docsUrl"`
-	CheatsheetUrl       string              `json:"cheatsheetUrl"`
-	ReleaseNotesUrl     string              `json:"releaseNotesUrl"`
-	GridParams          GridParameters      `json:"grid"`
-	WebSocketTimeoutMs  int                 `json:"webSocketTimeoutMs"`
-	TipTimeoutMs        int                 `json:"tipTimeoutMs"`
-	ApiTimeoutMs        int                 `json:"apiTimeoutMs"`
-	CacheExpirationMs   int                 `json:"cacheExpirationMs"`
-	InactiveTools       []string            `json:"inactiveTools"`
-	Tools               []ClientTool        `json:"tools"`
-	CasesEnabled        bool                `json:"casesEnabled"`
-	EnableReverseLookup bool                `json:"enableReverseLookup"`
-	DetectionsEnabled   bool                `json:"detectionsEnabled"`
+	HuntingParams       HuntingParameters    `json:"hunt"`
+	AlertingParams      HuntingParameters    `json:"alerts"`
+	CasesParams         HuntingParameters    `json:"cases"`
+	CaseParams          CaseParameters       `json:"case"`
+	DashboardsParams    HuntingParameters    `json:"dashboards"`
+	JobParams           HuntingParameters    `json:"job"`
+	DetectionsParams    DetectionsParameters `json:"detections"`
+	DetectionParams     DetectionParameters  `json:"detection"`
+	DocsUrl             string               `json:"docsUrl"`
+	CheatsheetUrl       string               `json:"cheatsheetUrl"`
+	ReleaseNotesUrl     string               `json:"releaseNotesUrl"`
+	GridParams          GridParameters       `json:"grid"`
+	WebSocketTimeoutMs  int                  `json:"webSocketTimeoutMs"`
+	TipTimeoutMs        int                  `json:"tipTimeoutMs"`
+	ApiTimeoutMs        int                  `json:"apiTimeoutMs"`
+	CacheExpirationMs   int                  `json:"cacheExpirationMs"`
+	InactiveTools       []string             `json:"inactiveTools"`
+	Tools               []ClientTool         `json:"tools"`
+	CasesEnabled        bool                 `json:"casesEnabled"`
+	EnableReverseLookup bool                 `json:"enableReverseLookup"`
+	DetectionsEnabled   bool                 `json:"detectionsEnabled"`
 }
 
 func (config *ClientParameters) Verify() error {
@@ -190,15 +190,23 @@ type GridParameters struct {
 	StaleMetricsMs uint64 `json:"staleMetricsMs,omitempty"`
 }
 
-type DetectionParameters struct {
+type DetectionsParameters struct {
 	HuntingParameters
-	Presets              map[string]PresetParameters `json:"presets"`
-	SeverityTranslations map[string]string           `json:"severityTranslations"`
+	DetectionParameters
 }
 
-func (params *DetectionParameters) Verify() error {
+type DetectionParameters struct {
+	Presets              map[string]PresetParameters `json:"presets"`
+	SeverityTranslations map[string]string           `json:"severityTranslations"`
+	TemplateDetections   map[string]string           `json:"templateDetections"`
+}
+
+func (params *DetectionsParameters) Verify() error {
 	err := params.HuntingParameters.Verify()
 
 	return err
+}
 
+func (params *DetectionParameters) Verify() error {
+	return nil
 }

--- a/html/index.html
+++ b/html/index.html
@@ -1064,7 +1064,7 @@
                   <div class="header">{{ i18n.add }} {{ i18n.detection }}</div>
                   <!-- Language -->
                   <span data-aid="detection_new_language_select">
-                    <v-select id="detection-language-create" v-model="detect.language" :items="getPresets('language')" persistent-hint :hint="i18n.language" :rules="[rules.required]" v-on:change="onDetectionChange"/>
+                    <v-select id="detection-language-create" v-model="detect.language" :items="getPresets('language')" persistent-hint :hint="i18n.language" :rules="[rules.required]" v-on:change="onNewDetectionLanguageChange"/>
                   </span>
 
                   <!-- License -->

--- a/server/detectionengine.go
+++ b/server/detectionengine.go
@@ -19,6 +19,7 @@ type DetectionEngine interface {
 	InterruptSync(forceFull bool, notify bool)
 	DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error)
 	GetState() *model.EngineState
+	GenerateUnusedPublicId(ctx context.Context) (string, error)
 }
 
 type SyncStatus struct {

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1333,7 +1333,7 @@ func (e *ElastAlertEngine) sigmaToElastAlert(ctx context.Context, det *model.Det
 	return query, nil
 }
 
-func (e *ElastAlertEngine) generateUnusedPublicId(ctx context.Context) (string, error) {
+func (e *ElastAlertEngine) GenerateUnusedPublicId(ctx context.Context) (string, error) {
 	id := uuid.New().String()
 
 	i := 0
@@ -1359,7 +1359,7 @@ func (e *ElastAlertEngine) generateUnusedPublicId(ctx context.Context) (string, 
 }
 
 func (e *ElastAlertEngine) DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error) {
-	id, err := e.generateUnusedPublicId(ctx)
+	id, err := e.GenerateUnusedPublicId(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/modules/elastalert/validate_test.go
+++ b/server/modules/elastalert/validate_test.go
@@ -189,7 +189,7 @@ func TestGenerateUnusedPublicId(t *testing.T) {
 		isRunning: true,
 	}
 
-	id, err := eng.generateUnusedPublicId(ctx)
+	id, err := eng.GenerateUnusedPublicId(ctx)
 
 	assert.Empty(t, id)
 	assert.Error(t, err)

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -1003,6 +1003,12 @@ func (e *StrelkaEngine) DuplicateDetection(ctx context.Context, detection *model
 	return det, nil
 }
 
+func (e *StrelkaEngine) GenerateUnusedPublicId(ctx context.Context) (string, error) {
+	// PublicIDs for Strelka are the rule name which should correlate with what the rule does.
+	// Cannot generate arbitrary but still useful public IDs
+	return "", fmt.Errorf("not implemented")
+}
+
 func (e *StrelkaEngine) IntegrityCheck(canInterrupt bool) error {
 	// escape
 	if canInterrupt && !e.IntegrityCheckerData.IsRunning {

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1506,7 +1506,7 @@ func lookupLicense(ruleset string) string {
 	return license
 }
 
-func (e *SuricataEngine) generateUnusedPublicId(ctx context.Context) (string, error) {
+func (e *SuricataEngine) GenerateUnusedPublicId(ctx context.Context) (string, error) {
 	id := strconv.Itoa(rand.IntN(1000000) + 1000000) // [1000000, 2000000)
 
 	i := 0
@@ -1532,7 +1532,7 @@ func (e *SuricataEngine) generateUnusedPublicId(ctx context.Context) (string, er
 }
 
 func (e *SuricataEngine) DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error) {
-	id, err := e.generateUnusedPublicId(ctx)
+	id, err := e.GenerateUnusedPublicId(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/modules/suricata/validate_test.go
+++ b/server/modules/suricata/validate_test.go
@@ -215,7 +215,7 @@ func TestGenerateUnusedPublicId(t *testing.T) {
 		isRunning: true,
 	}
 
-	id, err := eng.generateUnusedPublicId(ctx)
+	id, err := eng.GenerateUnusedPublicId(ctx)
 
 	assert.Empty(t, id)
 	assert.Error(t, err)


### PR DESCRIPTION
When you select a language from the dropdown on the New Detection page, a request is made to get an unused public Id for that engine (except YARA/Strelka). The source field is then filled with the template for that language/engine with publicId inserted in the right place.