### PR TITLE
Deduplication of Detections by Public Id

### DIFF
--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -280,3 +280,56 @@ func TestProxyToTransportOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestDeduplicateByPublicId(t *testing.T) {
+	tests := []struct {
+		Name      string
+		InputIds  []string
+		ExpOutput []string
+	}{
+		{
+			Name:      "Empty",
+			InputIds:  []string{},
+			ExpOutput: []string{},
+		},
+		{
+			Name:      "No Duplicates",
+			InputIds:  []string{"1", "2", "3"},
+			ExpOutput: []string{"1", "2", "3"},
+		},
+		{
+			Name:      "Only Duplicates",
+			InputIds:  []string{"1", "1", "1", "1", "1", "1", "1", "1", "1", "1"},
+			ExpOutput: []string{"1"},
+		},
+		{
+			Name:      "Mixed",
+			InputIds:  []string{"1", "2", "1", "3", "2", "4", "1", "5", "2", "6"},
+			ExpOutput: []string{"1", "2", "3", "4", "5", "6"},
+		},
+		{
+			Name:      "One Duplicate",
+			InputIds:  []string{"1", "2", "3", "4", "5", "6", "1"},
+			ExpOutput: []string{"1", "2", "3", "4", "5", "6"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			dets := make([]*model.Detection, 0, len(test.InputIds))
+			for _, id := range test.InputIds {
+				dets = append(dets, &model.Detection{PublicID: id})
+			}
+
+			deduped := DeduplicateByPublicId(dets)
+
+			output := make([]string, 0, len(deduped))
+			for _, det := range deduped {
+				output = append(output, det.PublicID)
+			}
+
+			assert.Equal(t, test.ExpOutput, output)
+		})
+	}
+}

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/module"
 	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/elastalert/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 
@@ -529,7 +530,8 @@ level: high
 	}
 
 	engine := ElastAlertEngine{
-		isRunning: true,
+		isRunning:         true,
+		sigmaRulePackages: []string{"all_rules"},
 	}
 	engine.allowRegex = regexp.MustCompile("00000000-0000-0000-0000-00000000")
 	engine.denyRegex = regexp.MustCompile("deny")
