### PR TITLE
Add Suricata Tests

### DIFF
--- a/server/modules/detections/handmock/mock_dir_entry.go
+++ b/server/modules/detections/handmock/mock_dir_entry.go
@@ -1,0 +1,44 @@
+package handmock
+
+import (
+	"io/fs"
+	"time"
+)
+
+type MockDirEntry struct {
+	Filename string
+	Dir      bool
+	FMode    fs.FileMode
+}
+
+func (mde *MockDirEntry) Name() string {
+	return mde.Filename
+}
+
+func (mde *MockDirEntry) IsDir() bool {
+	return mde.Dir
+}
+
+func (mde *MockDirEntry) Type() fs.FileMode {
+	return mde.FMode
+}
+
+func (mde *MockDirEntry) ModTime() time.Time {
+	return time.Now()
+}
+
+func (mde *MockDirEntry) Mode() fs.FileMode {
+	return mde.FMode
+}
+
+func (mde *MockDirEntry) Size() int64 {
+	return 100
+}
+
+func (mde *MockDirEntry) Sys() any {
+	return nil
+}
+
+func (mde *MockDirEntry) Info() (fs.FileInfo, error) {
+	return mde, nil
+}

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/module"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/handmock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/elastalert/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 
@@ -593,8 +594,8 @@ license: Elastic-2.0
 
 	mio := mock.NewMockIOManager(gomock.NewController(t))
 	mio.EXPECT().WalkDir(gomock.Eq("repo-path"), gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
-		return fn("rules/so_soc_failed_login.yml", &MockDirEntry{
-			name: "so_soc_failed_login.yml",
+		return fn("rules/so_soc_failed_login.yml", &handmock.MockDirEntry{
+			Filename: "so_soc_failed_login.yml",
 		}, nil)
 	})
 	mio.EXPECT().ReadFile(gomock.Eq("rules/so_soc_failed_login.yml")).Return([]byte(data), nil)
@@ -783,44 +784,6 @@ falsepositives:
   - Unlikely`
 )
 
-type MockDirEntry struct {
-	name  string
-	isDir bool
-	typ   fs.FileMode
-}
-
-func (mde *MockDirEntry) Name() string {
-	return mde.name
-}
-
-func (mde *MockDirEntry) IsDir() bool {
-	return mde.isDir
-}
-
-func (mde *MockDirEntry) Type() fs.FileMode {
-	return mde.typ
-}
-
-func (mde *MockDirEntry) ModTime() time.Time {
-	return time.Now()
-}
-
-func (mde *MockDirEntry) Mode() fs.FileMode {
-	return mde.typ
-}
-
-func (mde *MockDirEntry) Size() int64 {
-	return 100
-}
-
-func (mde *MockDirEntry) Sys() any {
-	return nil
-}
-
-func (mde *MockDirEntry) Info() (fs.FileInfo, error) {
-	return mde, nil
-}
-
 func TestSyncElastAlert(t *testing.T) {
 	t.Parallel()
 
@@ -863,15 +826,15 @@ func TestSyncElastAlert(t *testing.T) {
 				// IndexExistingRules
 				filename := SimpleRuleSID + ".yml"
 				m.EXPECT().ReadDir(mod.elastAlertRulesFolder).Return([]fs.DirEntry{
-					&MockDirEntry{
-						name: filename,
+					&handmock.MockDirEntry{
+						Filename: filename,
 					},
-					&MockDirEntry{
-						name:  "ignored_dir",
-						isDir: true,
+					&handmock.MockDirEntry{
+						Filename: "ignored_dir",
+						Dir:      true,
 					},
-					&MockDirEntry{
-						name: "ignored.txt",
+					&handmock.MockDirEntry{
+						Filename: "ignored.txt",
 					},
 				}, nil)
 				// DeleteFile when disabling
@@ -1006,18 +969,18 @@ func TestGetDeployedPublicIds(t *testing.T) {
 	path := "path"
 
 	mio.EXPECT().ReadDir(path).Return([]fs.DirEntry{
-		&MockDirEntry{
-			name: "00000000-0000-0000-0000-000000000000.yml",
+		&handmock.MockDirEntry{
+			Filename: "00000000-0000-0000-0000-000000000000.yml",
 		},
-		&MockDirEntry{
-			name: "11111111-1111-1111-1111-111111111111.yaml",
+		&handmock.MockDirEntry{
+			Filename: "11111111-1111-1111-1111-111111111111.yaml",
 		},
-		&MockDirEntry{
-			name:  "ignored_dir",
-			isDir: true,
+		&handmock.MockDirEntry{
+			Filename: "ignored_dir",
+			Dir:      true,
 		},
-		&MockDirEntry{
-			name: "ignored.txt",
+		&handmock.MockDirEntry{
+			Filename: "ignored.txt",
 		},
 	}, nil)
 

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -8,6 +8,8 @@ package suricata
 import (
 	"context"
 	"errors"
+	"io/fs"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -17,6 +19,7 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/module"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	servermock "github.com/security-onion-solutions/securityonion-soc/server/mock"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/handmock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/suricata/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 	"github.com/security-onion-solutions/securityonion-soc/web"
@@ -105,6 +108,87 @@ func TestSettingByID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadAndHash(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	content := "content"
+
+	iom := mock.NewMockIOManager(ctrl)
+	iom.EXPECT().ReadFile("file").Return([]byte(content), nil)
+
+	e := &SuricataEngine{
+		srv:       &server.Server{},
+		IOManager: iom,
+	}
+
+	fileContent, sha256Hash, err := e.readAndHash("file")
+
+	assert.NoError(t, err)
+	assert.Equal(t, content, fileContent)
+	assert.Equal(t, "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73", sha256Hash)
+}
+
+func TestReadFingerprint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	content := " fingerprint\n\t"
+
+	iom := mock.NewMockIOManager(ctrl)
+	iom.EXPECT().ReadFile("file").Return([]byte(content), nil)
+
+	e := &SuricataEngine{
+		srv:       &server.Server{},
+		IOManager: iom,
+	}
+
+	fingerprint, ok, err := e.readFingerprint("file")
+
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.NotNil(t, fingerprint)
+	assert.Equal(t, "fingerprint", *fingerprint)
+}
+
+func TestReadFingerprintDoesNotExist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+	iom.EXPECT().ReadFile("file").Return(nil, os.ErrNotExist)
+
+	e := &SuricataEngine{
+		srv:       &server.Server{},
+		IOManager: iom,
+	}
+
+	fingerprint, ok, err := e.readFingerprint("file")
+
+	assert.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, fingerprint)
+}
+
+func TestReadFingerprintError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+	iom.EXPECT().ReadFile("file").Return(nil, errors.New("error"))
+
+	e := &SuricataEngine{
+		srv:       &server.Server{},
+		IOManager: iom,
+	}
+
+	fingerprint, ok, err := e.readFingerprint("file")
+
+	assert.Error(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, fingerprint)
 }
 
 func TestExtractSID(t *testing.T) {
@@ -1740,4 +1824,51 @@ func TestReadCustomRulesets(t *testing.T) {
 			assert.Equal(t, test.ExpDetections, detects)
 		})
 	}
+}
+
+func TestCheckForMigrations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+
+	iom.EXPECT().ReadDir("/opt/so/conf/soc/migrations/").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: "suricata-migration-2.4.70",
+		},
+		&handmock.MockDirEntry{
+			Filename: "etc",
+			Dir:      true,
+		},
+		&handmock.MockDirEntry{
+			Filename: "not-a-migration",
+		},
+	}, nil)
+
+	m2470 := 0
+	m2471 := 0
+
+	e := &SuricataEngine{
+		migrations: map[string]func(string) error{
+			"2.4.70": func(string) error {
+				m2470++
+
+				return nil
+			},
+			"2.4.71": func(string) error {
+				// shouldn't be called
+				m2471++
+
+				return nil
+			},
+		},
+		IOManager: iom,
+	}
+
+	e.checkForMigrations()
+
+	assert.Equal(t, m2470, 1)
+	assert.Equal(t, m2471, 0)
+	assert.False(t, e.EngineState.MigrationFailure)
+	assert.False(t, e.EngineState.Migrating)
 }


### PR DESCRIPTION
Reorganize MockDirEntry so other engines can use it. Update old references.

Refactored readAndHash and readFingerprint to be attached to the engine and use the IOManager for it's IO. Added tests for these functions.

Added a migration test.