### PR TITLE
Unify Sync

### DIFF
--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -137,7 +137,7 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 	// pull or clone repos
 	for _, repo := range rulesRepos {
 		if !*isRunning {
-			return nil, false, fmt.Errorf("module has stopped running")
+			return nil, false, ErrModuleStopped
 		}
 
 		parser, err := url.Parse(repo.Repo)

--- a/server/modules/detections/handmock/mock_dir_entry.go
+++ b/server/modules/detections/handmock/mock_dir_entry.go
@@ -1,3 +1,8 @@
+// Copyright 2020-2024 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
 package handmock
 
 import (

--- a/server/modules/detections/integrity_check.go
+++ b/server/modules/detections/integrity_check.go
@@ -18,7 +18,7 @@ var ErrIntCheckerStopped = fmt.Errorf("integrity checker has stopped running")
 var ErrIntCheckFailed = fmt.Errorf("integrity check failed; discrepancies found")
 
 type IntegrityChecked interface {
-	IntegrityCheck(bool) ([]string, []string, error)
+	IntegrityCheck(bool, *log.Entry) ([]string, []string, error)
 	InterruptSync(forceFull bool, notify bool)
 	IsRunning() bool
 }
@@ -37,7 +37,7 @@ func IntegrityChecker(engName model.EngineName, eng IntegrityChecked, data *Inte
 		data.IsRunning = false
 	}()
 
-	logger := log.WithField("engineName", engName)
+	logger := log.WithField("detectionEngine", engName)
 	failCount := uint(0)
 
 	for {
@@ -56,7 +56,7 @@ func IntegrityChecker(engName model.EngineName, eng IntegrityChecked, data *Inte
 			continue
 		}
 
-		_, _, err := eng.IntegrityCheck(true)
+		_, _, err := eng.IntegrityCheck(true, logger)
 		if err != nil {
 			if err != ErrIntCheckerStopped {
 				failCount++

--- a/server/modules/detections/io_manager.go
+++ b/server/modules/detections/io_manager.go
@@ -1,3 +1,8 @@
+// Copyright 2020-2024 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
 package detections
 
 import (

--- a/server/modules/detections/io_manager_test.go
+++ b/server/modules/detections/io_manager_test.go
@@ -1,3 +1,8 @@
+// Copyright 2020-2024 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
 package detections
 
 import (

--- a/server/modules/detections/sync.go
+++ b/server/modules/detections/sync.go
@@ -36,10 +36,9 @@ type SyncSchedulerParams struct {
 	StateFilePath                        string
 	CommunityRulesImportFrequencySeconds int
 	CommunityRulesImportErrorSeconds     int
-	IOManager
 }
 
-func SyncScheduler(e DetailedDetectionEngine, syncParams *SyncSchedulerParams, engineState *model.EngineState, engName model.EngineName, isRunning *bool) {
+func SyncScheduler(e DetailedDetectionEngine, syncParams *SyncSchedulerParams, engineState *model.EngineState, engName model.EngineName, isRunning *bool, iom IOManager) {
 	syncParams.SyncThread.Add(1)
 	defer func() {
 		syncParams.SyncThread.Done()

--- a/server/modules/detections/sync.go
+++ b/server/modules/detections/sync.go
@@ -1,0 +1,120 @@
+// Copyright 2020-2024 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package detections
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/util"
+)
+
+var (
+	ErrSyncFailed    = errors.New("failed to sync community rules")
+	ErrModuleStopped = errors.New("module stopped")
+)
+
+type DetailedDetectionEngine interface {
+	ResumeIntegrityChecker()
+	PauseIntegrityChecker()
+	Sync(bool) error
+	IOManager
+}
+
+type SyncSchedulerParams struct {
+	SyncThread                           *sync.WaitGroup
+	InterruptChan                        chan bool
+	StateFilePath                        string
+	CommunityRulesImportFrequencySeconds int
+	CommunityRulesImportErrorSeconds     int
+	IOManager
+}
+
+func SyncScheduler(e DetailedDetectionEngine, syncParams *SyncSchedulerParams, engineState *model.EngineState, engName model.EngineName, isRunning *bool) {
+	syncParams.SyncThread.Add(1)
+	defer func() {
+		syncParams.SyncThread.Done()
+		*isRunning = false
+	}()
+
+	var lastSyncSuccess *bool
+
+	lastImport, timerDur := DetermineWaitTime(e, syncParams.StateFilePath, time.Duration(syncParams.CommunityRulesImportFrequencySeconds)*time.Second)
+
+	logger := log.WithField("detectionEngineName", engName)
+
+	for *isRunning {
+		if lastImport == nil && lastSyncSuccess != nil && *lastSyncSuccess {
+			lastImport = util.Ptr(uint64(time.Now().UnixMilli()))
+		}
+
+		engineState.Syncing = false
+		engineState.Importing = lastImport == nil
+		engineState.Migrating = false
+		engineState.SyncFailure = lastSyncSuccess != nil && !*lastSyncSuccess
+
+		forceSync := false
+
+		if lastSyncSuccess != nil {
+			if *lastSyncSuccess {
+				timerDur = time.Second * time.Duration(syncParams.CommunityRulesImportFrequencySeconds)
+			} else {
+				timerDur = time.Second * time.Duration(syncParams.CommunityRulesImportErrorSeconds)
+				forceSync = true
+			}
+		}
+
+		timer := time.NewTimer(timerDur)
+
+		lastSyncStatus := "nil"
+		if lastSyncSuccess != nil {
+			lastSyncStatus = strconv.FormatBool(*lastSyncSuccess)
+		}
+
+		logger.WithFields(log.Fields{
+			"waitTimeSeconds":   timerDur.Seconds(),
+			"forceSync":         forceSync,
+			"lastSyncSuccess":   lastSyncStatus,
+			"expectedStartTime": time.Now().Add(timerDur).Format(time.RFC3339),
+		}).Info("waiting for next community rules sync")
+
+		e.ResumeIntegrityChecker()
+
+		select {
+		case <-timer.C:
+		case typ := <-syncParams.InterruptChan:
+			forceSync = forceSync || typ
+		}
+
+		e.PauseIntegrityChecker()
+
+		if !*isRunning {
+			break
+		}
+
+		if lastImport == nil {
+			forceSync = true
+		}
+
+		lastSyncSuccess = util.Ptr(false)
+
+		err := e.Sync(forceSync)
+		if err != nil {
+			if strings.Contains(err.Error(), "module stopped") {
+				logger.Info("module stopped, exiting sync scheduler loop")
+				return
+			}
+			logger.WithError(err).Error("failed to sync community rules")
+		} else {
+			*lastSyncSuccess = true
+		}
+	}
+}

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -22,7 +23,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -41,8 +41,6 @@ import (
 	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
 )
-
-var errModuleStopped = fmt.Errorf("elastalert module has stopped running")
 
 const (
 	DEFAULT_AIRGAP_BASE_PATH                         = "/nsm/rules/detect-sigma/rulesets/"
@@ -69,34 +67,30 @@ var acceptedExtensions = map[string]bool{
 }
 
 type ElastAlertEngine struct {
-	srv                                  *server.Server
-	airgapBasePath                       string
-	communityRulesImportFrequencySeconds int
-	communityRulesImportErrorSeconds     int
-	failAfterConsecutiveErrorCount       int
-	sigmaPackageDownloadTemplate         string
-	elastAlertRulesFolder                string
-	rulesFingerprintFile                 string
-	sigmaPipelineFinal                   string
-	sigmaPipelineSO                      string
-	sigmaPipelinesFingerprintFile        string
-	sigmaRulePackages                    []string
-	autoEnabledSigmaRules                []string
-	additionalAlerters                   []string
-	rulesRepos                           []*model.RuleRepo
-	reposFolder                          string
-	isRunning                            bool
-	syncThread                           *sync.WaitGroup
-	interruptSync                        chan bool
-	interm                               sync.Mutex
-	allowRegex                           *regexp.Regexp
-	denyRegex                            *regexp.Regexp
-	airgapEnabled                        bool
-	notify                               bool
-	stateFilePath                        string
+	srv                            *server.Server
+	airgapBasePath                 string
+	failAfterConsecutiveErrorCount int
+	sigmaPackageDownloadTemplate   string
+	elastAlertRulesFolder          string
+	rulesFingerprintFile           string
+	sigmaPipelineFinal             string
+	sigmaPipelineSO                string
+	sigmaPipelinesFingerprintFile  string
+	sigmaRulePackages              []string
+	autoEnabledSigmaRules          []string
+	additionalAlerters             []string
+	rulesRepos                     []*model.RuleRepo
+	reposFolder                    string
+	isRunning                      bool
+	interm                         sync.Mutex
+	allowRegex                     *regexp.Regexp
+	denyRegex                      *regexp.Regexp
+	airgapEnabled                  bool
+	notify                         bool
+	writeNoRead                    *string
+	detections.SyncSchedulerParams
 	detections.IntegrityCheckerData
 	model.EngineState
-	detections.IOManager
 }
 
 func checkRulesetEnabled(e *ElastAlertEngine, det *model.Detection) {
@@ -135,13 +129,13 @@ func (e *ElastAlertEngine) GetState() *model.EngineState {
 }
 
 func (e *ElastAlertEngine) Init(config module.ModuleConfig) (err error) {
-	e.syncThread = &sync.WaitGroup{}
-	e.interruptSync = make(chan bool, 1)
+	e.SyncThread = &sync.WaitGroup{}
+	e.InterruptChan = make(chan bool, 1)
 	e.IntegrityCheckerData.Thread = &sync.WaitGroup{}
 	e.IntegrityCheckerData.Interrupt = make(chan bool, 1)
 
 	e.airgapBasePath = module.GetStringDefault(config, "airgapBasePath", DEFAULT_AIRGAP_BASE_PATH)
-	e.communityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", DEFAULT_COMMUNITY_RULES_IMPORT_FREQUENCY_SECONDS)
+	e.CommunityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", DEFAULT_COMMUNITY_RULES_IMPORT_FREQUENCY_SECONDS)
 	e.sigmaPackageDownloadTemplate = module.GetStringDefault(config, "sigmaPackageDownloadTemplate", DEFAULT_SIGMA_PACKAGE_DOWNLOAD_TEMPLATE)
 	e.elastAlertRulesFolder = module.GetStringDefault(config, "elastAlertRulesFolder", DEFAULT_ELASTALERT_RULES_FOLDER)
 	e.sigmaPipelineFinal = module.GetStringDefault(config, "sigmaPipelineFinal", DEFAULT_SIGMA_PIPELINE_FINAL_FILE)
@@ -149,7 +143,7 @@ func (e *ElastAlertEngine) Init(config module.ModuleConfig) (err error) {
 	e.sigmaPipelinesFingerprintFile = module.GetStringDefault(config, "sigmaPipelinesFingerprintFile", DEFAULT_SIGMA_PIPELINES_FINGERPRINT_FILE)
 	e.rulesFingerprintFile = module.GetStringDefault(config, "rulesFingerprintFile", DEFAULT_RULES_FINGERPRINT_FILE)
 	e.autoEnabledSigmaRules = module.GetStringArrayDefault(config, "autoEnabledSigmaRules", []string{"securityonion-resources+critical", "securityonion-resources+high"})
-	e.communityRulesImportErrorSeconds = module.GetIntDefault(config, "communityRulesImportErrorSeconds", DEFAULT_COMMUNITY_RULES_IMPORT_ERROR_SECS)
+	e.CommunityRulesImportErrorSeconds = module.GetIntDefault(config, "communityRulesImportErrorSeconds", DEFAULT_COMMUNITY_RULES_IMPORT_ERROR_SECS)
 	e.failAfterConsecutiveErrorCount = module.GetIntDefault(config, "failAfterConsecutiveErrorCount", DEFAULT_FAIL_AFTER_CONSECUTIVE_ERROR_COUNT)
 	e.additionalAlerters = module.GetStringArrayDefault(config, "additionalAlerters", []string{})
 	e.IntegrityCheckerData.FrequencySeconds = module.GetIntDefault(config, "integrityCheckFrequencySeconds", DEFAULT_INTEGRITY_CHECK_FREQUENCY_SECONDS)
@@ -194,7 +188,7 @@ func (e *ElastAlertEngine) Init(config module.ModuleConfig) (err error) {
 		}
 	}
 
-	e.stateFilePath = module.GetStringDefault(config, "stateFilePath", DEFAULT_STATE_FILE_PATH)
+	e.SyncSchedulerParams.StateFilePath = module.GetStringDefault(config, "stateFilePath", DEFAULT_STATE_FILE_PATH)
 
 	return nil
 }
@@ -204,7 +198,7 @@ func (e *ElastAlertEngine) Start() error {
 	e.isRunning = true
 	e.IntegrityCheckerData.IsRunning = true
 
-	go e.startCommunityRuleImport()
+	go detections.SyncScheduler(e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameElastAlert, &e.isRunning)
 	go detections.IntegrityChecker(model.EngineNameElastAlert, e, &e.IntegrityCheckerData, &e.EngineState.IntegrityFailure)
 
 	return nil
@@ -214,8 +208,8 @@ func (e *ElastAlertEngine) Stop() error {
 	e.isRunning = false
 
 	e.InterruptSync(false, false)
-	e.syncThread.Wait()
-	e.pauseIntegrityChecker()
+	e.SyncSchedulerParams.SyncThread.Wait()
+	e.PauseIntegrityChecker()
 	e.interruptIntegrityCheck()
 	e.IntegrityCheckerData.Thread.Wait()
 
@@ -228,8 +222,8 @@ func (e *ElastAlertEngine) InterruptSync(fullUpgrade bool, notify bool) {
 
 	e.notify = notify
 
-	if len(e.interruptSync) == 0 {
-		e.interruptSync <- fullUpgrade
+	if len(e.InterruptChan) == 0 {
+		e.InterruptChan <- fullUpgrade
 	}
 }
 
@@ -239,8 +233,8 @@ func (e *ElastAlertEngine) resetInterruptSync() {
 
 	e.notify = false
 
-	if len(e.interruptSync) != 0 {
-		<-e.interruptSync
+	if len(e.InterruptChan) != 0 {
+		<-e.InterruptChan
 	}
 }
 
@@ -253,11 +247,11 @@ func (e *ElastAlertEngine) interruptIntegrityCheck() {
 	}
 }
 
-func (e *ElastAlertEngine) pauseIntegrityChecker() {
+func (e *ElastAlertEngine) PauseIntegrityChecker() {
 	e.IntegrityCheckerData.IsRunning = false
 }
 
-func (e *ElastAlertEngine) resumeIntegrityChecker() {
+func (e *ElastAlertEngine) ResumeIntegrityChecker() {
 	e.IntegrityCheckerData.IsRunning = true
 }
 
@@ -432,110 +426,14 @@ func (e *ElastAlertEngine) SyncLocalDetections(ctx context.Context, detections [
 	return errMap, nil
 }
 
-func (e *ElastAlertEngine) startCommunityRuleImport() {
-	e.syncThread.Add(1)
+func (e *ElastAlertEngine) Sync(forceSync bool) error {
 	defer func() {
-		e.syncThread.Done()
-		e.isRunning = false
+		e.resetInterruptSync()
 	}()
 
-	var err error
-
-	// |> nil: no import has been completed, it's this way during the first sync
-	// so that the timerDur returned by DetermineWaitTime is used. After first sync,
-	// the pointer should always have a value
-	// |> false: the last sync was not successful, the timer for the next sync should use
-	// the shorter communityRulesImportErrorSeconds timer.
-	// |> true: the last sync was successful, the timer for the next sync should use
-	// the normal communityRulesImportFrequencySeconds timer.
-	var lastSyncSuccess *bool
-
-	// publicId of a detection that was written but not read back
-	var writeNoRead *string
-
-	ctx := e.srv.Context
-
-	lastImport, timerDur := detections.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Duration(e.communityRulesImportFrequencySeconds)*time.Second)
-
-	for e.isRunning {
-		if lastImport == nil && lastSyncSuccess != nil && *lastSyncSuccess {
-			now := uint64(time.Now().UnixMilli())
-			lastImport = &now
-		}
-
-		e.EngineState.Syncing = false
-		e.EngineState.Importing = lastImport == nil
-		e.EngineState.Migrating = false
-		e.EngineState.SyncFailure = lastSyncSuccess != nil && !*lastSyncSuccess
-
-		e.resetInterruptSync()
-
-		var forceSync bool
-
-		if lastSyncSuccess != nil {
-			if *lastSyncSuccess {
-				timerDur = time.Second * time.Duration(e.communityRulesImportFrequencySeconds)
-			} else {
-				timerDur = time.Second * time.Duration(e.communityRulesImportErrorSeconds)
-				forceSync = true
-			}
-		}
-
-		timer := time.NewTimer(timerDur)
-
-		lastSyncStatus := "nil"
-		if lastSyncSuccess != nil {
-			lastSyncStatus = strconv.FormatBool(*lastSyncSuccess)
-		}
-
-		log.WithFields(log.Fields{
-			"waitTimeSeconds":   timerDur.Seconds(),
-			"forceSync":         forceSync,
-			"lastSyncSuccess":   lastSyncStatus,
-			"expectedStartTime": time.Now().Add(timerDur).Format(time.RFC3339),
-		}).Info("waiting for next elastalert community rules sync")
-
-		e.resumeIntegrityChecker()
-
-		select {
-		case <-timer.C:
-		case typ := <-e.interruptSync:
-			forceSync = forceSync || typ
-		}
-
-		e.pauseIntegrityChecker()
-
-		if !e.isRunning {
-			break
-		}
-
-		lastSyncSuccess = util.Ptr(false)
-
-		if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, writeNoRead) {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		writeNoRead = nil
-
-		timerDur = time.Second * time.Duration(e.communityRulesImportFrequencySeconds)
-
-		log.WithFields(log.Fields{
-			"forceSync": forceSync,
-		}).Info("syncing elastalert community rules")
-
-		e.EngineState.Syncing = true
-
-		start := time.Now()
-
-		tmplExists := detections.CheckTemplate(e.srv.Context, e.srv.Detectionstore)
-		if !tmplExists {
+	// handle write/no-read
+	if e.writeNoRead != nil {
+		if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, e.writeNoRead) {
 			if e.notify {
 				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
 					Engine: model.EngineNameElastAlert,
@@ -543,212 +441,114 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 				})
 			}
 
-			continue
+			return detections.ErrSyncFailed
+		}
+	}
+
+	e.writeNoRead = nil
+
+	// setup logger
+	syncId := uuid.New().String()
+	logger := log.WithFields(log.Fields{
+		"detectionEngineName": model.EngineNameElastAlert,
+		"syncId":              syncId,
+	})
+
+	// announce the beginning of the sync
+	start := time.Now()
+	logger.WithField("forceSync", forceSync).Info("syncing elastalert community rules")
+	e.EngineState.Syncing = true
+
+	// Check to see if the sigma processing pipelines have changed.
+	// If they have, set forceSync to true to regenerate the elastalert rule files.
+	regenNeeded, sigmaPipelineNewHash, err := e.checkSigmaPipelines()
+	if err != nil {
+		logger.WithField("sigmaPipelineError", err).Error("failed to check the sigma processing pipelines")
+	} else {
+		logger.Info("successfully checked the sigma processing pipelines")
+	}
+
+	if regenNeeded {
+		forceSync = true
+	}
+
+	var zips map[string][]byte
+	var errMap map[string]error
+
+	// If the system is Airgap, load the sigma packages from disk.
+	// else, not Airgap, downoad the sigma packages.
+	if e.airgapEnabled {
+		zips, errMap = e.loadSigmaPackagesFromDisk()
+	} else {
+		zips, errMap = e.downloadSigmaPackages()
+	}
+
+	if len(errMap) != 0 {
+		logger.WithField("sigmaPackageErrors", errMap).Error("something went wrong loading sigma packages")
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameElastAlert,
+				Status: "error",
+			})
 		}
 
-		var zips map[string][]byte
-		var errMap map[string]error
-		var regenNeeded bool
-		var sigmaPipelineNewHash string
+		return detections.ErrSyncFailed
+	}
 
-		// Check to see if the sigma processing pipelines have changed.
-		// If they have, (later) set forceSync to true to regenerate the elastalert rule files.
-		regenNeeded, sigmaPipelineNewHash, err = e.checkSigmaPipelines()
+	// ensure repos are up to date
+	dirtyRepos, repoChanges, err := detections.UpdateRepos(&e.isRunning, e.reposFolder, e.rulesRepos, e.srv.Config, e.IOManager)
+	if err != nil {
+		if errors.Is(err, detections.ErrModuleStopped) {
+			return err
+		}
+
+		logger.WithError(err).Error("unable to update Sigma repos")
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameElastAlert,
+				Status: "error",
+			})
+		}
+
+		return detections.ErrSyncFailed
+	}
+
+	zipHashes := map[string]string{}
+	for pkg, data := range zips {
+		h := sha256.Sum256(data)
+		zipHashes[pkg] = base64.StdEncoding.EncodeToString(h[:])
+	}
+
+	if !forceSync {
+		// if we're not forcing a sync, check to see if anything has changed
+		// if nothing has changed, the sync is finished
+		raw, err := e.ReadFile(e.rulesFingerprintFile)
+		if err != nil && !os.IsNotExist(err) {
+			logger.WithError(err).WithField("fingerprintPath", e.rulesFingerprintFile).Error("unable to read rules fingerprint file")
+
+			return detections.ErrSyncFailed
+		}
+
+		oldHashes := map[string]string{}
+
+		err = json.Unmarshal(raw, &oldHashes)
 		if err != nil {
-			log.WithField("sigmaPipelineError", err).Error("failed to check the sigma processing pipelines")
-		} else {
-			log.Info("successfully checked the sigma processing pipelines")
+			logger.WithError(err).Error("unable to unmarshal rules fingerprint file")
+
+			return detections.ErrSyncFailed
 		}
 
-		// If the system is Airgap, load the sigma packages from disk.
-		// else, not Airgap, downoad the sigma packages.
-		if e.airgapEnabled {
-			zips, errMap = e.loadSigmaPackagesFromDisk()
-		} else {
-			zips, errMap = e.downloadSigmaPackages()
-		}
+		if reflect.DeepEqual(oldHashes, zipHashes) && !repoChanges {
+			// only an exact match means no work needs to be done.
+			// If there's extra hashes in the old file, we need to remove them.
+			// If there's extra hashes in the new file, we need to add them.
+			// If there's a mix of new and old hashes, we need to include them all
+			// or the old ones would be removed.
+			logger.Info("community rule sync found no changes")
 
-		if len(errMap) != 0 {
-			log.WithField("sigmaPackageErrors", errMap).Error("something went wrong loading sigma packages")
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameElastAlert,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		dirtyRepos, repoChanges, err := detections.UpdateRepos(&e.isRunning, e.reposFolder, e.rulesRepos, e.srv.Config, e.IOManager)
-		if err != nil {
-			if strings.Contains(err.Error(), "module stopped") {
-				break
-			}
-
-			log.WithError(err).Error("unable to update Sigma repos")
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameElastAlert,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		zipHashes := map[string]string{}
-		for pkg, data := range zips {
-			h := sha256.Sum256(data)
-			zipHashes[pkg] = base64.StdEncoding.EncodeToString(h[:])
-		}
-
-		// If no import has been completed, or
-		// elastalert rule files need to be regenerated -
-		// then do a full sync.
-		if lastImport == nil || regenNeeded {
-			forceSync = true
-		}
-
-		if !forceSync {
-			raw, err := e.ReadFile(e.rulesFingerprintFile)
-			if err != nil && !os.IsNotExist(err) {
-				log.WithError(err).WithField("fingerprintPath", e.rulesFingerprintFile).Error("unable to read rules fingerprint file")
-				continue
-			} else if err == nil {
-				oldHashes := map[string]string{}
-
-				err = json.Unmarshal(raw, &oldHashes)
-				if err != nil {
-					log.WithError(err).Error("unable to unmarshal rules fingerprint file")
-					continue
-				}
-
-				if reflect.DeepEqual(oldHashes, zipHashes) && !repoChanges {
-					// only an exact match means no work needs to be done.
-					// If there's extra hashes in the old file, we need to remove them.
-					// If there's extra hashes in the new file, we need to add them.
-					// If there's a mix of new and old hashes, we need to include them all
-					// or the old ones would be removed.
-					log.Info("elastalert sync found no changes")
-
-					detections.WriteStateFile(e.IOManager, e.stateFilePath)
-
-					if e.notify {
-						e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-							Engine: model.EngineNameElastAlert,
-							Status: "success",
-						})
-					}
-
-					_, _, err = e.IntegrityCheck(false)
-
-					e.EngineState.IntegrityFailure = err != nil
-					lastSyncSuccess = util.Ptr(err == nil)
-
-					if err != nil {
-						log.WithError(err).Error("post-sync integrity check failed")
-					} else {
-						log.Info("post-sync integrity check passed")
-					}
-
-					continue
-				}
-			}
-		}
-
-		if !e.isRunning {
-			break
-		}
-
-		detects, errMap := e.parseZipRules(zips)
-		if errMap != nil {
-			log.WithField("sigmaParseError", errMap).Error("something went wrong while parsing sigma rule files from zips")
-		}
-
-		if errMap["module"] == errModuleStopped || !e.isRunning {
-			break
-		}
-
-		repoDets, errMap := e.parseRepoRules(dirtyRepos)
-		if errMap != nil {
-			log.WithField("sigmaParseError", errMap).Error("something went wrong while parsing sigma rule files from repos")
-		}
-
-		if errMap["module"] == errModuleStopped || !e.isRunning {
-			break
-		}
-
-		detects = append(detects, repoDets...)
-
-		detects = detections.DeduplicateByPublicId(detects)
-
-		errMap, err = e.syncCommunityDetections(ctx, detects)
-		if err != nil {
-			if err == errModuleStopped {
-				log.Info("incomplete sync of elastalert community detections due to module stopping")
-				return
-			}
-
-			if err.Error() == "Object not found" {
-				// errMap contains exactly 1 error: the publicId of the detection that
-				// was written to but not read back
-				for publicId := range errMap {
-					writeNoRead = util.Ptr(publicId)
-				}
-			}
-
-			log.WithError(err).Error("unable to sync elastalert community detections")
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameElastAlert,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		detections.WriteStateFile(e.IOManager, e.stateFilePath)
-		lastSyncSuccess = util.Ptr(true)
-
-		if len(errMap) > 0 {
-			// there were errors, don't save the fingerprint.
-			// idempotency means we might fix it if we try again later.
-			log.WithFields(log.Fields{
-				"elastAlertSyncErrors": detections.TruncateMap(errMap, 5),
-			}).Error("unable to sync all ElastAlert community detections")
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameElastAlert,
-					Status: "partial",
-				})
-			}
-		} else {
-			fingerprints, err := json.Marshal(zipHashes)
-			if err != nil {
-				log.WithError(err).Error("unable to marshal rules fingerprints")
-			} else {
-				err = e.WriteFile(e.rulesFingerprintFile, fingerprints, 0644)
-				if err != nil {
-					log.WithError(err).WithField("fingerprintPath", e.rulesFingerprintFile).Error("unable to write rules fingerprint file")
-				}
-			}
-
-			// Now that a successful sync completed - if the sigma pipelines changed, write out the new sigma pipelines hash .
-			if regenNeeded {
-				err = e.WriteFile(e.sigmaPipelinesFingerprintFile, []byte(sigmaPipelineNewHash), 0644)
-				if err != nil {
-					log.WithError(err).WithField("fingerprintPath", e.sigmaPipelinesFingerprintFile).Error("unable to write sigma pipelines fingerprint file")
-				} else {
-					log.WithField("fingerprintPath", e.sigmaPipelinesFingerprintFile).Info("updated sigma pipelines fingerprint file")
-				}
-
-			}
+			detections.WriteStateFile(e.IOManager, e.StateFilePath)
 
 			if e.notify {
 				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
@@ -760,21 +560,130 @@ func (e *ElastAlertEngine) startCommunityRuleImport() {
 			_, _, err = e.IntegrityCheck(false)
 
 			e.EngineState.IntegrityFailure = err != nil
-			lastSyncSuccess = util.Ptr(err == nil)
 
 			if err != nil {
-				log.WithError(err).Error("post-sync integrity check failed")
+				logger.WithError(err).Error("post-sync integrity check failed")
 			} else {
-				log.Info("post-sync integrity check passed")
+				logger.Info("post-sync integrity check passed")
+			}
+
+			// a non-forceSync sync that found no changes is a success
+			return nil
+		}
+	}
+
+	if !e.isRunning {
+		return detections.ErrModuleStopped
+	}
+
+	detects, errMap := e.parseZipRules(zips)
+	if errMap != nil {
+		logger.WithField("sigmaParseError", errMap).Error("something went wrong while parsing sigma rule files from zips")
+	}
+
+	if errors.Is(errMap["module"], detections.ErrModuleStopped) || !e.isRunning {
+		return detections.ErrModuleStopped
+	}
+
+	repoDets, errMap := e.parseRepoRules(dirtyRepos)
+	if errMap != nil {
+		logger.WithField("sigmaParseError", errMap).Error("something went wrong while parsing sigma rule files from repos")
+	}
+
+	if errors.Is(errMap["module"], detections.ErrModuleStopped) || !e.isRunning {
+		return detections.ErrModuleStopped
+	}
+
+	detects = append(detects, repoDets...)
+
+	detects = detections.DeduplicateByPublicId(detects)
+
+	errMap, err = e.syncCommunityDetections(e.srv.Context, detects)
+	if err != nil {
+		if errors.Is(err, detections.ErrModuleStopped) {
+			logger.Info("incomplete sync of elastalert community detections due to module stopping")
+			return err
+		}
+
+		if err.Error() == "Object not found" {
+			// errMap contains exactly 1 error: the publicId of the detection that
+			// was written to but not read back
+			for publicId := range errMap {
+				e.writeNoRead = util.Ptr(publicId)
 			}
 		}
 
-		dur := time.Since(start)
+		logger.WithError(err).Error("unable to sync elastalert community detections")
 
-		log.WithFields(log.Fields{
-			"durationSeconds": dur.Seconds(),
-		}).Info("elastalert community rules sync finished")
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameElastAlert,
+				Status: "error",
+			})
+		}
+
+		return detections.ErrSyncFailed
 	}
+
+	detections.WriteStateFile(e.IOManager, e.StateFilePath)
+
+	if len(errMap) > 0 {
+		// there were errors, don't save the fingerprint.
+		// idempotency means we might fix it if we try again later.
+		logger.WithField("elastAlertSyncErrors", detections.TruncateMap(errMap, 5)).Error("unable to sync all ElastAlert community detections")
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameElastAlert,
+				Status: "partial",
+			})
+		}
+	} else {
+		fingerprints, err := json.Marshal(zipHashes)
+		if err != nil {
+			logger.WithError(err).Error("unable to marshal rules fingerprints")
+		} else {
+			err = e.WriteFile(e.rulesFingerprintFile, fingerprints, 0644)
+			if err != nil {
+				logger.WithError(err).WithField("fingerprintPath", e.rulesFingerprintFile).Error("unable to write rules fingerprint file")
+			}
+		}
+
+		// Now that a successful sync completed - if the sigma pipelines changed, write out the new sigma pipelines hash .
+		if regenNeeded {
+			err = e.WriteFile(e.sigmaPipelinesFingerprintFile, []byte(sigmaPipelineNewHash), 0644)
+			if err != nil {
+				logger.WithError(err).WithField("fingerprintPath", e.sigmaPipelinesFingerprintFile).Error("unable to write sigma pipelines fingerprint file")
+			} else {
+				logger.WithField("fingerprintPath", e.sigmaPipelinesFingerprintFile).Info("updated sigma pipelines fingerprint file")
+			}
+		}
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameElastAlert,
+				Status: "success",
+			})
+		}
+
+		_, _, err = e.IntegrityCheck(false)
+
+		e.EngineState.IntegrityFailure = err != nil
+
+		if err != nil {
+			logger.WithError(err).Error("post-sync integrity check failed")
+		} else {
+			logger.Info("post-sync integrity check passed")
+		}
+	}
+
+	dur := time.Since(start)
+
+	logger.WithFields(log.Fields{
+		"durationSeconds": dur.Seconds(),
+	}).Info("elastalert community rules sync finished")
+
+	return nil
 }
 
 func (e *ElastAlertEngine) checkSigmaPipelines() (bool, string, error) {
@@ -816,7 +725,7 @@ func (e *ElastAlertEngine) hashFile(filePath string) (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
-func (e *ElastAlertEngine) parseZipRules(pkgZips map[string][]byte) (detections []*model.Detection, errMap map[string]error) {
+func (e *ElastAlertEngine) parseZipRules(pkgZips map[string][]byte) (detects []*model.Detection, errMap map[string]error) {
 	errMap = map[string]error{} // map[pkgName|fileName]error
 	defer func() {
 		if len(errMap) == 0 {
@@ -826,7 +735,7 @@ func (e *ElastAlertEngine) parseZipRules(pkgZips map[string][]byte) (detections 
 
 	for _, pkg := range e.sigmaRulePackages {
 		if !e.isRunning {
-			return nil, map[string]error{"module": errModuleStopped}
+			return nil, map[string]error{"module": detections.ErrModuleStopped}
 		}
 
 		zipData := pkgZips[pkg]
@@ -839,7 +748,7 @@ func (e *ElastAlertEngine) parseZipRules(pkgZips map[string][]byte) (detections 
 
 		for _, file := range reader.File {
 			if !e.isRunning {
-				return nil, map[string]error{"module": errModuleStopped}
+				return nil, map[string]error{"module": detections.ErrModuleStopped}
 			}
 
 			if file.FileInfo().IsDir() || !acceptedExtensions[strings.ToLower(filepath.Ext(file.Name))] {
@@ -880,14 +789,14 @@ func (e *ElastAlertEngine) parseZipRules(pkgZips map[string][]byte) (detections 
 
 			det := rule.ToDetection(pkg, model.LicenseDRL, true)
 
-			detections = append(detections, det)
+			detects = append(detects, det)
 		}
 	}
 
-	return detections, errMap
+	return detects, errMap
 }
 
-func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (detections []*model.Detection, errMap map[string]error) {
+func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (detects []*model.Detection, errMap map[string]error) {
 	errMap = map[string]error{} // map[repoName]error
 	defer func() {
 		if len(errMap) == 0 {
@@ -897,7 +806,7 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 
 	for _, repo := range allRepos {
 		if !e.isRunning {
-			return nil, map[string]error{"module": errModuleStopped}
+			return nil, map[string]error{"module": detections.ErrModuleStopped}
 		}
 
 		baseDir := repo.Path
@@ -912,7 +821,7 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 			}
 
 			if !e.isRunning {
-				return errModuleStopped
+				return detections.ErrModuleStopped
 			}
 
 			if d.IsDir() {
@@ -940,7 +849,7 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 
 			det := rule.ToDetection(ruleset, repo.Repo.License, repo.Repo.Community)
 
-			detections = append(detections, det)
+			detects = append(detects, det)
 
 			return nil
 		})
@@ -950,7 +859,7 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 		}
 	}
 
-	return detections, errMap
+	return detects, errMap
 }
 
 func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, detects []*model.Detection) (errMap map[string]error, err error) {
@@ -987,7 +896,7 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, detects 
 
 	for _, det := range detects {
 		if !e.isRunning {
-			return nil, errModuleStopped
+			return nil, detections.ErrModuleStopped
 		}
 
 		path, ok := index[det.PublicID]
@@ -1091,7 +1000,7 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, detects 
 
 	for publicId := range toDelete {
 		if !e.isRunning {
-			return nil, errModuleStopped
+			return nil, detections.ErrModuleStopped
 		}
 
 		_, err = e.srv.Detectionstore.DeleteDetection(ctx, community[publicId].Id)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -89,6 +89,7 @@ type ElastAlertEngine struct {
 	writeNoRead                    *string
 	detections.SyncSchedulerParams
 	detections.IntegrityCheckerData
+	detections.IOManager
 	model.EngineState
 }
 
@@ -197,7 +198,7 @@ func (e *ElastAlertEngine) Start() error {
 	e.isRunning = true
 	e.IntegrityCheckerData.IsRunning = true
 
-	go detections.SyncScheduler(e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameElastAlert, &e.isRunning)
+	go detections.SyncScheduler(e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameElastAlert, &e.isRunning, e.IOManager)
 	go detections.IntegrityChecker(model.EngineNameElastAlert, e, &e.IntegrityCheckerData, &e.EngineState.IntegrityFailure)
 
 	return nil
@@ -1013,11 +1014,11 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 	}
 
 	logger.WithFields(log.Fields{
-		"elastAlertSyncadded":     results.Added,
-		"elastAlertSyncupdated":   results.Updated,
-		"elastAlertSyncremoved":   results.Removed,
-		"elastAlertSyncunchanged": results.Unchanged,
-		"elastAlertSyncerrors":    detections.TruncateMap(errMap, 5),
+		"syncAdded":     results.Added,
+		"syncUpdated":   results.Updated,
+		"syncRemoved":   results.Removed,
+		"syncUnchanged": results.Unchanged,
+		"syncErrors":    detections.TruncateMap(errMap, 5),
 	}).Info("elastalert community diff")
 
 	return errMap, nil

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -341,9 +341,18 @@ func TestSigmaToElastAlertSunnyDay(t *testing.T) {
 
 	det := &model.Detection{
 		PublicID: "00000000-0000-0000-0000-000000000000",
-		Content:  "totally good sigma",
+		Content:  `{"detection": {"condition": "*"}}`,
 		Title:    "Test Detection",
 		Severity: model.SeverityHigh,
+		Overrides: []*model.Override{
+			{
+				Type:      model.OverrideTypeCustomFilter,
+				IsEnabled: true,
+				OverrideParameters: model.OverrideParameters{
+					CustomFilter: util.Ptr(`{"this": ["that"]}`),
+				},
+			},
+		},
 	}
 
 	query, err := engine.sigmaToElastAlert(context.Background(), det)

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -246,9 +246,7 @@ func TestCheckSigmaPipelines(t *testing.T) {
 		sigmaPipelineFinal:            "/opt/sensoroni/sigma_final_pipeline.yaml",
 		sigmaPipelineSO:               "/opt/sensoroni/sigma_so_pipeline.yaml",
 		sigmaPipelinesFingerprintFile: "/opt/sensoroni/fingerprints/sigma.pipelines.fingerprint",
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager:                     iom,
 	}
 
 	testList := []struct {
@@ -336,9 +334,7 @@ func TestSigmaToElastAlertSunnyDay(t *testing.T) {
 	})).Return([]byte("<eql>"), 0, time.Duration(0), nil)
 
 	engine := ElastAlertEngine{
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager: iom,
 	}
 
 	det := &model.Detection{
@@ -399,9 +395,7 @@ func TestSigmaToElastAlertSunnyDayLicensed(t *testing.T) {
 	})).Return([]byte("<eql>"), 0, time.Duration(0), nil)
 
 	engine := ElastAlertEngine{
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager: iom,
 	}
 
 	det := &model.Detection{
@@ -465,9 +459,7 @@ func TestSigmaToElastAlertError(t *testing.T) {
 	})).Return([]byte("Error: something went wrong"), 1, time.Duration(0), errors.New("non-zero return"))
 
 	engine := ElastAlertEngine{
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager: iom,
 	}
 
 	det := &model.Detection{
@@ -616,9 +608,7 @@ license: Elastic-2.0
 
 	engine := ElastAlertEngine{
 		isRunning: true,
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager: iom,
 	}
 	engine.allowRegex = regexp.MustCompile("bf86ef21-41e6-417b-9a05-b9ea6bf28a38")
 	engine.denyRegex = regexp.MustCompile("deny")
@@ -673,9 +663,7 @@ func TestDownloadSigmaPackages(t *testing.T) {
 	engine := ElastAlertEngine{
 		sigmaRulePackages:            pkgs,
 		sigmaPackageDownloadTemplate: "localhost:3000/%s.zip",
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager:                    iom,
 	}
 
 	pkgZips, errMap := engine.downloadSigmaPackages()
@@ -711,9 +699,7 @@ func TestLoadSigmaPackagesFromDisks(t *testing.T) {
 	engine := ElastAlertEngine{
 		sigmaRulePackages: pkgs,
 		airgapBasePath:    airgapBasePath,
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager:         iom,
 	}
 
 	zipData, errMap := engine.loadSigmaPackagesFromDisk()
@@ -1011,9 +997,7 @@ func TestGetDeployedPublicIds(t *testing.T) {
 
 	eng := &ElastAlertEngine{
 		elastAlertRulesFolder: path,
-		SyncSchedulerParams: detections.SyncSchedulerParams{
-			IOManager: iom,
-		},
+		IOManager:             iom,
 	}
 
 	ids, err := eng.getDeployedPublicIds()

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -19,10 +19,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/module"
@@ -50,31 +48,26 @@ const (
 	DEFAULT_INTEGRITY_CHECK_FREQUENCY_SECONDS        = 600
 )
 
-var errModuleStopped = fmt.Errorf("strelka module has stopped running")
 var titleUpdater = regexp.MustCompile(`(?i)rule\s+(\w+)(\s+:(\s*[^{]+))?(\s+){`)
 var nameValidator = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,127}$`) // alphanumeric + underscore, can't start with a number
 
 type StrelkaEngine struct {
-	srv                                  *server.Server
-	isRunning                            bool
-	syncThread                           *sync.WaitGroup
-	interruptSync                        chan bool
-	interm                               sync.Mutex
-	communityRulesImportFrequencySeconds int
-	communityRulesImportErrorSeconds     int
-	failAfterConsecutiveErrorCount       int
-	yaraRulesFolder                      string
-	reposFolder                          string
-	autoEnabledYaraRules                 []string
-	rulesRepos                           []*model.RuleRepo
-	compileYaraPythonScriptPath          string
-	allowRegex                           *regexp.Regexp
-	denyRegex                            *regexp.Regexp
-	notify                               bool
-	stateFilePath                        string
+	srv                            *server.Server
+	isRunning                      bool
+	interm                         sync.Mutex
+	failAfterConsecutiveErrorCount int
+	yaraRulesFolder                string
+	reposFolder                    string
+	autoEnabledYaraRules           []string
+	rulesRepos                     []*model.RuleRepo
+	compileYaraPythonScriptPath    string
+	allowRegex                     *regexp.Regexp
+	denyRegex                      *regexp.Regexp
+	notify                         bool
+	writeNoRead                    *string
+	detections.SyncSchedulerParams
 	detections.IntegrityCheckerData
 	model.EngineState
-	detections.IOManager
 }
 
 func checkRulesetEnabled(e *StrelkaEngine, det *model.Detection) {
@@ -90,8 +83,10 @@ func checkRulesetEnabled(e *StrelkaEngine, det *model.Detection) {
 
 func NewStrelkaEngine(srv *server.Server) *StrelkaEngine {
 	return &StrelkaEngine{
-		srv:       srv,
-		IOManager: &detections.ResourceManager{Config: srv.Config},
+		srv: srv,
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			IOManager: &detections.ResourceManager{Config: srv.Config},
+		},
 	}
 }
 
@@ -104,17 +99,17 @@ func (e *StrelkaEngine) GetState() *model.EngineState {
 }
 
 func (e *StrelkaEngine) Init(config module.ModuleConfig) (err error) {
-	e.syncThread = &sync.WaitGroup{}
-	e.interruptSync = make(chan bool, 1)
+	e.SyncThread = &sync.WaitGroup{}
+	e.InterruptChan = make(chan bool, 1)
 	e.IntegrityCheckerData.Thread = &sync.WaitGroup{}
 	e.IntegrityCheckerData.Interrupt = make(chan bool, 1)
 
-	e.communityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", DEFAULT_COMMUNITY_RULES_IMPORT_FREQUENCY_SECONDS)
+	e.CommunityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", DEFAULT_COMMUNITY_RULES_IMPORT_FREQUENCY_SECONDS)
 	e.yaraRulesFolder = module.GetStringDefault(config, "yaraRulesFolder", DEFAULT_YARA_RULES_FOLDER)
 	e.reposFolder = module.GetStringDefault(config, "reposFolder", DEFAULT_REPOS_FOLDER)
 	e.compileYaraPythonScriptPath = module.GetStringDefault(config, "compileYaraPythonScriptPath", DEFAULT_COMPILE_YARA_PYTHON_SCRIPT_PATH)
 	e.autoEnabledYaraRules = module.GetStringArrayDefault(config, "autoEnabledYaraRules", []string{DEFAULT_AUTO_ENABLED_YARA_RULES})
-	e.communityRulesImportErrorSeconds = module.GetIntDefault(config, "communityRulesImportErrorSeconds", DEFAULT_COMMUNITY_RULES_IMPORT_ERROR_SECS)
+	e.CommunityRulesImportErrorSeconds = module.GetIntDefault(config, "communityRulesImportErrorSeconds", DEFAULT_COMMUNITY_RULES_IMPORT_ERROR_SECS)
 	e.failAfterConsecutiveErrorCount = module.GetIntDefault(config, "failAfterConsecutiveErrorCount", DEFAULT_FAIL_AFTER_CONSECUTIVE_ERROR_COUNT)
 	e.IntegrityCheckerData.FrequencySeconds = module.GetIntDefault(config, "integrityCheckFrequencySeconds", DEFAULT_INTEGRITY_CHECK_FREQUENCY_SECONDS)
 
@@ -146,7 +141,7 @@ func (e *StrelkaEngine) Init(config module.ModuleConfig) (err error) {
 		}
 	}
 
-	e.stateFilePath = module.GetStringDefault(config, "stateFilePath", DEFAULT_STATE_FILE_PATH)
+	e.StateFilePath = module.GetStringDefault(config, "stateFilePath", DEFAULT_STATE_FILE_PATH)
 
 	return nil
 }
@@ -155,7 +150,7 @@ func (e *StrelkaEngine) Start() error {
 	e.srv.DetectionEngines[model.EngineNameStrelka] = e
 	e.isRunning = true
 
-	go e.startCommunityRuleImport()
+	go detections.SyncScheduler(e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameStrelka, &e.isRunning)
 	go detections.IntegrityChecker(model.EngineNameStrelka, e, &e.IntegrityCheckerData, &e.EngineState.IntegrityFailure)
 
 	return nil
@@ -164,8 +159,8 @@ func (e *StrelkaEngine) Start() error {
 func (e *StrelkaEngine) Stop() error {
 	e.isRunning = false
 	e.InterruptSync(false, false)
-	e.syncThread.Wait()
-	e.pauseIntegrityChecker()
+	e.SyncThread.Wait()
+	e.PauseIntegrityChecker()
 	e.interruptIntegrityCheck()
 	e.IntegrityCheckerData.Thread.Wait()
 
@@ -178,8 +173,8 @@ func (e *StrelkaEngine) InterruptSync(fullUpgrade bool, notify bool) {
 
 	e.notify = notify
 
-	if len(e.interruptSync) == 0 {
-		e.interruptSync <- fullUpgrade
+	if len(e.InterruptChan) == 0 {
+		e.InterruptChan <- fullUpgrade
 	}
 }
 
@@ -189,8 +184,8 @@ func (e *StrelkaEngine) resetInterrupt() {
 
 	e.notify = false
 
-	if len(e.interruptSync) != 0 {
-		<-e.interruptSync
+	if len(e.InterruptChan) != 0 {
+		<-e.InterruptChan
 	}
 }
 
@@ -203,11 +198,11 @@ func (e *StrelkaEngine) interruptIntegrityCheck() {
 	}
 }
 
-func (e *StrelkaEngine) pauseIntegrityChecker() {
+func (e *StrelkaEngine) PauseIntegrityChecker() {
 	e.IntegrityCheckerData.IsRunning = false
 }
 
-func (e *StrelkaEngine) resumeIntegrityChecker() {
+func (e *StrelkaEngine) ResumeIntegrityChecker() {
 	e.IntegrityCheckerData.IsRunning = true
 }
 
@@ -256,294 +251,196 @@ func (s *StrelkaEngine) ExtractDetails(detect *model.Detection) error {
 }
 
 func (e *StrelkaEngine) SyncLocalDetections(ctx context.Context, _ []*model.Detection) (errMap map[string]string, err error) {
-	return e.syncDetections(ctx)
+	return nil, e.syncDetections(ctx)
 }
 
-func (e *StrelkaEngine) startCommunityRuleImport() {
-	e.syncThread.Add(1)
+func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 	defer func() {
-		e.syncThread.Done()
-		e.isRunning = false
+		e.resetInterrupt()
 	}()
 
-	// |> nil: no import has been completed, it's this way during the first sync
-	// so that the timerDur returned by DetermineWaitTime is used. After first sync,
-	// the pointer should always have a value
-	// |> false: the last sync was not successful, the timer for the next sync should use
-	// the shorter communityRulesImportErrorSeconds timer.
-	// |> true: the last sync was successful, the timer for the next sync should use
-	// the normal communityRulesImportFrequencySeconds timer.
-	var lastSyncSuccess *bool
-
-	// publicId of a detection that was written but not read back
-	var writeNoRead *string
-
-	lastImport, timerDur := detections.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Second*time.Duration(e.communityRulesImportFrequencySeconds))
-
-	for e.isRunning {
-		if lastImport == nil && lastSyncSuccess != nil && *lastSyncSuccess {
-			now := uint64(time.Now().UnixMilli())
-			lastImport = &now
-		}
-
-		e.EngineState.Syncing = false
-		e.EngineState.Importing = lastImport == nil
-		e.EngineState.Migrating = false
-		e.EngineState.SyncFailure = lastSyncSuccess != nil && !*lastSyncSuccess
-
-		e.resetInterrupt()
-
-		var forceSync bool
-
-		if lastSyncSuccess != nil {
-			if *lastSyncSuccess {
-				timerDur = time.Second * time.Duration(e.communityRulesImportFrequencySeconds)
-			} else {
-				timerDur = time.Second * time.Duration(e.communityRulesImportErrorSeconds)
-				forceSync = true
-			}
-		}
-
-		timer := time.NewTimer(timerDur)
-
-		lastSyncStatus := "nil"
-		if lastSyncSuccess != nil {
-			lastSyncStatus = strconv.FormatBool(*lastSyncSuccess)
-		}
-
-		log.WithFields(log.Fields{
-			"waitTimeSeconds":   timerDur.Seconds(),
-			"forceSync":         forceSync,
-			"lastSyncSuccess":   lastSyncStatus,
-			"expectedStartTime": time.Now().Add(timerDur).Format(time.RFC3339),
-		}).Info("waiting for next Strelka community rules sync")
-
-		e.resumeIntegrityChecker()
-
-		select {
-		case <-timer.C:
-		case typ := <-e.interruptSync:
-			forceSync = forceSync || typ
-		}
-
-		e.pauseIntegrityChecker()
-
-		if !e.isRunning {
-			break
-		}
-
-		lastSyncSuccess = util.Ptr(false)
-
-		if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, writeNoRead) {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		writeNoRead = nil
-
-		log.WithFields(log.Fields{
-			"forceSync": forceSync,
-		}).Info("syncing Strelka community rules")
-
-		e.EngineState.Syncing = true
-
-		start := time.Now()
-
-		tmplExists := detections.CheckTemplate(e.srv.Context, e.srv.Detectionstore)
-		if !tmplExists {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		allRepos, anythingNew, err := detections.UpdateRepos(&e.isRunning, e.reposFolder, e.rulesRepos, e.srv.Config, e.IOManager)
-		if err != nil {
-			if strings.Contains(err.Error(), "module stopped") {
-				break
-			}
-		}
-
-		// If no import has been completed, then do a full sync
-		if lastImport == nil {
-			forceSync = true
-		}
-
-		if !anythingNew && !forceSync {
-			// no updates, skip
-			log.Info("Strelka sync found no changes")
-
-			detections.WriteStateFile(e.IOManager, e.stateFilePath)
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "success",
-				})
-			}
-
-			_, _, err = e.IntegrityCheck(false)
-
-			e.EngineState.IntegrityFailure = err != nil
-			lastSyncSuccess = util.Ptr(err == nil)
-
-			if err != nil {
-				log.WithError(err).Error("post-sync integrity check failed")
-			} else {
-				log.Info("post-sync integrity check passed")
-			}
-
-			continue
-		}
-
-		communityDetections, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameStrelka), model.WithCommunity(true))
-		if err != nil {
-			log.WithError(err).Error("Failed to get all community SIDs")
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		toDelete := map[string]struct{}{}
-		for _, det := range communityDetections {
-			toDelete[det.PublicID] = struct{}{}
-		}
-
-		et := detections.NewErrorTracker(e.failAfterConsecutiveErrorCount)
-		detects := []*model.Detection{}
-
-		// parse *.yar files in repos
-		for repopath, repo := range allRepos {
-			if !e.isRunning {
-				return
-			}
-
-			if !repo.WasModified && !forceSync {
-				continue
-			}
-
-			baseDir := repo.Path
-			if repo.Repo.Folder != nil {
-				baseDir = filepath.Join(baseDir, *repo.Repo.Folder)
-			}
-
-			err = e.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
-				if err != nil {
-					log.WithError(err).WithField("repoPath", path).Error("Failed to walk path")
-					return nil
-				}
-
-				if !e.isRunning {
-					return errModuleStopped
-				}
-
-				if d.IsDir() {
-					return nil
-				}
-
-				ext := filepath.Ext(d.Name())
-				if strings.ToLower(ext) != ".yar" {
-					return nil
-				}
-
-				raw, err := e.ReadFile(path)
-				if err != nil {
-					log.WithError(err).WithField("yaraRuleFile", path).Error("failed to read yara rule file")
-					return nil
-				}
-
-				parsed, err := e.parseYaraRules(raw, true)
-				if err != nil {
-					log.WithError(err).WithField("yaraRuleFile", path).Error("failed to parse yara rule file")
-					return nil
-				}
-
-				for _, rule := range parsed {
-					det := rule.ToDetection(repo.Repo.License, filepath.Base(repo.Path), repo.Repo.Community)
-					detects = append(detects, det)
-				}
-
-				return nil
+	if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, e.writeNoRead) {
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameStrelka,
+				Status: "error",
 			})
-			if err != nil {
-				log.WithError(err).WithField("strelkaRepo", repopath).Error("failed while walking repo")
-
-				continue
-			}
 		}
 
-		var eterr error
-		detects = detections.DeduplicateByPublicId(detects)
+		return detections.ErrSyncFailed
+	}
 
-		for _, det := range detects {
-			log.WithFields(log.Fields{
-				"rule.uuid": det.PublicID,
-				"rule.name": det.Title,
-			}).Info("Strelka community sync - processing YARA rule")
+	e.writeNoRead = nil
 
-			comRule, exists := communityDetections[det.PublicID]
-			if exists {
-				if comRule.Content != det.Content || comRule.Ruleset != det.Ruleset || len(det.Overrides) != 0 {
-					// pre-existing detection, update it
-					det.IsEnabled = comRule.IsEnabled
-					det.Id = comRule.Id
-					det.Overrides = comRule.Overrides
-					det.CreateTime = comRule.CreateTime
+	e.EngineState.Syncing = true
 
-					log.WithFields(log.Fields{
-						"rule.uuid": det.PublicID,
-						"rule.name": det.Title,
-					}).Info("Updating Yara detection")
+	// ensure repos are up to date
+	allRepos, anythingNew, err := detections.UpdateRepos(&e.isRunning, e.reposFolder, e.rulesRepos, e.srv.Config, e.IOManager)
+	if err != nil {
+		if errors.Is(err, detections.ErrModuleStopped) {
+			return err
+		}
+	}
 
-					_, err = e.srv.Detectionstore.UpdateDetection(e.srv.Context, det)
-					if err != nil && err.Error() == "Object not found" {
-						writeNoRead = util.Ptr(det.PublicID)
-						log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
+	if !anythingNew && !forceSync {
+		// no updates, skip
+		logger.Info("community rule sync found no changes")
 
-						break
-					}
+		detections.WriteStateFile(e.IOManager, e.StateFilePath)
 
-					eterr = et.AddError(err)
-					if eterr != nil {
-						break
-					}
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameStrelka,
+				Status: "success",
+			})
+		}
 
-					if err != nil {
-						log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to update detection")
-						continue
-					}
-				}
+		_, _, err = e.IntegrityCheck(false)
 
-				delete(toDelete, det.PublicID)
-			} else {
-				// new detection, create it
-				log.WithFields(log.Fields{
+		e.EngineState.IntegrityFailure = err != nil
+
+		if err != nil {
+			logger.WithError(err).Error("post-sync integrity check failed")
+		} else {
+			logger.Info("post-sync integrity check passed")
+		}
+
+		// a non-forceSync sync that found no changes is a success
+		return nil
+	}
+
+	if !e.isRunning {
+		return detections.ErrModuleStopped
+	}
+
+	communityDetections, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameStrelka), model.WithCommunity(true))
+	if err != nil {
+		logger.WithError(err).Error("failed to get all community SIDs")
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameStrelka,
+				Status: "error",
+			})
+		}
+
+		return detections.ErrSyncFailed
+	}
+
+	if !e.isRunning {
+		return detections.ErrModuleStopped
+	}
+
+	toDelete := map[string]struct{}{}
+	for _, det := range communityDetections {
+		toDelete[det.PublicID] = struct{}{}
+	}
+
+	et := detections.NewErrorTracker(e.failAfterConsecutiveErrorCount)
+	detects := []*model.Detection{}
+
+	// parse *.yar files in repos
+	for repopath, repo := range allRepos {
+		if !e.isRunning {
+			return detections.ErrModuleStopped
+		}
+
+		if !repo.WasModified && !forceSync {
+			continue
+		}
+
+		baseDir := repo.Path
+		if repo.Repo.Folder != nil {
+			baseDir = filepath.Join(baseDir, *repo.Repo.Folder)
+		}
+
+		err = e.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				logger.WithError(err).WithField("repoPath", path).Error("failed to walk path")
+				return nil
+			}
+
+			if !e.isRunning {
+				return detections.ErrModuleStopped
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			ext := filepath.Ext(d.Name())
+			if strings.ToLower(ext) != ".yar" {
+				return nil
+			}
+
+			raw, err := e.ReadFile(path)
+			if err != nil {
+				logger.WithError(err).WithField("yaraRuleFile", path).Error("failed to read yara rule file")
+				return nil
+			}
+
+			parsed, err := e.parseYaraRules(raw, true)
+			if err != nil {
+				logger.WithError(err).WithField("yaraRuleFile", path).Error("failed to parse yara rule file")
+				return nil
+			}
+
+			for _, rule := range parsed {
+				det := rule.ToDetection(repo.Repo.License, filepath.Base(repo.Path), repo.Repo.Community)
+				detects = append(detects, det)
+			}
+
+			return nil
+		})
+		if err != nil {
+			logger.WithError(err).WithField("strelkaRepo", repopath).Error("failed while walking repo")
+
+			continue
+		}
+	}
+
+	if !e.isRunning {
+		return detections.ErrModuleStopped
+	}
+
+	var eterr error
+	detects = detections.DeduplicateByPublicId(detects)
+
+	results := struct {
+		Added     int
+		Updated   int
+		Removed   int
+		Unchanged int
+	}{}
+
+	for _, det := range detects {
+		if !e.isRunning {
+			return detections.ErrModuleStopped
+		}
+
+		logger.WithFields(log.Fields{
+			"rule.uuid": det.PublicID,
+			"rule.name": det.Title,
+		}).Info("syncing YARA detection")
+
+		comRule, exists := communityDetections[det.PublicID]
+		if exists {
+			if comRule.Content != det.Content || comRule.Ruleset != det.Ruleset || len(det.Overrides) != 0 {
+				// pre-existing detection, update it
+				det.IsEnabled = comRule.IsEnabled
+				det.Id = comRule.Id
+				det.Overrides = comRule.Overrides
+				det.CreateTime = comRule.CreateTime
+
+				logger.WithFields(log.Fields{
 					"rule.uuid": det.PublicID,
 					"rule.name": det.Title,
-				}).Info("Creating new Yara detection")
+				}).Info("updating YARA detection")
 
-				checkRulesetEnabled(e, det)
-
-				_, err = e.srv.Detectionstore.CreateDetection(e.srv.Context, det)
+				_, err = e.srv.Detectionstore.UpdateDetection(e.srv.Context, det)
 				if err != nil && err.Error() == "Object not found" {
-					writeNoRead = util.Ptr(det.PublicID)
-					log.WithField("publicId", det.PublicID).Error("unable to read back successful write")
+					e.writeNoRead = util.Ptr(det.PublicID)
+					logger.WithField("publicId", det.PublicID).Error("unable to read back successful write")
 
 					break
 				}
@@ -554,94 +451,126 @@ func (e *StrelkaEngine) startCommunityRuleImport() {
 				}
 
 				if err != nil {
-					log.WithError(err).WithField("publicId", det.PublicID).Error("Failed to create detection")
+					logger.WithError(err).WithField("publicId", det.PublicID).Error("failed to update detection")
 					continue
 				}
 
-				delete(toDelete, det.PublicID)
-			}
-		}
-
-		if eterr != nil || writeNoRead != nil {
-			if eterr != nil {
-				log.WithError(eterr).Error("unable to sync YARA community detections")
-			}
-			if writeNoRead != nil {
-				log.Warn("detection was written but not read back, attempting read before continuing")
+				results.Updated++
+			} else {
+				results.Unchanged++
 			}
 
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameElastAlert,
-					Status: "error",
-				})
-			}
+			delete(toDelete, det.PublicID)
+		} else {
+			// new detection, create it
+			logger.WithFields(log.Fields{
+				"rule.uuid": det.PublicID,
+				"rule.name": det.Title,
+			}).Info("creating new YARA detection")
 
-			continue
-		}
+			checkRulesetEnabled(e, det)
 
-		for publicId := range toDelete {
-			if !e.isRunning {
+			_, err = e.srv.Detectionstore.CreateDetection(e.srv.Context, det)
+			if err != nil && err.Error() == "Object not found" {
+				e.writeNoRead = util.Ptr(det.PublicID)
+				logger.WithField("publicId", det.PublicID).Error("unable to read back successful write")
+
 				break
 			}
 
-			_, err = e.srv.Detectionstore.DeleteDetection(e.srv.Context, communityDetections[publicId].Id)
-			if err != nil {
-				log.WithError(err).WithField("publicId", publicId).Error("Failed to delete unreferenced community detection")
+			eterr = et.AddError(err)
+			if eterr != nil {
+				break
 			}
+
+			if err != nil {
+				logger.WithError(err).WithField("publicId", det.PublicID).Error("failed to create detection")
+				continue
+			}
+
+			delete(toDelete, det.PublicID)
+			results.Added++
+		}
+	}
+
+	if eterr != nil || e.writeNoRead != nil {
+		if eterr != nil {
+			logger.WithError(eterr).Error("unable to sync YARA community detections")
+		}
+		if e.writeNoRead != nil {
+			logger.Warn("detection was written but not read back, attempting read before continuing")
 		}
 
-		errMap, err := e.syncDetections(e.srv.Context)
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameElastAlert,
+				Status: "error",
+			})
+		}
+
+		return detections.ErrSyncFailed
+	}
+
+	for publicId := range toDelete {
+		if !e.isRunning {
+			break
+		}
+
+		_, err = e.srv.Detectionstore.DeleteDetection(e.srv.Context, communityDetections[publicId].Id)
 		if err != nil {
-			if err == errModuleStopped {
-				log.Info("incomplete sync of YARA community detections due to module stopping")
-				return
-			}
-
-			log.WithError(err).Error("unable to sync YARA community detections")
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "error",
-				})
-			}
-
+			logger.WithError(err).WithField("publicId", publicId).Error("Failed to delete unreferenced community detection")
 			continue
 		}
 
-		detections.WriteStateFile(e.IOManager, e.stateFilePath)
+		results.Removed++
+	}
+
+	err = e.syncDetections(e.srv.Context)
+	if err != nil {
+		if errors.Is(err, detections.ErrModuleStopped) {
+			logger.Info("incomplete sync of YARA community detections due to module stopping")
+			return err
+		}
+
+		log.WithError(err).Error("unable to sync YARA community detections")
 
 		if e.notify {
-			if len(errMap) > 0 {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "partial",
-				})
-			} else {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "success",
-				})
-			}
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameStrelka,
+				Status: "error",
+			})
 		}
 
-		_, _, err = e.IntegrityCheck(false)
-
-		e.EngineState.IntegrityFailure = err != nil
-		lastSyncSuccess = util.Ptr(err == nil)
-
-		if err != nil {
-			log.WithError(err).Error("post-sync integrity check failed")
-		} else {
-			log.Info("post-sync integrity check passed")
-		}
-
-		log.WithFields(log.Fields{
-			"errMap":        errMap,
-			"syncStartTime": time.Since(start).Seconds(),
-		}).Info("Strelka community rules sync finished")
+		return detections.ErrSyncFailed
 	}
+
+	detections.WriteStateFile(e.IOManager, e.StateFilePath)
+
+	if e.notify {
+		e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+			Engine: model.EngineNameStrelka,
+			Status: "success",
+		})
+	}
+
+	_, _, err = e.IntegrityCheck(false)
+
+	e.EngineState.IntegrityFailure = err != nil
+
+	if err != nil {
+		logger.WithError(err).Error("post-sync integrity check failed")
+	} else {
+		logger.Info("post-sync integrity check passed")
+	}
+
+	log.WithFields(log.Fields{
+		"strelkaSyncadded":     results.Added,
+		"strelkaSyncupdated":   results.Updated,
+		"strelkaSyncremoved":   results.Removed,
+		"strelkaSyncunchanged": results.Unchanged,
+	}).Info("strelka community diff")
+
+	return nil
 }
 
 func (e *StrelkaEngine) parseYaraRules(data []byte, filter bool) ([]*YaraRule, error) {
@@ -877,21 +806,21 @@ func buildImportChecker(pkg string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`[^"]\b%s\b[^"]`, pkg))
 }
 
-func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]string, err error) {
+func (e *StrelkaEngine) syncDetections(ctx context.Context) (err error) {
 	results, err := e.srv.Detectionstore.GetAllDetections(ctx, model.WithEngine(model.EngineNameStrelka), model.WithEnabled(true))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	enabledDetections := map[string]*model.Detection{}
 	for pid, det := range results {
 		if !e.isRunning {
-			return nil, errModuleStopped
+			return detections.ErrModuleStopped
 		}
 
 		_, exists := enabledDetections[pid]
 		if exists {
-			return nil, fmt.Errorf("duplicate detection with public ID %s", pid)
+			return fmt.Errorf("duplicate detection with public ID %s", pid)
 		}
 		enabledDetections[pid] = det
 	}
@@ -899,7 +828,7 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]s
 	// Clear existing .yar files in the directory
 	files, err := e.ReadDir(e.yaraRulesFolder)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read directory: %v", err)
+		return fmt.Errorf("failed to read directory: %v", err)
 	}
 
 	deleteByExt := map[string]struct{}{
@@ -912,7 +841,7 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]s
 		if ok {
 			err := e.DeleteFile(filepath.Join(e.yaraRulesFolder, file.Name()))
 			if err != nil {
-				return nil, fmt.Errorf("failed to delete existing .yar file %s: %v", file.Name(), err)
+				return fmt.Errorf("failed to delete existing .yar file %s: %v", file.Name(), err)
 			}
 		}
 	}
@@ -923,7 +852,7 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]s
 
 		err := e.WriteFile(filename, []byte(det.Content), 0644)
 		if err != nil {
-			return nil, fmt.Errorf("failed to write file for detection %s: %v", publicId, err)
+			return fmt.Errorf("failed to write file for detection %s: %v", publicId, err)
 		}
 	}
 
@@ -941,10 +870,10 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (errMap map[string]s
 	}).Info("yara compilation results")
 
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (e *StrelkaEngine) DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error) {

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -331,8 +331,8 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 	}
 
 	toDelete := map[string]struct{}{}
-	for _, det := range communityDetections {
-		toDelete[det.PublicID] = struct{}{}
+	for pid := range communityDetections {
+		toDelete[pid] = struct{}{}
 	}
 
 	et := detections.NewErrorTracker(e.failAfterConsecutiveErrorCount)

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -959,7 +959,7 @@ func TestIntegrityCheck(t *testing.T) {
 				IOManager: iom,
 			}
 
-			DbnE, EbnD, err := e.IntegrityCheck(false)
+			DbnE, EbnD, err := e.IntegrityCheck(false, nil)
 
 			if test.ExpError != nil {
 				assert.Error(t, err)

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -731,8 +731,8 @@ func TestGetCompilationResult(t *testing.T) {
 	mio.EXPECT().ReadFile("/opt/so/state/detections_yara_compilation-total.log").Return([]byte(jsn), nil)
 
 	eng := &StrelkaEngine{
-		IOManager:       mio,
 		yaraRulesFolder: "/opt/so/conf/strelka/rules",
+		IOManager:       mio,
 	}
 
 	report, err := eng.getCompilationReport()

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -8,6 +8,7 @@ package strelka
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -17,11 +18,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/module"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	servermock "github.com/security-onion-solutions/securityonion-soc/server/mock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/handmock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 
@@ -969,4 +972,239 @@ func TestIntegrityCheck(t *testing.T) {
 			assert.Equal(t, test.EbnD, EbnD)
 		})
 	}
+}
+
+func TestSyncWriteNoReadFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().GetDetectionByPublicId(gomock.Any(), "123").Return(nil, errors.New("Object not found"))
+
+	wnr := util.Ptr("123")
+
+	eng := &StrelkaEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+		},
+		writeNoRead: wnr,
+	}
+
+	logger := log.WithField("detectionEngineName", "test")
+
+	err := eng.Sync(logger, false)
+	assert.Equal(t, detections.ErrSyncFailed, err)
+	assert.Equal(t, wnr, eng.writeNoRead)
+}
+
+func TestSyncIncrementalNoChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+
+	// UpdateRepos
+	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: "repo",
+			Dir:      true,
+		},
+	}, nil)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo").Return(false, false)
+	// WriteStateFile
+	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	// IntegrityCheck
+	iom.EXPECT().ReadFile("/opt/so/state/detections_yara_compilation-total.log").Return([]byte(`{"timestamp": "now", "success": ["publicId"], "failure": [], "compiled_sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}`), nil) // getCompilationReport
+	iom.EXPECT().ReadFile("/opt/so/saltstack/local/salt/strelka/rules/compiled/rules.compiled").Return([]byte("abc"), nil)                                                                                                                                  // verifyCompiledHash
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		"publicId": nil,
+	}, nil)
+
+	eng := &StrelkaEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+		},
+		isRunning:   true,
+		reposFolder: "repos",
+		rulesRepos: []*model.RuleRepo{
+			{
+				Repo:      "https://github.com/user/repo",
+				Community: true,
+			},
+		},
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager: iom,
+	}
+
+	logger := log.WithField("detectionEngineName", "test-strelka")
+
+	err := eng.Sync(logger, false)
+	assert.NoError(t, err)
+
+	assert.True(t, eng.EngineState.Syncing) // stays true until the SyncScheduler resets it
+	assert.False(t, eng.EngineState.IntegrityFailure)
+	assert.False(t, eng.EngineState.Migrating)
+	assert.False(t, eng.EngineState.MigrationFailure)
+	assert.False(t, eng.EngineState.Importing)
+	assert.False(t, eng.EngineState.SyncFailure)
+}
+
+func TestSyncChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+
+	eng := &StrelkaEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+			Context:        ctx,
+		},
+		isRunning:   true,
+		reposFolder: "repos",
+		rulesRepos: []*model.RuleRepo{
+			{
+				Repo:      "https://github.com/user/repo",
+				Community: true,
+			},
+		},
+		autoEnabledYaraRules:        []string{"repo"},
+		yaraRulesFolder:             "yaraRulesFolder",
+		compileYaraPythonScriptPath: "compile_yara.py",
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager: iom,
+	}
+
+	logger := log.WithField("detectionEngineName", "test-strelka")
+
+	// UpdateRepos
+	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: "repo",
+			Dir:      true,
+		},
+	}, nil)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo").Return(true, false)
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		"dummy": {
+			Auditable: model.Auditable{
+				Id:         "abc",
+				CreateTime: util.Ptr(time.Now()),
+			},
+			PublicID:  "dummy",
+			IsEnabled: true,
+		},
+		"deleteme": {
+			Auditable: model.Auditable{
+				Id: "delete",
+			},
+			PublicID: "deleteme",
+		},
+	}, nil)
+	iom.EXPECT().WalkDir("repos/repo", gomock.Any()).DoAndReturn(func(path string, walkFn fs.WalkDirFunc) error {
+		files := []fs.DirEntry{
+			&handmock.MockDirEntry{
+				Filename: "rule1.yar",
+			},
+			&handmock.MockDirEntry{
+				Filename: "rule2.yar",
+			},
+		}
+
+		for _, f := range files {
+			err := walkFn(f.Name(), f, nil)
+			assert.NoError(t, err)
+		}
+		return nil
+	})
+	iom.EXPECT().ReadFile("rule1.yar").Return([]byte(simpleRule), nil)
+	iom.EXPECT().ReadFile("rule2.yar").Return([]byte(MyBasicRule), nil)
+	// UpdateDetection
+	detStore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, det *model.Detection) (*model.Detection, error) {
+		assert.Equal(t, "abc", det.Id)
+		assert.Equal(t, "dummy", det.PublicID)
+		assert.True(t, det.IsEnabled)
+		assert.NotEmpty(t, det.Content)
+
+		return nil, nil
+	})
+	// CreateDetection
+	detStore.EXPECT().CreateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, det *model.Detection) (*model.Detection, error) {
+		assert.Equal(t, "ExampleRule", det.PublicID)
+		assert.True(t, det.IsEnabled)
+		assert.True(t, det.IsCommunity)
+		assert.NotEmpty(t, det.Content)
+
+		return nil, nil
+	})
+	// DeleteDetection
+	detStore.EXPECT().DeleteDetection(ctx, "delete").Return(nil, nil)
+	// syncDetections
+	detStore.EXPECT().GetAllDetections(ctx, gomock.Any()).Return(map[string]*model.Detection{
+		"dummy": {
+			Auditable: model.Auditable{
+				Id:         "abc",
+				CreateTime: util.Ptr(time.Now()),
+			},
+			PublicID:  "dummy",
+			IsEnabled: true,
+		},
+		"ExampleRule": {
+			Auditable: model.Auditable{
+				Id:         "new",
+				CreateTime: util.Ptr(time.Now()),
+			},
+			PublicID: "ExampleRule",
+		},
+	}, nil)
+	iom.EXPECT().ReadDir("yaraRulesFolder").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: "pre-existing-rule.compiled",
+		},
+	}, nil)
+	iom.EXPECT().DeleteFile("yaraRulesFolder/pre-existing-rule.compiled").Return(nil)
+	iom.EXPECT().WriteFile("yaraRulesFolder/dummy.yar", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	iom.EXPECT().WriteFile("yaraRulesFolder/ExampleRule.yar", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	iom.EXPECT().ExecCommand(gomock.Any()).DoAndReturn(func(cmd *exec.Cmd) ([]byte, int, time.Duration, error) {
+		assert.Contains(t, cmd.Args, "python3")
+		assert.Len(t, cmd.Args, 3)
+		assert.Equal(t, "python3", cmd.Args[0])
+		assert.Equal(t, "compile_yara.py", cmd.Args[1])
+		assert.Equal(t, "yaraRulesFolder", cmd.Args[2])
+		return []byte("Compiled Successfully"), 0, time.Duration(time.Second), nil
+	})
+
+	// WriteStateFile
+	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	// IntegrityCheck
+	iom.EXPECT().ReadFile("/opt/so/state/detections_yara_compilation-total.log").Return([]byte(`{"timestamp": "now", "success": ["dummy", "ExampleRule"], "failure": [], "compiled_sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}`), nil) // getCompilationReport
+	iom.EXPECT().ReadFile("/opt/so/saltstack/local/salt/strelka/rules/compiled/rules.compiled").Return([]byte("abc"), nil)                                                                                                                                              // verifyCompiledHash
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		"dummy":       nil,
+		"ExampleRule": nil,
+	}, nil)
+
+	err := eng.Sync(logger, false)
+	assert.NoError(t, err)
+
+	assert.True(t, eng.EngineState.Syncing) // stays true until the SyncScheduler resets it
+	assert.False(t, eng.EngineState.IntegrityFailure)
+	assert.False(t, eng.EngineState.Migrating)
+	assert.False(t, eng.EngineState.MigrationFailure)
+	assert.False(t, eng.EngineState.Importing)
+	assert.False(t, eng.EngineState.SyncFailure)
 }

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1198,7 +1198,7 @@ func TestSyncChanges(t *testing.T) {
 		"ExampleRule": nil,
 	}, nil)
 