@@ -578,11 +580,14 @@ level: high
 license: Elastic-2.0
 `
 
-	repos := map[string]*model.RuleRepo{
-		"repo-path": {
-			Repo:      "github.com/repo-user/repo-path",
-			License:   "DRL",
-			Community: true,
+	repos := []*detections.RepoOnDisk{
+		{
+			Repo: &model.RuleRepo{
+				Repo:      "github.com/repo-user/repo-path",
+				License:   "DRL",
+				Community: true,
+			},
+			Path: "repo-path",
 		},
 	}
 

--- a/server/modules/strelka/mock/mock_iomanager.go
+++ b/server/modules/strelka/mock/mock_iomanager.go
@@ -10,7 +10,6 @@ package mock
 
 import (
 	fs "io/fs"
-	http "net/http"
 	exec "os/exec"
 	reflect "reflect"
 	time "time"
@@ -72,21 +71,6 @@ func (mr *MockIOManagerMockRecorder) ExecCommand(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCommand", reflect.TypeOf((*MockIOManager)(nil).ExecCommand), arg0)
 }
 
-// MakeRequest mocks base method.
-func (m *MockIOManager) MakeRequest(arg0 *http.Request) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeRequest", arg0)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MakeRequest indicates an expected call of MakeRequest.
-func (mr *MockIOManagerMockRecorder) MakeRequest(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRequest", reflect.TypeOf((*MockIOManager)(nil).MakeRequest), arg0)
-}
-
 // ReadDir mocks base method.
 func (m *MockIOManager) ReadDir(arg0 string) ([]fs.DirEntry, error) {
 	m.ctrl.T.Helper()
@@ -115,6 +99,20 @@ func (m *MockIOManager) ReadFile(arg0 string) ([]byte, error) {
 func (mr *MockIOManagerMockRecorder) ReadFile(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockIOManager)(nil).ReadFile), arg0)
+}
+
+// WalkDir mocks base method.
+func (m *MockIOManager) WalkDir(arg0 string, arg1 fs.WalkDirFunc) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WalkDir", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WalkDir indicates an expected call of WalkDir.
+func (mr *MockIOManagerMockRecorder) WalkDir(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkDir", reflect.TypeOf((*MockIOManager)(nil).WalkDir), arg0, arg1)
 }
 
 // WriteFile mocks base method.

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -60,6 +60,7 @@ type IOManager interface {
 	DeleteFile(path string) error
 	ReadDir(path string) ([]os.DirEntry, error)
 	ExecCommand(cmd *exec.Cmd) ([]byte, int, time.Duration, error)
+	WalkDir(root string, fn fs.WalkDirFunc) error
 }
 
 type StrelkaEngine struct {
@@ -396,8 +397,6 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 			templateFound = true
 		}
 
-		upToDate := map[string]*model.RuleRepo{}
-
 		allRepos, anythingNew, err := detections.UpdateRepos(&e.isRunning, e.reposFolder, e.rulesRepos, e.srv.Config)
 		if err != nil {
 			if strings.Contains(err.Error(), "module stopped") {
@@ -437,12 +436,6 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 			continue
 		}
 
-		for k, v := range allRepos {
-			if v.WasModified || forceSync {
-				upToDate[k] = v.Repo
-			}
-		}
-
 		communityDetections, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameStrelka), model.WithCommunity(true))
 		if err != nil {
 			log.WithError(err).Error("Failed to get all community SIDs")
@@ -463,20 +456,24 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 		}
 
 		et := detections.NewErrorTracker(e.failAfterConsecutiveErrorCount)
-		failSync := false
+		detects := []*model.Detection{}
 
 		// parse *.yar files in repos
-		for repopath, repo := range upToDate {
+		for repopath, repo := range allRepos {
 			if !e.isRunning {
 				return
 			}
 
-			baseDir := repopath
-			if repo.Folder != nil {
-				baseDir = filepath.Join(baseDir, *repo.Folder)
+			if !repo.WasModified && !forceSync {
+				continue
 			}
 
-			err = filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+			baseDir := repo.Path
+			if repo.Repo.Folder != nil {
+				baseDir = filepath.Join(baseDir, *repo.Repo.Folder)
+			}
+
+			err = e.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
 					log.WithError(err).WithField("repoPath", path).Error("Failed to walk path")
 					return nil
@@ -508,81 +505,8 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 				}
 
 				for _, rule := range parsed {
-					det := rule.ToDetection(repo.License, filepath.Base(repopath), repo.Community)
-					log.WithFields(log.Fields{
-						"rule.uuid": det.PublicID,
-						"rule.name": det.Title,
-					}).Info("Strelka community sync - processing YARA rule")
-
-					comRule, exists := communityDetections[det.PublicID]
-					if exists {
-						if comRule.Content != det.Content || comRule.Ruleset != det.Ruleset || len(det.Overrides) != 0 {
-							// pre-existing detection, update it
-							det.IsEnabled = comRule.IsEnabled
-							det.Id = comRule.Id
-							det.Overrides = comRule.Overrides
-							det.CreateTime = comRule.CreateTime
-
-							log.WithFields(log.Fields{
-								"rule.uuid": det.PublicID,
-								"rule.name": det.Title,
-							}).Info("Updating Yara detection")
-
-							_, err = e.srv.Detectionstore.UpdateDetection(e.srv.Context, det)
-							if err != nil && err.Error() == "Object not found" {
-								log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
-
-								writeNoRead = util.Ptr(det.PublicID)
-								failSync = true
-
-								return err
-							}
-
-							eterr := et.AddError(err)
-							if eterr != nil {
-								return eterr
-							}
-
-							if err != nil {
-								log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to update detection")
-								continue
-							}
-						}
-
-						delete(toDelete, det.PublicID)
-					} else {
-						// new detection, create it
-						log.WithFields(log.Fields{
-							"rule.uuid": det.PublicID,
-							"rule.name": det.Title,
-						}).Info("Creating new Yara detection")
-
-						checkRulesetEnabled(e, det)
-
-						_, err = e.srv.Detectionstore.CreateDetection(e.srv.Context, det)
-						if err != nil && err.Error() == "Object not found" {
-							log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
-
-							writeNoRead = util.Ptr(det.PublicID)
-							failSync = true
-
-							return err
-						}
-
-						eterr := et.AddError(err)
-						if eterr != nil {
-							failSync = true
-
-							return eterr
-						}
-
-						if err != nil {
-							log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to create detection")
-							continue
-						}
-
-						delete(toDelete, det.PublicID)
-					}
+					det := rule.ToDetection(repo.Repo.License, filepath.Base(repo.Path), repo.Repo.Community)
+					detects = append(detects, det)
 				}
 
 				return nil
@@ -590,15 +514,99 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 			if err != nil {
 				log.WithError(err).WithField("strelkaRepo", repopath).Error("failed while walking repo")
 
-				if failSync {
-					break
-				}
-
 				continue
 			}
 		}
 
-		if failSync {
+		var eterr error
+		detects = detections.DeduplicateByPublicId(detects)
+
+		for _, det := range detects {
+			log.WithFields(log.Fields{
+				"rule.uuid": det.PublicID,
+				"rule.name": det.Title,
+			}).Info("Strelka community sync - processing YARA rule")
+
+			comRule, exists := communityDetections[det.PublicID]
+			if exists {
+				if comRule.Content != det.Content || comRule.Ruleset != det.Ruleset || len(det.Overrides) != 0 {
+					// pre-existing detection, update it
+					det.IsEnabled = comRule.IsEnabled
+					det.Id = comRule.Id
+					det.Overrides = comRule.Overrides
+					det.CreateTime = comRule.CreateTime
+
+					log.WithFields(log.Fields{
+						"rule.uuid": det.PublicID,
+						"rule.name": det.Title,
+					}).Info("Updating Yara detection")
+
+					_, err = e.srv.Detectionstore.UpdateDetection(e.srv.Context, det)
+					if err != nil && err.Error() == "Object not found" {
+						writeNoRead = util.Ptr(det.PublicID)
+						log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
+
+						break
+					}
+
+					eterr = et.AddError(err)
+					if eterr != nil {
+						break
+					}
+
+					if err != nil {
+						log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to update detection")
+						continue
+					}
+				}
+
+				delete(toDelete, det.PublicID)
+			} else {
+				// new detection, create it
+				log.WithFields(log.Fields{
+					"rule.uuid": det.PublicID,
+					"rule.name": det.Title,
+				}).Info("Creating new Yara detection")
+
+				checkRulesetEnabled(e, det)
+
+				_, err = e.srv.Detectionstore.CreateDetection(e.srv.Context, det)
+				if err != nil && err.Error() == "Object not found" {
+					writeNoRead = util.Ptr(det.PublicID)
+					log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
+
+					break
+				}
+
+				eterr = et.AddError(err)
+				if eterr != nil {
+					break
+				}
+
+				if err != nil {
+					log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to create detection")
+					continue
+				}
+
+				delete(toDelete, det.PublicID)
+			}
+		}
+
+		if eterr != nil || writeNoRead != nil {
+			if eterr != nil {
+				log.WithError(eterr).Error("unable to sync YARA community detections")
+			}
+			if writeNoRead != nil {
+				log.Warn("detection was written but not read back, attempting read before continuing")
+			}
+
+			if e.notify {
+				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+					Engine: model.EngineNameElastAlert,
+					Status: "error",
+				})
+			}
+
 			continue
 		}
 
@@ -1170,6 +1178,7 @@ func (_ *ResourceManager) DeleteFile(path string) error {
 func (_ *ResourceManager) ReadDir(path string) ([]os.DirEntry, error) {
 	return os.ReadDir(path)
 }
+
 func (_ *ResourceManager) ExecCommand(cmd *exec.Cmd) (output []byte, exitCode int, runtime time.Duration, err error) {
 	start := time.Now()
 	output, err = cmd.CombinedOutput()
@@ -1178,4 +1187,8 @@ func (_ *ResourceManager) ExecCommand(cmd *exec.Cmd) (output []byte, exitCode in
 	exitCode = cmd.ProcessState.ExitCode()
 
 	return output, exitCode, runtime, err
+}
+
+func (_ *ResourceManager) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return filepath.WalkDir(root, fn)
 }

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -509,6 +509,8 @@ func (e *SuricataEngine) watchCommunityRules() {
 			continue
 		}
 
+		commDetections = detections.DeduplicateByPublicId(commDetections)
+
 		for _, d := range commDetections {
 			d.IsCommunity = true
 		}


### PR DESCRIPTION
To support this properly, engines need to process their rules in a deterministic order. If different detections are marked as duplicates from one sync to the next, you never really know which rules your system is executing.

UpdateRepos has been refactored to return an array instead of an unordered map. The array of RepoOnDisk (formerly DirtyRepo) will be in the same order as the repos listed in the config.

Strelka needed even more refactoring as it would parse each rule from beginning to end before going to the next rule. Now it gathers all the detections, dedupes them, then syncs them. Refactored the call to WalkDir to use the IOManager instead of directly calling filepath.WalkDir.

Suricata parses the rules in the order that they exist in the `communityRulesFile` file. Strelka processes the repos in the order they appear in the config, inside each repo the files are parsed in lexical order.

Some tests needed to be updated to work around the changes to UpdateRepos and other determinism changes. Added a new test for the deduplication process.