### PR TITLE
When duplicating a suricata rule, ensure the msg value is quoted

### DIFF
--- a/server/modules/suricata/validate_test.go
+++ b/server/modules/suricata/validate_test.go
@@ -234,35 +234,46 @@ func TestUpdateForDuplication(t *testing.T) {
 	}{
 		{
 			Name:          "Normal Options",
-			Input:         `alert any any <> any any (msg:"test"; sid:1; rev:1;)`,
+			Input:         `alert http any any <> any any (msg:"test"; sid:1; rev:1;)`,
 			OptionsBefore: 3,
 			OptionsAfter:  3,
 			ExpectedOptions: []*RuleOption{
-				{Name: "msg", Value: util.Ptr("test (copy)")},
+				{Name: "msg", Value: util.Ptr(`"test (copy)"`)},
 				{Name: "sid", Value: util.Ptr(publicId)},
 				{Name: "rev", Value: util.Ptr("1")},
 			},
 		},
 		{
 			Name:          "Present but Empty Options",
-			Input:         `alert any any <> any any (msg; sid; rev;)`,
+			Input:         `alert http any any <> any any (msg; sid; rev;)`,
 			OptionsBefore: 3,
 			OptionsAfter:  3,
 			ExpectedOptions: []*RuleOption{
-				{Name: "msg", Value: util.Ptr("(copy)")},
+				{Name: "msg", Value: util.Ptr(`"(copy)"`)},
 				{Name: "sid", Value: util.Ptr(publicId)},
 				{Name: "rev", Value: nil},
 			},
 		},
 		{
 			Name:          "Missing Options",
-			Input:         `alert any any <> any any (rev;)`,
+			Input:         `alert http any any <> any any (rev;)`,
 			OptionsBefore: 1,
 			OptionsAfter:  3,
 			ExpectedOptions: []*RuleOption{
-				{Name: "msg", Value: util.Ptr("(copy)")},
+				{Name: "msg", Value: util.Ptr(`"(copy)"`)},
 				{Name: "sid", Value: util.Ptr(publicId)},
 				{Name: "rev", Value: nil},
+			},
+		},
+		{
+			Name:          "Double Quotes in Title",
+			Input:         `alert http any any <> any any (msg:"\"test\""; sid:1; rev:1;)`,
+			OptionsBefore: 3,
+			OptionsAfter:  3,
+			ExpectedOptions: []*RuleOption{
+				{Name: "msg", Value: util.Ptr(`"\"test\" (copy)"`)},
+				{Name: "sid", Value: util.Ptr(publicId)},
+				{Name: "rev", Value: util.Ptr("1")},
 			},
 		},
 	}
@@ -291,41 +302,4 @@ func TestUpdateForDuplication(t *testing.T) {
 			}
 		})
 	}
-
-	// rule, err = ParseSuricataRule(`alert any any <> any any (rev:1;)`)
-	// assert.NoError(t, err)
-	// assert.NotNil(t, rule)
-	//
-	// assert.Equal(t, len(rule.Options), 1)
-	// rev, ok = rule.GetOption("rev")
-	// assert.True(t, ok)
-	// assert.NotNil(t, rev)
-	// assert.Equal(t, "1", *rev)
-	//
-	// sid, ok = rule.GetOption("sid")
-	// assert.False(t, ok)
-	// assert.Nil(t, sid)
-	//
-	// msg, ok = rule.GetOption("msg")
-	// assert.False(t, ok)
-	// assert.Nil(t, msg)
-	//
-	// rule.UpdateForDuplication("1")
-	//
-	// assert.Equal(t, len(rule.Options), 3)
-	//
-	// sid, ok = rule.GetOption("sid")
-	// assert.True(t, ok)
-	// assert.NotNil(t, sid)
-	// assert.Equal(t, "1", *sid)
-	//
-	// msg, ok = rule.GetOption("msg")
-	// assert.True(t, ok)
-	// assert.NotNil(t, msg)
-	// assert.Equal(t, "(copy)", *msg)
-	//
-	// rev, ok = rule.GetOption("rev")
-	// assert.True(t, ok)
-	// assert.NotNil(t, rev)
-	// assert.Equal(t, "1", *rev)
 }


### PR DESCRIPTION
The msg option must be quoted for suricata to accept the rule. Now we use strconv.Quote to put the quotes we removed back.

However strconv.Quote plays with escape sequences because it tries to convert Target Strings to the source code string that when printed would print the Target String. Because we're still dealing with source (suricata source code) we must unescape everything in the string to get the desired result.