### PR TITLE
Show tip when Bulk Action starts

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -697,10 +697,12 @@ $(document).ready(function() {
       },
       updateEditorTheme() {
         var link = $('link[href^="css/external/prism-custom-"]')[0];
-        if (this.$vuetify.theme.dark) {
-          link.href = "css/external/prism-custom-dark-v1.29.0.css";
-        } else {
-          link.href = "css/external/prism-custom-light-v1.29.0.css";
+        if (link) {
+          if (this.$vuetify.theme.dark) {
+            link.href = "css/external/prism-custom-dark-v1.29.0.css";
+          } else {
+            link.href = "css/external/prism-custom-light-v1.29.0.css";
+          }
         }
       },
       subscribe(kind, fn) {

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -121,6 +121,8 @@ const i18n = {
       betweenOp: 'Between',
       blog: 'Blog',
       bulkAction: 'Bulk Action:',
+      bulkActionStarted: 'Updating {total} detections. This may take awhile.',
+      bulkActionDeleteStarted: 'Deleting {total} detections. This may take awhile.',
       bulkError: '',
       bulkSuccessUpdate: 'Bulk update successfully updated {modified} of {total} events. ({time})',
       bulkSuccessDelete: 'Bulk delete successfully deleted {modified} of {total} events. ({time})',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2216,6 +2216,16 @@ const huntComponent = {
 
       try {
         await this.$root.papi.post('detection/bulk/' + this.selectedAction, payload);
+
+        let msg = this.i18n.bulkActionStarted;
+        if (this.selectedAction === 'delete') {
+          msg = this.i18n.bulkActionDeleteStarted;
+        }
+
+        msg = msg.replace('{total}', this.selectedCount.toLocaleString());
+
+        this.$root.showTip(msg);
+
         this.selectAllState = false;
         this.selectedCount = 0;
         this.hunt(false);

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1200,6 +1200,7 @@ test('bulkAction - delete - pre-confirm', async () => {
 
   expect(comp.showBulkDeleteConfirmDialog).toBe(true);
   expect(comp.selectedCount).toBe(2);
+  expect(comp.$root.tip).toBe(false);
 });
 
 test('bulkAction - enable', async () => {
@@ -1219,6 +1220,8 @@ test('bulkAction - enable', async () => {
   expect(mock).toHaveBeenCalledWith('detection/bulk/enable', { ids: ["1", "3"] });
   expect(comp.hunt).toHaveBeenCalledTimes(1);
   expect(comp.hunt).toHaveBeenCalledWith(false);
+  expect(comp.$root.tip).toBe(true);
+  expect(comp.$root.tipMessage).toBe('Updating 2 detections. This may take awhile.');
 });
 
 test('bulkAction - disable', async () => {
@@ -1238,6 +1241,8 @@ test('bulkAction - disable', async () => {
   expect(mock).toHaveBeenCalledWith('detection/bulk/disable', { ids: ["1", "3"] });
   expect(comp.hunt).toHaveBeenCalledTimes(1);
   expect(comp.hunt).toHaveBeenCalledWith(false);
+  expect(comp.$root.tip).toBe(true);
+  expect(comp.$root.tipMessage).toBe('Updating 2 detections. This may take awhile.');
 });
 
 test('bulkAction - delete - confirm - success', async () => {
@@ -1258,6 +1263,8 @@ test('bulkAction - delete - confirm - success', async () => {
   expect(mock).toHaveBeenCalledWith('detection/bulk/delete', { ids: ["1", "3"] });
   expect(comp.hunt).toHaveBeenCalledTimes(1);
   expect(comp.hunt).toHaveBeenCalledWith(false);
+  expect(comp.$root.tip).toBe(true);
+  expect(comp.$root.tipMessage).toBe('Deleting 2 detections. This may take awhile.');
 });
 
 test('bulkAction - delete - confirm - failure', async () => {


### PR DESCRIPTION
Now shows a tip when a Bulk Action starts showing the number of detections being updated/deleted and with update/delete specific verbiage.