### PR TITLE
Suricata Custom Rulesets

### DIFF
--- a/model/custom_ruleset.go
+++ b/model/custom_ruleset.go
@@ -82,7 +82,7 @@ func GetCustomRulesetsDefault(cfg map[string]interface{}, field string, dflt []*
 		ext := filepath.Ext(file)
 		if strings.ToLower(ext) != ".rules" {
 			log.WithFields(log.Fields{
-				"file": file,
+				"customRulesetFile": file,
 			}).Warn("customRulesets file should have a .rules extension")
 		}
 

--- a/model/custom_ruleset.go
+++ b/model/custom_ruleset.go
@@ -1,0 +1,102 @@
+package model
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/apex/log"
+)
+
+type CustomRuleset struct {
+	Community  bool   `json:"community"`
+	License    string `json:"license"`
+	Url        string `json:"url"`
+	TargetFile string `json:"target-file"`
+	File       string `json:"file"`
+	Ruleset    string `json:"ruleset"`
+}
+
+func GetCustomRulesetsDefault(cfg map[string]interface{}, field string, dflt []*CustomRuleset) ([]*CustomRuleset, error) {
+	cfgInter, ok := cfg[field]
+	if !ok {
+		// config doesn't have any customRulesets, no error, return defaults
+		return dflt, nil
+	}
+
+	ruleMaps, ok := cfgInter.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf(`top level config value "%s" is not an array of objects`, field)
+	}
+
+	rulesets := make([]*CustomRuleset, 0, len(ruleMaps))
+
+	for _, item := range ruleMaps {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf(`"%s" entry is not an object`, field)
+		}
+
+		file, _ := obj["file"].(string)
+		url, _ := obj["url"].(string)
+		target, _ := obj["target-file"].(string)
+
+		if file == "" && url == "" && target == "" {
+			return nil, fmt.Errorf(`missing "file" or "url"+"target-file" from "%s" entry`, field)
+		}
+
+		if url != "" && target == "" {
+			return nil, fmt.Errorf(`missing "target-file" from "%s" entry`, field)
+		}
+		if target != "" && url == "" {
+			return nil, fmt.Errorf(`missing "url" from "%s" entry`, field)
+		}
+
+		ruleset, ok := obj["ruleset"].(string)
+		if !ok {
+			return nil, fmt.Errorf(`missing "ruleset" from "%s" entry`, field)
+		}
+
+		license, ok := obj["license"].(string)
+		if !ok {
+			return nil, fmt.Errorf(`missing "license" from "%s" entry`, field)
+		}
+
+		isCommunity := false
+
+		community := obj["community"]
+		switch c := community.(type) {
+		case bool:
+			isCommunity = c
+		case int:
+			isCommunity = c != 0
+		case string:
+			var err error
+			isCommunity, err = strconv.ParseBool(c)
+			if err != nil {
+				isCommunity = false
+			}
+		}
+
+		ext := filepath.Ext(file)
+		if strings.ToLower(ext) != ".rules" {
+			log.WithFields(log.Fields{
+				"file": file,
+			}).Warn("customRulesets file should have a .rules extension")
+		}
+
+		r := &CustomRuleset{
+			File:       file,
+			Url:        url,
+			TargetFile: target,
+			License:    license,
+			Community:  isCommunity,
+			Ruleset:    ruleset,
+		}
+
+		rulesets = append(rulesets, r)
+	}
+
+	return rulesets, nil
+}

