### PR TITLE
Updated history highlight to accurately detect changes in suricata rule severity without implicitly highlighting the content field.

### DIFF
--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -537,8 +537,21 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 					newDict['content'] = JSON.stringify(contentJsonNew);
 				
 				} else if (oldDict['engine'] === 'suricata'){
-					oldDict['content'] = oldDict['content'].replaceAll(/\s/g,'').replaceAll('msg:"' + oldDict['title'].replaceAll(/\s/g,'') + '"', '').replaceAll('signature_severity' + oldDict['severity'].replaceAll(/\s/g,''), '');
-					newDict['content'] = newDict['content'].replaceAll(/\s/g,'').replaceAll('msg:"' + newDict['title'].replaceAll(/\s/g,'') + '"', '').replaceAll('signature_severity' + newDict['severity'].replaceAll(/\s/g,''), '');
+					let sev1 = oldDict['severity'];
+					let sev2 = newDict['severity'];			
+					let reversedSevTranslations = Object.fromEntries(
+						Object.entries(this.severityTranslations).map(([k, v]) => [v, k])
+					);
+
+					if (reversedSevTranslations.hasOwnProperty(sev1)) sev1 = reversedSevTranslations[sev1];
+					if (reversedSevTranslations.hasOwnProperty(sev2)) sev2 = reversedSevTranslations[sev2];
+
+					regex1 = new RegExp('signature_severity' + sev1, 'ig');
+					regex2 = new RegExp('signature_severity' + sev2, 'ig');
+
+					oldDict['content'] = oldDict['content'].replaceAll(/\s/g,'').replaceAll('msg:"' + oldDict['title'].replaceAll(/\s/g,'') + '"', '').replaceAll(regex1, '');
+					newDict['content'] = newDict['content'].replaceAll(/\s/g,'').replaceAll('msg:"' + newDict['title'].replaceAll(/\s/g,'') + '"', '').replaceAll(regex2, '');
+					
 				} else {
 					oldDict['content'] = oldDict['content'].replaceAll(/\s/g,'').replaceAll('rule' + oldDict['title'].replaceAll(/\s/g,''), '').replaceAll('description="' + oldDict['description'].replaceAll(/\s/g,'') + '"', '');
 					newDict['content'] = newDict['content'].replaceAll(/\s/g,'').replaceAll('rule' + newDict['title'].replaceAll(/\s/g,''), '').replaceAll('description="' + newDict['description'].replaceAll(/\s/g,'') + '"', '');

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -725,10 +725,10 @@ test('findHistoryChange', () => {
 			"operation": "create",
 			"publicId": "1997691",
 			"title": "test rule",
-			"severity": "unknown",
+			"severity": "low",
 			"author": "matthew.wright@securityonionsolutions.com",
 			"description": "Detection description not yet provided",
-			"content": "alert http $EXTERNAL_NET any -> $HOME_NET any (msg:\"test rule\"; content:\"example\"; sid:1997691; rev:1;)\n",
+			"content": "alert http $EXTERNAL_NET any -> $HOME_NET any (msg:\"test rule\"; content:\"example\"; sid:1997691; rev:1; metadata:signature_severity Minor;)\n",
 			"isEnabled": false,
 			"isReporting": false,
 			"isCommunity": false,
@@ -747,11 +747,11 @@ test('findHistoryChange', () => {
 			"kind": "detection",
 			"operation": "update",
 			"publicId": "1997691",
-			"title": "test rule updated",
-			"severity": "unknown",
+			"title": "test rule",
+			"severity": "high",
 			"author": "matthew.wright@securityonionsolutions.com",
 			"description": "Detection description not yet provided",
-			"content": "alert http $EXTERNAL_NET any -> $HOME_NET any (msg:\"test rule updated\"; content:\"example\"; sid:1997691; rev:1;)\n",
+			"content": "alert http $EXTERNAL_NET any -> $HOME_NET any (msg:\"test rule\"; content:\"example\"; sid:1997691; rev:1; metadata:signature_severity Major;)\n",
 			"isEnabled": false,
 			"isReporting": false,
 			"isCommunity": false,
@@ -763,9 +763,10 @@ test('findHistoryChange', () => {
 			"license": "Apache-2.0"
 		}
 	];
+	comp.severityTranslations = { "major" : "high", "minor" : "low" };
 	id = comp.history[1]['id'];
 	comp.findHistoryChange(id);
-	expect(comp.changedKeys[id]).toStrictEqual(['title']);
+	expect(comp.changedKeys[id]).toStrictEqual(['severity']);
 
 	// strelka
 	comp.history = [
@@ -799,12 +800,12 @@ test('findHistoryChange', () => {
 			"userId": "5ac4acbe-6299-463d-9449-9a728ec48ab8",
 			"kind": "detection",
 			"operation": "update",
-			"publicId": "testRuleStrelka2",
-			"title": "testRuleStrelka2",
+			"publicId": "testRuleStrelka",
+			"title": "testRuleStrelka",
 			"severity": "unknown",
 			"author": "matthew.wright@securityonionsolutions.com",
-			"description": "Generic YARA Rule",
-			"content": "rule testRuleStrelka2 // This identifier _must_ be unique\n{\n    meta:\n        description=\"Generic YARA Rule\"\n        author = \"@SecurityOnion\"\n        date = \"YYYY-MM-DD\"\n        reference = \"https://local.invalid\"\n    strings:\n        $my_text_string = \"text here\"\n        $my_hex_string = { E2 34 A1 C8 23 FB }\n    condition:\n        filesize < 3MB and ($my_text_string or $my_hex_string)\n}\n",
+			"description": "Generic YARA Rule updated",
+			"content": "rule testRuleStrelka // This identifier _must_ be unique\n{\n    meta:\n        description=\"Generic YARA Rule updated\"\n        author = \"@SecurityOnion\"\n        date = \"YYYY-MM-DD\"\n        reference = \"https://local.invalid\"\n    strings:\n        $my_text_string = \"text here\"\n        $my_hex_string = { E2 34 A1 C8 23 FB }\n    condition:\n        filesize < 3MB and ($my_text_string or $my_hex_string)\n}\n",
 			"isEnabled": false,
 			"isReporting": false,
 			"isCommunity": false,
@@ -818,7 +819,7 @@ test('findHistoryChange', () => {
 	];
 	id = comp.history[1]['id'];
 	comp.findHistoryChange(id);
-	expect(comp.changedKeys[id]).toStrictEqual(['title']);
+	expect(comp.changedKeys[id]).toStrictEqual(['description']);
 });
 
 test('checkChangedKey', () => {


### PR DESCRIPTION
Utilized severityTranslations dictionary and regualar expressions to avoid highlighting the content field when unnecessary in suricata rule updates.