### PR TITLE
New Query Param for Advanced Config

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1353,7 +1353,7 @@
                       <!-- ip -->
                       <v-text-field v-if="newOverride.type === 'suppress'" id="new-override-ip-edit" v-model="newOverride.ip" :rules="[rules.required, rules.cidrFormat]" persistent-hint :hint="i18n.ipCidr" data-aid="detection_new_override_suppress_ip_input">
                         <template v-slot:append-outer>
-                          <router-link :to="{ name: 'config', query: { s: 'suricata.config.vars' }}" target="_blank" data-aid="new_override_ip_edit_config_shortcut">
+                          <router-link :to="{ name: 'config', query: { s: 'suricata.config.vars', a: '1', e: '1' }}" target="_blank" data-aid="new_override_ip_edit_config_shortcut">
                             <v-icon>fa fa-gear</v-icon>
                           </router-link>
                         </template>

--- a/html/js/routes/config.js
+++ b/html/js/routes/config.js
@@ -63,11 +63,19 @@ routes.push({ path: '/config', name: 'config', component: {
   },
   methods: {
     processRouteParameters() {
+      if (this.$route.query.a == "1") {
+        this.advanced = true;
+      }
       if (this.$route.query.f) {
         this.search = this.$route.query.f;
       }
       if (this.$route.query.e == "1") {
         this.autoExpand = true;
+        if (this.advanced) {
+          this.$nextTick(() => {
+            this.autoExpand = true;
+          });
+        }
       }
       if (this.$route.query.s) {
         this.autoSelect = this.$route.query.s;
@@ -326,7 +334,7 @@ routes.push({ path: '/config', name: 'config', component: {
       }
       this.recomputeAvailableNodes(this.findActiveSetting());
       this.activeBackup = [...this.active];
-      this.showDuplicate = false; 
+      this.showDuplicate = false;
       this.showDefault = false;
       window.scrollTo(0,0);
     },
@@ -507,7 +515,7 @@ routes.push({ path: '/config', name: 'config', component: {
     },
     toggleDuplicate(setting) {
       this.duplicateId = this.suggestDuplicateName(setting);
-      this.showDuplicate = !this.showDuplicate; 
+      this.showDuplicate = !this.showDuplicate;
     },
     suggestDuplicateName(setting) {
       return setting.name + "_dup";

--- a/html/js/routes/config.test.js
+++ b/html/js/routes/config.test.js
@@ -9,11 +9,11 @@ require('./config.js');
 
 global.GridMemberAccepted = "accepted";
 
-const a = { 
-  category: 'general', 
-  id: 'fake.setting.foo', 
-  description: 'Nearby', 
-  title: 'Farout', 
+const a = {
+  category: 'general',
+  id: 'fake.setting.foo',
+  description: 'Nearby',
+  title: 'Farout',
   nodeValues: new Map(),
   regex: "True|False",
   regexFailureMessage: "Wrong!",
@@ -50,7 +50,7 @@ test('loadData', async () => {
   const expectedSettings = [{
       "advanced": undefined,
       "default": null,
-      "defaultAvailable": false, 
+      "defaultAvailable": false,
       "description": "Nearby",
       "duplicates": undefined,
       "file": undefined,
@@ -73,7 +73,7 @@ test('loadData', async () => {
     {
       "advanced": undefined,
       "default": undefined,
-      "defaultAvailable": undefined, 
+      "defaultAvailable": undefined,
       "description": "NADA",
       "duplicates": undefined,
       "file": undefined,
@@ -96,7 +96,7 @@ test('loadData', async () => {
     {
       "advanced": undefined,
       "default": undefined,
-      "defaultAvailable": undefined, 
+      "defaultAvailable": undefined,
       "description": "Cocoa",
       "duplicates": undefined,
       "file": undefined,
@@ -125,79 +125,79 @@ test('loadData', async () => {
           "children": [
             {
               "advanced": undefined,
-              "default": null, 
-              "defaultAvailable": false, 
-              "description": "Nearby", 
+              "default": null,
+              "defaultAvailable": false,
+              "description": "Nearby",
               "duplicates": undefined,
               "file": undefined,
-              "global": false, 
+              "global": false,
               "helpLink": undefined,
-              "id": "fake.setting.foo", 
-              "multiline": undefined, 
-              "name": "foo", 
-              "node": undefined, 
-              "nodeValues": m1, 
-              "readonly": undefined, 
+              "id": "fake.setting.foo",
+              "multiline": undefined,
+              "name": "foo",
+              "node": undefined,
+              "nodeValues": m1,
+              "readonly": undefined,
               "readonlyUi": undefined,
               "regex": "True|False",
               "regexFailureMessage": "Wrong!",
-              "sensitive": undefined, 
+              "sensitive": undefined,
               "syntax": undefined,
-              "title": "Farout", 
+              "title": "Farout",
               "value": null
-            }, 
+            },
             {
               "advanced": undefined,
               "default": undefined,
-              "defaultAvailable": undefined, 
-              "description": "Cocoa", 
+              "defaultAvailable": undefined,
+              "description": "Cocoa",
               "duplicates": undefined,
               "file": undefined,
-              "global": undefined, 
+              "global": undefined,
               "helpLink": undefined,
-              "id": "fake.setting.bar", 
-              "multiline": undefined, 
-              "name": "bar", 
-              "node": false, 
-              "nodeValues": new Map(), 
-              "readonly": undefined, 
+              "id": "fake.setting.bar",
+              "multiline": undefined,
+              "name": "bar",
+              "node": false,
+              "nodeValues": new Map(),
+              "readonly": undefined,
               "readonlyUi": undefined,
               "regex": undefined,
               "regexFailureMessage": undefined,
-              "sensitive": undefined, 
+              "sensitive": undefined,
               "syntax": undefined,
-              "title": "Barley", 
+              "title": "Barley",
               "value": undefined
             }
-          ], 
-          "id": "fake.setting", 
+          ],
+          "id": "fake.setting",
           "name": "setting"
         }
-      ], 
-      "id": "fake", 
+      ],
+      "id": "fake",
       "name": "fake"
-    }, 
+    },
     {
       "advanced": undefined,
       "default": undefined,
-      "defaultAvailable": undefined, 
-      "description": "NADA", 
+      "defaultAvailable": undefined,
+      "description": "NADA",
       "duplicates": undefined,
       "file": undefined,
-      "global": undefined, 
+      "global": undefined,
       "helpLink": undefined,
-      "id": "car", 
-      "multiline": undefined, 
-      "name": "car", 
-      "node": false, 
-      "nodeValues": new Map(), 
-      "readonly": undefined, 
+      "id": "car",
+      "multiline": undefined,
+      "name": "car",
+      "node": false,
+      "nodeValues": new Map(),
+      "readonly": undefined,
       "readonlyUi": undefined,
       "regex": undefined,
       "regexFailureMessage": undefined,
-      "sensitive": undefined, 
+      "sensitive": undefined,
       "syntax": undefined,
-      "title": "CCA", 
+      "title": "CCA",
       "value": undefined
     }
   ];
@@ -258,7 +258,7 @@ test('isPendingSave', () => {
   const values = new Map();
   values.set('bar', '123');
   const setting = { id: 'foo', value: "something", nodeValues: values};
-  
+
   // Form key is null, nothing pending
   var nodeId = null;
   expect(comp.isPendingSave(setting, nodeId)).toBe(false);
@@ -294,7 +294,7 @@ test('reset', () => {
 
 setupSettings = () => {
   comp.cancelDialog = true;
-  comp.nodes = [{id: "n1", status: GridMemberAccepted }, {id: "n1a", status: GridMemberAccepted }, 
+  comp.nodes = [{id: "n1", status: GridMemberAccepted }, {id: "n1a", status: GridMemberAccepted },
                 {id: "n2", name: "node2", role: "standalone", status: "accepted" }, {id:"n3", status: "pending" }];
 
   const nodeValues = new Map();
@@ -555,7 +555,7 @@ test('addNode', () => {
   expect(comp.settings[0].nodeValues.get('n2')).toBe(undefined);
   expect(comp.form.key).toBe("n1");
   expect(comp.form.value).toBe("touched-value");
-  expect(comp.cancelDialog).toBe(true);  
+  expect(comp.cancelDialog).toBe(true);
 });
 
 test('addToNode_Malformed', () => {
@@ -622,4 +622,65 @@ test('isReadOnly', () => {
   expect(comp.isReadOnly(setting)).toBe(true);
   setting.readonly = true;
   expect(comp.isReadOnly(setting)).toBe(true);
+});
+
+test('processRouteParameters', () => {
+  comp.$route.query = {
+    f: 'search',
+  };
+  comp.$nextTick = jest.fn();
+
+  comp.processRouteParameters();
+
+  expect(comp.search).toBe('search');
+  expect(comp.autoSelect).toBe('');
+  expect(comp.autoExpand).toBe(false);
+  expect(comp.searchFilter).toBe('search');
+  expect(comp.advanced).toBe(false);
+  expect(comp.$nextTick).toHaveBeenCalledTimes(0);
+
+  comp.search = '';
+  comp.searchFilter = '';
+  comp.$route.query = {
+    e: '1',
+  };
+
+  comp.processRouteParameters();
+
+  expect(comp.search).toBe('');
+  expect(comp.autoSelect).toBe('');
+  expect(comp.autoExpand).toBe(true);
+  expect(comp.searchFilter).toBe('');
+  expect(comp.advanced).toBe(false);
+  expect(comp.$nextTick).toHaveBeenCalledTimes(0);
+
+  comp.autoExpand = false;
+  comp.$route.query = {
+    a: '1',
+  };
+
+  comp.processRouteParameters();
+
+  expect(comp.search).toBe('');
+  expect(comp.autoSelect).toBe('');
+  expect(comp.autoExpand).toBe(false);
+  expect(comp.searchFilter).toBe('');
+  expect(comp.advanced).toBe(true);
+  expect(comp.$nextTick).toHaveBeenCalledTimes(0);
+
+  comp.advanced = false
+  comp.$route.query = {
+    a: '1',
+    e: '1',
+    f: 'search',
+  };
+
+  comp.processRouteParameters();
+
+  expect(comp.search).toBe('search');
+  expect(comp.autoSelect).toBe('');
+  expect(comp.autoExpand).toBe(true);
+  expect(comp.searchFilter).toBe('search');
+  expect(comp.advanced).toBe(true);
+  expect(comp.$nextTick).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
Specifying `a=1` on the query string will now cause the config to load with Advanced already toggled to true.

The nextTick is necessary because on mount, the browser will call processRouterParameters and then loadData. The component is also watching `advanced` and will call refreshTree if it changes.

What happens is that onMounted will call processRouterParameters and set advanced which queues up a refreshTree in the event stack. Then execution exits processRouterParameters and enters loadData. loadData is async so the first half of the function up to the request executes. Then the queued up refreshTree executes. refreshTree checks autoExpand, expands, and then unsets autoExpand. When refreshTree finishes, control is eventually returned to the async part of loadData because the request came back. The second half of loadData calls refreshTree, but this time autoExpand is false so the tree isn't expanded.

With the $nextTick, I queue up the call to refreshTree same as before when I modify advanced in processRouterParameters, then nextTick queues up a function to set autoExpand = true again but after that refreshTree event in the queue. Now when loadData calls refreshTree, autoExpand is set, and the tree expands as expected. We only need to expand on nextTick if we load the page as advanced.