--- a/model/custom_ruleset_test.go
+++ b/model/custom_ruleset_test.go
@@ -1,0 +1,215 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+func TestGetCustomRulesetsDefault(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Cfg      map[string]interface{}
+		Default  []*CustomRuleset
+		Expected []*CustomRuleset
+		ExpError string
+	}{
+		{
+			Name: "Missing",
+			Cfg:  map[string]interface{}{},
+			Default: []*CustomRuleset{
+				{
+					Ruleset: "default",
+					License: "DRL",
+					File:    "default.rules",
+				},
+			},
+			Expected: []*CustomRuleset{
+				{
+					Ruleset: "default",
+					License: "DRL",
+					File:    "default.txt",
+				},
+			},
+		},
+		{
+			Name: "Empty",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{},
+			},
+			Default: []*CustomRuleset{
+				{
+					Ruleset: "default",
+					License: "DRL",
+					File:    "default.rules",
+				},
+			},
+			Expected: []*CustomRuleset{},
+		},
+		{
+			Name: "Valid",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{
+					map[string]interface{}{
+						"community":   true,
+						"url":         "https://example.com",
+						"target-file": "example.rules",
+						"ruleset":     "example",
+						"license":     "MIT",
+					},
+					map[string]interface{}{
+						"community": 1,
+						"file":      "example2.rules",
+						"ruleset":   "example2",
+						"license":   "MIT",
+					},
+					map[string]interface{}{
+						"community":   "T",
+						"url":         "https://example3.com",
+						"target-file": "example3.rules",
+						"ruleset":     "example3",
+						"license":     "MIT",
+					},
+					map[string]interface{}{
+						"community":   "definitely",
+						"url":         "https://example4.com",
+						"target-file": "example4.rules",
+						"ruleset":     "example4",
+						"license":     "DRL",
+					},
+				},
+			},
+			Default: []*CustomRuleset{},
+			Expected: []*CustomRuleset{
+				{
+					Community:  true,
+					Url:        "https://example.com",
+					TargetFile: "example.rules",
+					Ruleset:    "example",
+					License:    "MIT",
+				},
+				{
+					Community: true,
+					File:      "example2.rules",
+					Ruleset:   "example2",
+					License:   "MIT",
+				},
+				{
+					Community:  true,
+					Url:        "https://example3.com",
+					TargetFile: "example3.rules",
+					Ruleset:    "example3",
+					License:    "MIT",
+				},
+				{
+					Community:  false,
+					Url:        "https://example4.com",
+					TargetFile: "example4.rules",
+					Ruleset:    "example4",
+					License:    "DRL",
+				},
+			},
+		},
+		{
+			Name: "Invalid Type",
+			Cfg: map[string]interface{}{
+				"customRulesets": "invalid",
+			},
+			Default:  []*CustomRuleset{},
+			ExpError: `top level config value "customRulesets" is not an array of objects`,
+		},
+		{
+			Name: "Invalid Entry",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{
+					"invalid",
+				},
+			},
+			Default:  []*CustomRuleset{},
+			ExpError: `"customRulesets" entry is not an object`,
+		},
+		{
+			Name: "Invalid Key/Value Pairs",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{
+					map[string]interface{}{
+						"wrong": "key/value",
+					},
+				},
+			},
+			Default:  []*CustomRuleset{},
+			ExpError: `missing "file" or "url"+"target-file" from "customRulesets" entry`,
+		},
+		{
+			Name: "Missing URL",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{
+					map[string]interface{}{
+						"target-file": "example.rules",
+						"ruleset":     "example",
+						"license":     "MIT",
+					},
+				},
+			},
+			Default:  []*CustomRuleset{},
+			ExpError: `missing "url" from "customRulesets" entry`,
+		},
+		{
+			Name: "Missing Target",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{
+					map[string]interface{}{
+						"url":     "https://example.com",
+						"ruleset": "example",
+						"license": "MIT",
+					},
+				},
+			},
+			Default:  []*CustomRuleset{},
+			ExpError: `missing "target-file" from "customRulesets" entry`,
+		},
+		{
+			Name: "Missing Ruleset",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{
+					map[string]interface{}{
+						"url":         "https://example.com",
+						"target-file": "example.rules",
+						"license":     "MIT",
+					},
+				},
+			},
+			Default:  []*CustomRuleset{},
+			ExpError: `missing "ruleset" from "customRulesets" entry`,
+		},
+		{
+			Name: "Missing License",
+			Cfg: map[string]interface{}{
+				"customRulesets": []interface{}{
+					map[string]interface{}{
+						"url":         "https://example.com",
+						"target-file": "example.rules",
+						"ruleset":     "example",
+					},
+				},
+			},
+			Default:  []*CustomRuleset{},
+			ExpError: `missing "license" from "customRulesets" entry`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			out, err := GetCustomRulesetsDefault(test.Cfg, "customRulesets", test.Default)
+			if test.ExpError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.Expected, out)
+		})
+	}
+}

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1614,7 +1614,7 @@ func (e *SuricataEngine) ReadCustomRulesets() (detects []*model.Detection, err e
 		if custom.File != "" {
 			content, err = e.ReadFile(custom.File)
 			if err != nil {
-				log.WithError(err).WithField("file", custom.File).Error("unable to read custom ruleset File, skipping")
+				log.WithError(err).WithField("customRulesetFilePath", custom.File).Error("unable to read custom ruleset File, skipping")
 
 				return nil, err
 			}
@@ -1623,7 +1623,7 @@ func (e *SuricataEngine) ReadCustomRulesets() (detects []*model.Detection, err e
 
 			content, err = e.ReadFile(path)
 			if err != nil {
-				log.WithError(err).WithField("file", path).Error("unable to read custom ruleset TargetFile, skipping")
+				log.WithError(err).WithField("customRulesetTargetFilePath", path).Error("unable to read custom ruleset TargetFile, skipping")
 
 				return nil, err
 			}
@@ -1637,7 +1637,7 @@ func (e *SuricataEngine) ReadCustomRulesets() (detects []*model.Detection, err e
 
 		dets, err := e.ParseRules(string(content), custom.Ruleset, false)
 		if err != nil {
-			log.WithError(err).WithField("rulesetName", custom.Ruleset).Error("unable to parse custom ruleset, skipping")
+			log.WithError(err).WithField("customRulesetName", custom.Ruleset).Error("unable to parse custom ruleset, skipping")
 
 			return nil, err
 		}


### PR DESCRIPTION
New customRulesets config option allowing the specification of download targets or local files for import.

During a sync, the custom rulesets rules are parsed and added deterministically before deduplication. If a ruleset file or target-file can't be read, the sync is aborted otherwise the `delete unreferenced community rules` part of the sync would remove all of them.

Tests.