### PR TITLE
Account for customRulesets: null

### DIFF
--- a/model/custom_ruleset.go
+++ b/model/custom_ruleset.go
@@ -20,7 +20,7 @@ type CustomRuleset struct {
 
 func GetCustomRulesetsDefault(cfg map[string]interface{}, field string, dflt []*CustomRuleset) ([]*CustomRuleset, error) {
 	cfgInter, ok := cfg[field]
-	if !ok {
+	if !ok || cfgInter == nil {
 		// config doesn't have any customRulesets, no error, return defaults
 		return dflt, nil
 	}

--- a/model/custom_ruleset_test.go
+++ b/model/custom_ruleset_test.go
@@ -47,6 +47,26 @@ func TestGetCustomRulesetsDefault(t *testing.T) {
 			Expected: []*CustomRuleset{},
 		},
 		{
+			Name: "Nil",
+			Cfg: map[string]interface{}{
+				"customRulesets": nil,
+			},
+			Default: []*CustomRuleset{
+				{
+					Ruleset: "default",
+					License: "DRL",
+					File:    "default.rules",
+				},
+			},
+			Expected: []*CustomRuleset{
+				{
+					Ruleset: "default",
+					License: "DRL",
+					File:    "default.rules",
+				},
+			},
+		},
+		{
 			Name: "Valid",
 			Cfg: map[string]interface{}{
 				"customRulesets": []interface{}{


### PR DESCRIPTION
Update GetCustomRulesetsDefault to account for the very probably situation of the field being present but null. Add regression test.