-	err := eng.Sync(logger, false)
+	err := eng.Sync(logger, true)
 	assert.NoError(t, err)
 
 	assert.True(t, eng.EngineState.Syncing) // stays true until the SyncScheduler resets it

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -18,7 +18,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/module"
@@ -34,7 +33,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var errModuleStopped = fmt.Errorf("suricata module has stopped running")
 var sidExtracter = regexp.MustCompile(`(?i)\bsid: ?['"]?(.*?)['"]?;`)
 
 const modifyFromTo = `"flowbits" "noalert; flowbits"`
@@ -60,26 +58,24 @@ const (
 )
 
 type SuricataEngine struct {
-	srv                                  *server.Server
-	communityRulesFile                   string
-	allRulesFile                         string
-	rulesFingerprintFile                 string
-	communityRulesImportFrequencySeconds int
-	communityRulesImportErrorSeconds     int
-	failAfterConsecutiveErrorCount       int
-	isRunning                            bool
-	syncThread                           *sync.WaitGroup
-	interruptSync                        chan bool
-	interm                               sync.Mutex
-	allowRegex                           *regexp.Regexp
-	denyRegex                            *regexp.Regexp
-	notify                               bool
-	stateFilePath                        string
-	migrations                           map[string]func(string) error
-	customRulesets                       []*model.CustomRuleset
+	srv                            *server.Server
+	communityRulesFile             string
+	allRulesFile                   string
+	rulesFingerprintFile           string
+	failAfterConsecutiveErrorCount int
+	isRunning                      bool
+	interm                         sync.Mutex
+	allowRegex                     *regexp.Regexp
+	denyRegex                      *regexp.Regexp
+	notify                         bool
+	migrations                     map[string]func(string) error
+	customRulesets                 []*model.CustomRuleset
+	writeNoRead                    *string
+	checkMigrationsOnce            func()
+	detections.SyncSchedulerParams
 	detections.IntegrityCheckerData
-	model.EngineState
 	detections.IOManager
+	model.EngineState
 }
 
 func NewSuricataEngine(srv *server.Server) *SuricataEngine {
@@ -87,6 +83,8 @@ func NewSuricataEngine(srv *server.Server) *SuricataEngine {
 		srv:       srv,
 		IOManager: &detections.ResourceManager{Config: srv.Config},
 	}
+
+	e.checkMigrationsOnce = sync.OnceFunc(e.checkForMigrations)
 
 	e.migrations = map[string]func(string) error{
 		"2.4.70": e.Migration2470,
@@ -104,16 +102,16 @@ func (e *SuricataEngine) GetState() *model.EngineState {
 }
 
 func (e *SuricataEngine) Init(config module.ModuleConfig) (err error) {
-	e.syncThread = &sync.WaitGroup{}
-	e.interruptSync = make(chan bool, 1)
+	e.SyncThread = &sync.WaitGroup{}
+	e.InterruptChan = make(chan bool, 1)
 	e.IntegrityCheckerData.Thread = &sync.WaitGroup{}
 	e.IntegrityCheckerData.Interrupt = make(chan bool, 1)
 
 	e.communityRulesFile = module.GetStringDefault(config, "communityRulesFile", DEFAULT_COMMUNITY_RULES_FILE)
 	e.allRulesFile = module.GetStringDefault(config, "allRulesFile", DEFAULT_ALL_RULES_FILE)
 	e.rulesFingerprintFile = module.GetStringDefault(config, "rulesFingerprintFile", DEFAULT_RULES_FINGERPRINT_FILE)
-	e.communityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", DEFAULT_COMMUNITY_RULES_IMPORT_FREQUENCY_SECS)
-	e.communityRulesImportErrorSeconds = module.GetIntDefault(config, "communityRulesImportErrorSeconds", DEFAULT_COMMUNITY_RULES_IMPORT_ERROR_SECS)
+	e.CommunityRulesImportFrequencySeconds = module.GetIntDefault(config, "communityRulesImportFrequencySeconds", DEFAULT_COMMUNITY_RULES_IMPORT_FREQUENCY_SECS)
+	e.CommunityRulesImportErrorSeconds = module.GetIntDefault(config, "communityRulesImportErrorSeconds", DEFAULT_COMMUNITY_RULES_IMPORT_ERROR_SECS)
 	e.failAfterConsecutiveErrorCount = module.GetIntDefault(config, "failAfterConsecutiveErrorCount", DEFAULT_FAIL_AFTER_CONSECUTIVE_ERROR_COUNT)
 	e.IntegrityCheckerData.FrequencySeconds = module.GetIntDefault(config, "integrityCheckFrequencySeconds", DEFAULT_INTEGRITY_CHECK_FREQUENCY_SECONDS)
 
@@ -136,7 +134,7 @@ func (e *SuricataEngine) Init(config module.ModuleConfig) (err error) {
 		}
 	}
 
-	e.stateFilePath = module.GetStringDefault(config, "stateFilePath", DEFAULT_STATE_FILE_PATH)
+	e.StateFilePath = module.GetStringDefault(config, "stateFilePath", DEFAULT_STATE_FILE_PATH)
 	e.customRulesets, err = model.GetCustomRulesetsDefault(config, "customRulesets", []*model.CustomRuleset{})
 	if err != nil {
 		return fmt.Errorf("unable to get custom rulesets: %w", err)
@@ -150,7 +148,7 @@ func (e *SuricataEngine) Start() error {
 	e.isRunning = true
 	e.IntegrityCheckerData.IsRunning = true
 
-	go e.watchCommunityRules()
+	go detections.SyncScheduler(e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameSuricata, &e.isRunning, e.IOManager)
 	go detections.IntegrityChecker(model.EngineNameSuricata, e, &e.IntegrityCheckerData, &e.EngineState.IntegrityFailure)
 
 	return nil
@@ -159,8 +157,8 @@ func (e *SuricataEngine) Start() error {
 func (e *SuricataEngine) Stop() error {
 	e.isRunning = false
 	e.InterruptSync(false, false)
-	e.syncThread.Wait()
-	e.pauseIntegrityChecker()
+	e.SyncThread.Wait()
+	e.PauseIntegrityChecker()
 	e.interruptIntegrityCheck()
 	e.IntegrityCheckerData.Thread.Wait()
 
@@ -173,19 +171,19 @@ func (e *SuricataEngine) InterruptSync(fullUpgrade bool, notify bool) {
 
 	e.notify = notify
 
-	if len(e.interruptSync) == 0 {
-		e.interruptSync <- fullUpgrade
+	if len(e.InterruptChan) == 0 {
+		e.InterruptChan <- fullUpgrade
 	}
 }
 
-func (e *SuricataEngine) resetInterrupt() {
+func (e *SuricataEngine) resetInterruptSync() {
 	e.interm.Lock()
 	defer e.interm.Unlock()
 
 	e.notify = false
 
-	if len(e.interruptSync) != 0 {
-		<-e.interruptSync
+	if len(e.InterruptChan) != 0 {
+		<-e.InterruptChan
 	}
 }
 
@@ -198,11 +196,11 @@ func (e *SuricataEngine) interruptIntegrityCheck() {
 	}
 }
 
-func (e *SuricataEngine) pauseIntegrityChecker() {
+func (e *SuricataEngine) PauseIntegrityChecker() {
 	e.IntegrityCheckerData.IsRunning = false
 }
 
-func (e *SuricataEngine) resumeIntegrityChecker() {
+func (e *SuricataEngine) ResumeIntegrityChecker() {
 	e.IntegrityCheckerData.IsRunning = true
 }
 
@@ -287,277 +285,52 @@ func (e *SuricataEngine) ExtractDetails(detect *model.Detection) error {
 	return nil
 }
 
-func (e *SuricataEngine) watchCommunityRules() {
-	e.syncThread.Add(1)
+func (e *SuricataEngine) Sync(logger *log.Entry, forceSync bool) error {
 	defer func() {
-		e.syncThread.Done()
-		e.isRunning = false
+		e.resetInterruptSync()
 	}()
 
-	// |> nil: no import has been completed, it's this way during the first sync
-	// so that the timerDur returned by DetermineWaitTime is used. After first sync,
-	// the pointer should always have a value
-	// |> false: the last sync was not successful, the timer for the next sync should use
-	// the shorter communityRulesImportErrorSeconds timer.
-	// |> true: the last sync was successful, the timer for the next sync should use
-	// the normal communityRulesImportFrequencySeconds timer.
-	var lastSyncSuccess *bool
-
-	// publicId of a detection that was written but not read back
-	var writeNoRead *string
-
-	ctx := e.srv.Context
-	checkMigrationsOnce := sync.OnceFunc(e.checkForMigrations)
-
-	lastImport, timerDur := detections.DetermineWaitTime(e.IOManager, e.stateFilePath, time.Second*time.Duration(e.communityRulesImportFrequencySeconds))
-
-	for e.isRunning {
-		if lastImport == nil && lastSyncSuccess != nil && *lastSyncSuccess {
-			now := uint64(time.Now().UnixMilli())
-			lastImport = &now
+	if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, e.writeNoRead) {
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameStrelka,
+				Status: "error",
+			})
 		}
 
-		e.EngineState.Syncing = false
-		e.EngineState.Importing = lastImport == nil
-		e.EngineState.Migrating = false
-		e.EngineState.SyncFailure = lastSyncSuccess != nil && !*lastSyncSuccess
+		return detections.ErrSyncFailed
+	}
 
-		e.resetInterrupt()
+	e.writeNoRead = nil
 
-		var forceSync bool
+	e.EngineState.Syncing = true
 
-		if lastSyncSuccess != nil {
-			if *lastSyncSuccess {
-				timerDur = time.Second * time.Duration(e.communityRulesImportFrequencySeconds)
-			} else {
-				timerDur = time.Second * time.Duration(e.communityRulesImportErrorSeconds)
-				forceSync = true
-			}
+	rules, hash, err := e.readAndHash(e.communityRulesFile)
+	if err != nil {
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "error",
+			})
 		}
 
-		timer := time.NewTimer(timerDur)
+		logger.WithError(err).Error("unable to read community rules file")
 
-		lastSyncStatus := "nil"
-		if lastSyncSuccess != nil {
-			lastSyncStatus = strconv.FormatBool(*lastSyncSuccess)
-		}
+		return detections.ErrSyncFailed
+	}
 
-		log.WithFields(log.Fields{
-			"waitTimeSeconds":   timerDur.Seconds(),
-			"forceSync":         forceSync,
-			"lastSyncSuccess":   lastSyncStatus,
-			"expectedStartTime": time.Now().Add(timerDur).Format(time.RFC3339),
-		}).Info("waiting for next suricata community rules sync")
-
-		e.resumeIntegrityChecker()
-
-		select {
-		case <-timer.C:
-		case typ := <-e.interruptSync:
-			forceSync = forceSync || typ
-		}
-
-		e.pauseIntegrityChecker()
-
-		if !e.isRunning {
-			break
-		}
-
-		lastSyncSuccess = util.Ptr(false)
-
-		if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, writeNoRead) {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameStrelka,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		writeNoRead = nil
-
-		log.WithFields(log.Fields{
-			"forceSync": forceSync,
-		}).Info("syncing suricata community rules")
-
-		e.EngineState.Syncing = true
-
-		start := time.Now()
-
-		tmplExists := detections.CheckTemplate(e.srv.Context, e.srv.Detectionstore)
-		if !tmplExists {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameSuricata,
-					Status: "error",
-				})
-			}
-
-			continue
-		}
-
-		rules, hash, err := e.readAndHash(e.communityRulesFile)
+	if !forceSync {
+		fingerprint, haveFP, err := e.readFingerprint(e.rulesFingerprintFile)
 		if err != nil {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameSuricata,
-					Status: "error",
-				})
-			}
-
-			log.WithError(err).Error("unable to read community rules file")
-
-			continue
+			logger.WithError(err).Error("unable to read rules fingerprint file")
+			return detections.ErrSyncFailed
 		}
 
-		// If no import has been completed, then do a full sync
-		if lastImport == nil {
-			forceSync = true
-		}
+		if haveFP && strings.EqualFold(*fingerprint, hash) {
+			// if we have a fingerprint and the hashes are equal, there's nothing to do
+			logger.Info("community rule sync found no changes")
 
-		if !forceSync {
-			fingerprint, haveFP, err := e.readFingerprint(e.rulesFingerprintFile)
-			if err != nil {
-				log.WithError(err).Error("unable to read rules fingerprint file")
-				continue
-			}
-
-			if haveFP && strings.EqualFold(*fingerprint, hash) {
-				// if we have a fingerprint and the hashes are equal, there's nothing to do
-				log.Info("suricata sync found no changes")
-
-				detections.WriteStateFile(e.IOManager, e.stateFilePath)
-
-				if e.notify {
-					e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-						Engine: model.EngineNameSuricata,
-						Status: "success",
-					})
-				}
-
-				checkMigrationsOnce()
-
-				_, _, err = e.IntegrityCheck(false)
-
-				e.EngineState.IntegrityFailure = err != nil
-				lastSyncSuccess = util.Ptr(err == nil)
-
-				if err != nil {
-					log.WithError(err).Error("post-sync integrity check failed")
-				} else {
-					log.Info("post-sync integrity check passed")
-				}
-
-				continue
-			}
-		}
-
-		allSettings, err := e.srv.Configstore.GetSettings(ctx)
-		if err != nil {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameSuricata,
-					Status: "error",
-				})
-			}
-
-			log.WithError(err).Error("unable to get settings")
-
-			continue
-		}
-
-		if !e.isRunning {
-			break
-		}
-
-		ruleset := settingByID(allSettings, "idstools.config.ruleset")
-
-		commDetections, err := e.ParseRules(rules, ruleset.Value, true)
-		if err != nil {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameSuricata,
-					Status: "error",
-				})
-			}
-
-			log.WithError(err).Error("unable to parse community rules")
-
-			continue
-		}
-
-		for _, d := range commDetections {
-			d.IsCommunity = true
-		}
-
-		dets, err := e.ReadCustomRulesets()
-		if err != nil {
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameSuricata,
-					Status: "error",
-				})
-			}
-
-			log.WithError(err).Error("unable to parse custom rulesets")
-
-			continue
-		}
-
-		commDetections = append(commDetections, dets...)
-
-		commDetections = detections.DeduplicateByPublicId(commDetections)
-
-		errMap, err := e.syncCommunityDetections(ctx, commDetections, true, allSettings)
-		if err != nil {
-			if err == errModuleStopped {
-				log.Info("incomplete sync of suricata community detections due to module stopping")
-				break
-			}
-
-			if err.Error() == "Object not found" {
-				// errMap contains exactly 1 error: the publicId of the detection that
-				// was written to but not read back
-				for publicId := range errMap {
-					writeNoRead = util.Ptr(publicId)
-				}
-			}
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameSuricata,
-					Status: "error",
-				})
-			}
-
-			log.WithError(err).Error("unable to sync suricata community detections")
-
-			continue
-		}
-
-		detections.WriteStateFile(e.IOManager, e.stateFilePath)
-		lastSyncSuccess = util.Ptr(true)
-
-		if len(errMap) > 0 {
-			// there were errors, don't save the fingerprint.
-			// idempotency means we might fix it if we try again later.
-			log.WithFields(log.Fields{
-				"suricataSyncErrors": errMap,
-			}).Error("unable to sync all community detections")
-
-			if e.notify {
-				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-					Engine: model.EngineNameSuricata,
-					Status: "partial",
-				})
-			}
-		} else {
-			err = os.WriteFile(e.rulesFingerprintFile, []byte(hash), 0644)
-			if err != nil {
-				log.WithError(err).WithField("repoPath", e.rulesFingerprintFile).Error("unable to write rules fingerprint file")
-			}
+			detections.WriteStateFile(e.IOManager, e.StateFilePath)
 
 			if e.notify {
 				e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
@@ -566,26 +339,146 @@ func (e *SuricataEngine) watchCommunityRules() {
 				})
 			}
 
