### PR TITLE
Only disallow bulk action w/community rules on Delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ sensoroni
 jobs/
 logs/
 nsm/
+coverage/
 .vscode/
 .DS_Store
 

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -420,15 +420,17 @@ func (h *DetectionHandler) bulkUpdateDetection(w http.ResponseWriter, r *http.Re
 	} else {
 		for _, id := range body.IDs {
 			IDs = append(IDs, id)
-			det, err := h.server.Detectionstore.GetDetection(ctx, id)
-			if err != nil {
-				web.Respond(w, r, http.StatusInternalServerError, err)
-				return
-			}
+			if body.Delete {
+				det, err := h.server.Detectionstore.GetDetection(ctx, id)
+				if err != nil {
+					web.Respond(w, r, http.StatusInternalServerError, err)
+					return
+				}
 
-			if det.IsCommunity {
-				containsCommunity = true
-				break
+				if det.IsCommunity {
+					containsCommunity = true
+					break
+				}
 			}
 		}
 	}

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -433,7 +433,7 @@ func (h *DetectionHandler) bulkUpdateDetection(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	if containsCommunity {
+	if containsCommunity && body.Delete {
 		web.Respond(w, r, http.StatusBadRequest, "ERROR_BULK_COMMUNITY")
 		return
 	}

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1006,16 +1006,6 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, detects 
 		}
 	}
 
-	// carry forward existing overrides
-	for i := range detects {
-		det := detects[i]
-
-		comDet, exists := community[det.PublicID]
-		if exists {
-			det.Overrides = comDet.Overrides
-		}
-	}
-
 	results := struct {
 		Added     int
 		Updated   int


### PR DESCRIPTION
When adding BulkDelete, a check for the involvement of community rules was added since you can't delete community rules. However the check will fail Bulk Enables/Disables too. This is causing Cypress tests to fail.

In the sigma sync process, we had an extra bit of logic to copy over all the overrides of existing community rules. This was removed as line 1044 accomplishes the task as well.

Added a coverage folder to the gitignore. Jest coverage reports shouldn't be checked in.