### PR TITLE
Slimmed down Detections Configs

### DIFF
--- a/config/clientparameters.go
+++ b/config/clientparameters.go
@@ -191,19 +191,8 @@ type GridParameters struct {
 }
 
 type DetectionsParameters struct {
-	Actions               []*HuntingAction            `json:"actions"`
-	Advanced              bool                        `json:"advanced"`
-	CreateLink            string                      `json:"createLink"`
-	EventFetchLimit       int                         `json:"eventFetchLimit"`
-	EventFields           map[string][]string         `json:"eventFields"`
-	EventItemsPerPage     int                         `json:"eventItemsPerPage"`
-	GroupFetchLimit       int                         `json:"groupFetchLimit"`
-	MostRecentlyUsedLimit int                         `json:"mostRecentlyUsedLimit"`
-	Presets               map[string]PresetParameters `json:"presets"`
-	Queries               []*HuntingQuery             `json:"queries"`
-	QueryBaseFilter       string                      `json:"queryBaseFilter"`
-	SafeStringMaxLength   int                         `json:"safeStringMaxLength"`
-	ViewEnabled           bool                        `json:"viewEnabled"`
+	HuntingParameters
+	Presets              map[string]PresetParameters `json:"presets"`
 }
 
 type DetectionParameters struct {
@@ -213,20 +202,9 @@ type DetectionParameters struct {
 }
 
 func (params *DetectionsParameters) Verify() error {
-	if params.GroupFetchLimit <= 0 {
-		params.GroupFetchLimit = DEFAULT_GROUP_FETCH_LIMIT
-	}
-	if params.EventFetchLimit <= 0 {
-		params.EventFetchLimit = DEFAULT_EVENT_FETCH_LIMIT
-	}
-	if params.MostRecentlyUsedLimit < 0 {
-		params.MostRecentlyUsedLimit = 0
-	}
-	if params.SafeStringMaxLength <= 0 {
-		params.SafeStringMaxLength = DEFAULT_SAFE_STRING_MAX_LENGTH
-	}
+	err := params.HuntingParameters.Verify()
 
-	return nil
+	return err
 }
 
 func (params *DetectionParameters) Verify() error {

--- a/config/clientparameters.go
+++ b/config/clientparameters.go
@@ -191,8 +191,19 @@ type GridParameters struct {
 }
 
 type DetectionsParameters struct {
-	HuntingParameters
-	DetectionParameters
+	Actions               []*HuntingAction            `json:"actions"`
+	Advanced              bool                        `json:"advanced"`
+	CreateLink            string                      `json:"createLink"`
+	EventFetchLimit       int                         `json:"eventFetchLimit"`
+	EventFields           map[string][]string         `json:"eventFields"`
+	EventItemsPerPage     int                         `json:"eventItemsPerPage"`
+	GroupFetchLimit       int                         `json:"groupFetchLimit"`
+	MostRecentlyUsedLimit int                         `json:"mostRecentlyUsedLimit"`
+	Presets               map[string]PresetParameters `json:"presets"`
+	Queries               []*HuntingQuery             `json:"queries"`
+	QueryBaseFilter       string                      `json:"queryBaseFilter"`
+	SafeStringMaxLength   int                         `json:"safeStringMaxLength"`
+	ViewEnabled           bool                        `json:"viewEnabled"`
 }
 
 type DetectionParameters struct {
@@ -202,9 +213,20 @@ type DetectionParameters struct {
 }
 
 func (params *DetectionsParameters) Verify() error {
-	err := params.HuntingParameters.Verify()
+	if params.GroupFetchLimit <= 0 {
+		params.GroupFetchLimit = DEFAULT_GROUP_FETCH_LIMIT
+	}
+	if params.EventFetchLimit <= 0 {
+		params.EventFetchLimit = DEFAULT_EVENT_FETCH_LIMIT
+	}
+	if params.MostRecentlyUsedLimit < 0 {
+		params.MostRecentlyUsedLimit = 0
+	}
+	if params.SafeStringMaxLength <= 0 {
+		params.SafeStringMaxLength = DEFAULT_SAFE_STRING_MAX_LENGTH
+	}
 
-	return err
+	return nil
 }
 
 func (params *DetectionParameters) Verify() error {

--- a/config/clientparameters_test.go
+++ b/config/clientparameters_test.go
@@ -91,3 +91,17 @@ func TestVerifyCaseParams(tester *testing.T) {
 	assert.Nil(tester, err)
 	assert.Equal(tester, params.MostRecentlyUsedLimit, 0)
 }
+
+func TestVerifyDetectionsParams(t *testing.T) {
+	params := &DetectionsParameters{}
+	err := params.Verify()
+	assert.Nil(t, err)
+	verifyInitialDetectionsParams(t, params)
+}
+
+func verifyInitialDetectionsParams(t *testing.T, params *DetectionsParameters) {
+	assert.Equal(t, DEFAULT_GROUP_FETCH_LIMIT, params.GroupFetchLimit)
+	assert.Equal(t, DEFAULT_EVENT_FETCH_LIMIT, params.EventFetchLimit)
+	assert.Equal(t, DEFAULT_SAFE_STRING_MAX_LENGTH, params.SafeStringMaxLength)
+	assert.Equal(t, 0, params.MostRecentlyUsedLimit)
+}

--- a/config/clientparameters_test.go
+++ b/config/clientparameters_test.go
@@ -96,12 +96,5 @@ func TestVerifyDetectionsParams(t *testing.T) {
 	params := &DetectionsParameters{}
 	err := params.Verify()
 	assert.Nil(t, err)
-	verifyInitialDetectionsParams(t, params)
-}
-
-func verifyInitialDetectionsParams(t *testing.T, params *DetectionsParameters) {
-	assert.Equal(t, DEFAULT_GROUP_FETCH_LIMIT, params.GroupFetchLimit)
-	assert.Equal(t, DEFAULT_EVENT_FETCH_LIMIT, params.EventFetchLimit)
-	assert.Equal(t, DEFAULT_SAFE_STRING_MAX_LENGTH, params.SafeStringMaxLength)
-	assert.Equal(t, 0, params.MostRecentlyUsedLimit)
+	verifyInitialHuntingParams(t, &params.HuntingParameters)
 }

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -470,7 +470,7 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 	defer func() {
 		totalTime := time.Since(totalTimeStart)
 
-		log.WithFields(log.Fields{
+		withStats := log.WithFields(log.Fields{
 			"error":      len(errMap),
 			"total":      len(IDs),
 			"modified":   len(modified),
@@ -478,7 +478,13 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 			"updateTime": update.Seconds(),
 			"syncTime":   sync.Seconds(),
 			"totalTime":  totalTime.Seconds(),
-		}).Error("bulk update Detections finished")
+		})
+
+		if len(errMap) != 0 {
+			withStats.Error("bulk action Detections finished")
+		} else {
+			withStats.Info("bulk action Detections finished")
+		}
 
 		verb := "update"
 		if body.Delete {


### PR DESCRIPTION
Detections was only using about half of the HuntingParameters so instead of embedding them, I added the fields we need. Updated the Verify and added a test inspired by how Hunt's parameters are verified and tested.

While looking for errors in a cypress test, I noticed a log statement that was unconditionally an error log when it didn't always log a problem. Fixed it.