+			e.checkMigrationsOnce()
+
 			_, _, err = e.IntegrityCheck(false)
 
 			e.EngineState.IntegrityFailure = err != nil
-			lastSyncSuccess = util.Ptr(err == nil)
 
 			if err != nil {
-				log.WithError(err).Error("post-sync integrity check failed")
+				logger.WithError(err).Error("post-sync integrity check failed")
 			} else {
-				log.Info("post-sync integrity check passed")
+				logger.Info("post-sync integrity check passed")
+			}
+
+			// a non-forceSync sync that found no changes is a success
+			return nil
+		}
+	}
+
+	allSettings, err := e.srv.Configstore.GetSettings(e.srv.Context)
+	if err != nil {
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "error",
+			})
+		}
+
+		logger.WithError(err).Error("unable to get settings")
+
+		return detections.ErrSyncFailed
+	}
+
+	if !e.isRunning {
+		return detections.ErrModuleStopped
+	}
+
+	ruleset := settingByID(allSettings, "idstools.config.ruleset")
+
+	commDetections, err := e.ParseRules(rules, ruleset.Value, true)
+	if err != nil {
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "error",
+			})
+		}
+
+		logger.WithError(err).Error("unable to parse community rules")
+
+		return detections.ErrSyncFailed
+	}
+
+	for _, d := range commDetections {
+		d.IsCommunity = true
+	}
+
+	dets, err := e.ReadCustomRulesets()
+	if err != nil {
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "error",
+			})
+		}
+
+		logger.WithError(err).Error("unable to parse custom rulesets")
+
+		return detections.ErrSyncFailed
+	}
+
+	commDetections = append(commDetections, dets...)
+
+	commDetections = detections.DeduplicateByPublicId(commDetections)
+
+	errMap, err := e.syncCommunityDetections(e.srv.Context, logger, commDetections, true, allSettings)
+	if err != nil {
+		if errors.Is(err, detections.ErrModuleStopped) {
+			logger.Info("incomplete sync of suricata community detections due to module stopping")
+			return err
+		}
+
+		if err.Error() == "Object not found" {
+			// errMap contains exactly 1 error: the publicId of the detection that
+			// was written to but not read back
+			for publicId := range errMap {
+				e.writeNoRead = util.Ptr(publicId)
 			}
 		}
 
-		dur := time.Since(start)
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "error",
+			})
+		}
 
