### PR TITLE
Unified Template Checking

### DIFF
--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 
+	"github.com/apex/log"
 	"github.com/go-chi/chi/v5"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
All engines need to know that the so-detection template has been created before they can begin syncing. However they were all checking for the same template and keeping track of this separately.

Now there's a common function they all call to check for the template. A mutex prevents checking too often and once the template is found the function will return true without rechecking until the service is restarted.