-		log.WithFields(log.Fields{
-			"durationSeconds": dur.Seconds(),
-		}).Info("suricata community rules sync finished")
+		logger.WithError(err).Error("unable to sync suricata community detections")
 
-		checkMigrationsOnce()
+		return detections.ErrSyncFailed
 	}
+
+	detections.WriteStateFile(e.IOManager, e.StateFilePath)
+
+	if len(errMap) > 0 {
+		// there were errors, don't save the fingerprint.
+		// idempotency means we might fix it if we try again later.
+		logger.WithField("suricataSyncErrors", errMap).Error("unable to sync all community detections")
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "partial",
+			})
+		}
+	} else {
+		err = e.WriteFile(e.rulesFingerprintFile, []byte(hash), 0644)
+		if err != nil {
+			logger.WithError(err).WithField("repoPath", e.rulesFingerprintFile).Error("unable to write rules fingerprint file")
+		}
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "success",
+			})
+		}
+
+		_, _, err = e.IntegrityCheck(false)
+
+		e.EngineState.IntegrityFailure = err != nil
+
+		if err != nil {
+			logger.WithError(err).Error("post-sync integrity check failed")
+		} else {
+			logger.Info("post-sync integrity check passed")
+		}
+	}
+
+	e.checkMigrationsOnce()
+
+	return nil
 }
 
 func (e *SuricataEngine) checkForMigrations() {
@@ -709,7 +602,7 @@ func (e *SuricataEngine) ParseRules(content string, ruleset string, applyFilters
 
 	for i, line := range lines {
 		if !e.isRunning {
-			return nil, errModuleStopped
+			return nil, detections.ErrModuleStopped
 		}
 
 		line = strings.TrimSpace(line)
@@ -819,7 +712,7 @@ func (e *SuricataEngine) ParseRules(content string, ruleset string, applyFilters
 	return dets, nil
 }
 
-func (e *SuricataEngine) SyncLocalDetections(ctx context.Context, detections []*model.Detection) (errMap map[string]string, err error) {
+func (e *SuricataEngine) SyncLocalDetections(ctx context.Context, detects []*model.Detection) (errMap map[string]string, err error) {
 	defer func() {
 		if len(errMap) == 0 {
 			errMap = nil
@@ -834,7 +727,7 @@ func (e *SuricataEngine) SyncLocalDetections(ctx context.Context, detections []*
 	localDets := []*model.Detection{}
 	communityDets := []*model.Detection{}
 
-	for _, detect := range detections {
+	for _, detect := range detects {
 		if detect.IsCommunity {
 			communityDets = append(communityDets, detect)
 		} else {
@@ -845,7 +738,7 @@ func (e *SuricataEngine) SyncLocalDetections(ctx context.Context, detections []*
 	errMap = map[string]string{} // map[sid]error
 
 	if len(communityDets) != 0 {
-		eMap, err := e.syncCommunityDetections(ctx, communityDets, false, allSettings)
+		eMap, err := e.syncCommunityDetections(ctx, nil, communityDets, false, allSettings)
 		if err != nil {
 			return eMap, err
 		}
@@ -898,7 +791,7 @@ func (e *SuricataEngine) SyncLocalDetections(ctx context.Context, detections []*
 
 	for _, detect := range localDets {
 		if !e.isRunning {
-			return nil, errModuleStopped
+			return nil, detections.ErrModuleStopped
 		}
 
 		parsedRule, err := ParseSuricataRule(detect.Content)
@@ -1155,7 +1048,7 @@ func removeFromIndex(lines []string, index map[string]int, sid string) {
 	}
 }
 
-func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []*model.Detection, deleteUnreferenced bool, allSettings []*model.Setting) (errMap map[string]string, err error) {
+func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *log.Entry, detects []*model.Detection, deleteUnreferenced bool, allSettings []*model.Setting) (errMap map[string]string, err error) {
 	defer func() {
 		if len(errMap) == 0 {
 			errMap = nil
@@ -1164,6 +1057,10 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []
 	errMap = map[string]string{}
 
 	changedByUser := web.IsChangedByUser(ctx)
+
+	if logger == nil {
+		logger = log.WithField("detectionEngineName", model.EngineNameSuricata)
+	}
 
 	results := struct {
 		Added     int
@@ -1220,8 +1117,13 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []
 
 	for _, detect := range detects {
 		if !e.isRunning {
-			return nil, errModuleStopped
+			return nil, detections.ErrModuleStopped
 		}
+
+		logger.WithFields(log.Fields{
+			"rule.uuid": detect.PublicID,
+			"rule.name": detect.Title,
+		}).Info("syncing rule")
 
 		orig, exists := commSIDs[detect.PublicID]
 		if exists {
@@ -1273,6 +1175,11 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []
 			if orig.Content != detect.Content || orig.Ruleset != detect.Ruleset || len(detect.Overrides) != 0 || orig.IsEnabled != detect.IsEnabled {
 				detect.Kind = ""
 
+				logger.WithFields(log.Fields{
+					"rule.uuid": detect.PublicID,
+					"rule.name": detect.Title,
+				}).Info("updating Suricata detection")
+
 				_, err = e.srv.Detectionstore.UpdateDetection(ctx, detect)
 				if err != nil {
 					if err.Error() == "Object not found" {
@@ -1298,6 +1205,11 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []
 				delete(toDelete, detect.PublicID)
 			}
 		} else {
+			logger.WithFields(log.Fields{
+				"rule.uuid": detect.PublicID,
+				"rule.name": detect.Title,
+			}).Info("creating new Suricata detection")
+
 			_, err = e.srv.Detectionstore.CreateDetection(ctx, detect)
 			if err != nil {
 				if err.Error() == "Object not found" {
@@ -1323,7 +1235,7 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []
 	if deleteUnreferenced {
 		for sid := range toDelete {
 			if !e.isRunning {
-				return nil, errModuleStopped
+				return nil, detections.ErrModuleStopped
 			}
 
 			removeFromIndex(enabledLines, enabledIndex, sid)
@@ -1376,15 +1288,16 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, detects []
 		return errMap, err
 	}
 
-	log.WithFields(log.Fields{
-		"syncAdded":              results.Added,
-		"syncUpdated":            results.Updated,
-		"syncRemoved":            results.Removed,
-		"syncUnchanged":          results.Unchanged,
-		"syncErrors":             errMap,
-		"syncDeleteUnreferenced": deleteUnreferenced,
-	}).Info("suricata community diff")
-
+	if logger != nil {
+		logger.WithFields(log.Fields{
+			"syncAdded":              results.Added,
+			"syncUpdated":            results.Updated,
+			"syncRemoved":            results.Removed,
+			"syncUnchanged":          results.Unchanged,
+			"syncErrors":             errMap,
+			"syncDeleteUnreferenced": deleteUnreferenced,
+		}).Info("suricata community diff")
+	}
 	return errMap, nil
 }
 

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -2008,7 +2008,7 @@ func TestIntegrityCheck(t *testing.T) {
 				IOManager:    iom,
 			}
 
-			DbnE, EbnD, err := e.IntegrityCheck(false)
+			DbnE, EbnD, err := e.IntegrityCheck(false, nil)
 
 			if test.ExpError != nil {
 				assert.Error(t, err)

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -992,7 +992,7 @@ func TestSyncCommunitySuricata(t *testing.T) {
 
 			ctx := web.MarkChangedByUser(context.Background(), test.ChangedByUser)
 
-			errMap, err := mod.syncCommunityDetections(ctx, test.Detections, false, test.InitialSettings)
+			errMap, err := mod.syncCommunityDetections(ctx, nil, test.Detections, false, test.InitialSettings)
 
 			assert.Equal(t, test.ExpectedErr, err)
 			assert.Equal(t, test.ExpectedErrMap, errMap)

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -13,14 +13,17 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/module"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	servermock "github.com/security-onion-solutions/securityonion-soc/server/mock"
-	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/handmock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/handmock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 	"github.com/security-onion-solutions/securityonion-soc/web"
@@ -2018,4 +2021,196 @@ func TestIntegrityCheck(t *testing.T) {
 			assert.Equal(t, test.EbnD, EbnD)
 		})
 	}
+}
+
+func TestSyncWriteNoReadFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().GetDetectionByPublicId(gomock.Any(), "123").Return(nil, errors.New("Object not found"))
+
+	wnr := util.Ptr("123")
+
+	eng := &SuricataEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+		},
+		writeNoRead: wnr,
+	}
+
+	logger := log.WithField("detectionEngineName", "test-suricata")
+
+	err := eng.Sync(logger, false)
+	assert.Equal(t, detections.ErrSyncFailed, err)
+	assert.Equal(t, wnr, eng.writeNoRead)
+}
+
+func TestSyncIncrementalNoChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+	cfgStore := server.NewMemConfigStore([]*model.Setting{
+		{Id: "idstools.rules.local__rules"},
+		{Id: "idstools.sids.enabled"},
+		{Id: "idstools.sids.disabled"},
+		{Id: "idstools.sids.modify"},
+		{Id: "suricata.thresholding.sids__yaml"},
+	})
+
+	migrationChecked := false
+	checkMigration := func() {
+		migrationChecked = true
+	}
+
+	eng := &SuricataEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+			Configstore:    cfgStore,
+		},
+		isRunning:            true,
+		communityRulesFile:   "communityRulesFile",
+		rulesFingerprintFile: "rulesFingerprintFile",
+		checkMigrationsOnce:  sync.OnceFunc(checkMigration),
+		allRulesFile:         "allRulesFile",
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager: iom,
+	}
+
+	logger := log.WithField("detectionEngineName", "test-suricata")
+
+	// readAndHash
+	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule), nil)
+	// readFingerprint
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return([]byte("2a4374cf63736ccbaf7a58aedf2282cb21afebf82120e29e4cbcc459516852f2"), nil)
+	// WriteStateFile
+	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	// IntegrityCheck
+	iom.EXPECT().ReadFile("allRulesFile").Return([]byte(SimpleRule), nil)
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		"10000": nil,
+	}, nil)
+
+	err := eng.Sync(logger, false)
+	assert.NoError(t, err)
+
+	assert.True(t, eng.EngineState.Syncing) // stays true until the SyncScheduler resets it
+	assert.False(t, eng.EngineState.IntegrityFailure)
+	assert.False(t, eng.EngineState.Migrating)
+	assert.False(t, eng.EngineState.MigrationFailure)
+	assert.False(t, eng.EngineState.Importing)
+	assert.False(t, eng.EngineState.SyncFailure)
+	assert.True(t, migrationChecked)
+}
+
+func TestSyncChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+	cfgStore := server.NewMemConfigStore([]*model.Setting{
+		{Id: "idstools.rules.local__rules", Value: FlowbitsRuleA},
+		{Id: "idstools.sids.enabled", Value: SimpleRuleSID + "\n99999"},
+		{Id: "idstools.sids.disabled"},
+		{Id: "idstools.sids.modify", Value: FlowbitsRuleASID + " " + modifyFromTo}, // used to be disabled, will be enabled
+		{Id: "suricata.thresholding.sids__yaml"},
+		{Id: "idstools.config.ruleset", Value: "repo"},
+	})
+
+	migrationChecked := false
+	checkMigration := func() {
+		migrationChecked = true
+	}
+
+	eng := &SuricataEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+			Configstore:    cfgStore,
+			Context:        ctx,
+		},
+		isRunning:            true,
+		communityRulesFile:   "communityRulesFile",
+		rulesFingerprintFile: "rulesFingerprintFile",
+		checkMigrationsOnce:  sync.OnceFunc(checkMigration),
+		allRulesFile:         "allRulesFile",
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager: iom,
+	}
+
+	logger := log.WithField("detectionEngineName", "test-suricata")
+
+	// readAndHash
+	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule+"\n"+FlowbitsRuleA), nil)
+	// syncCommunityDetections
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		SimpleRuleSID: {
+			Auditable: model.Auditable{
+				Id:         "abc",
+				CreateTime: util.Ptr(time.Now()),
+			},
+			IsEnabled: true,
+		},
+		"99999": {
+			Auditable: model.Auditable{
+				Id: "deleteme",
+			},
+		}, // to be deleted
+	}, nil)
+	detStore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(nil, nil)
+	detStore.EXPECT().CreateDetection(ctx, gomock.Any()).Return(nil, nil)
+	detStore.EXPECT().DeleteDetection(ctx, "deleteme").Return(nil, nil)
+	// WriteStateFile
+	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	iom.EXPECT().WriteFile("rulesFingerprintFile", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	// IntegrityCheck
+	iom.EXPECT().ReadFile("allRulesFile").Return([]byte(SimpleRule+"\n"+FlowbitsRuleA), nil)
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		"10000": nil,
+		"50000": nil,
+	}, nil)
+
+	err := eng.Sync(logger, true)
+	assert.NoError(t, err)
+
+	assert.True(t, eng.EngineState.Syncing) // stays true until the SyncScheduler resets it
+	assert.False(t, eng.EngineState.IntegrityFailure)
+	assert.False(t, eng.EngineState.Migrating)
+	assert.False(t, eng.EngineState.MigrationFailure)
+	assert.False(t, eng.EngineState.Importing)
+	assert.False(t, eng.EngineState.SyncFailure)
+	assert.True(t, migrationChecked)
+
+	allSettings, err := cfgStore.GetSettings(ctx)
+	assert.NoError(t, err)
+
+	enabled := settingByID(allSettings, "idstools.sids.enabled")
+	assert.NotNil(t, enabled)
+	assert.Equal(t, SimpleRuleSID, enabled.Value)
+
+	disabled := settingByID(allSettings, "idstools.sids.disabled")
+	assert.NotNil(t, disabled)
+	assert.Equal(t, "", disabled.Value)
+
+	modify := settingByID(allSettings, "idstools.sids.modify")
+	assert.NotNil(t, modify)
+	assert.Equal(t, "", modify.Value)
+
+	threshold := settingByID(allSettings, "suricata.thresholding.sids__yaml")
+	assert.NotNil(t, threshold)
+	assert.Equal(t, "{}\n", threshold.Value)
 }


### PR DESCRIPTION
Refactor sync to eliminate duplicate code and processes shared between the engines. The timing of when syncs happen are all managed the same way and have been simplified with the new SyncScheduler. This also introduces syncIds to the log statements so every individual sync can have it's logs correlated. Logging between the engines has also been made more consistent.