### PR TITLE
Cogburn/suricata sync dupe fix

### DIFF
--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -81,13 +81,13 @@ func readStateFile(iom IOManager, path string) (lastImport *uint64, err error) {
 	return &unix, nil
 }
 
-func TruncateMap[K comparable, V any](originalMap map[K]V, limit int) map[K]V {
-	if len(originalMap) <= limit {
+func TruncateMap[K comparable, V any](originalMap map[K]V, limit uint) map[K]V {
+	if uint(len(originalMap)) <= limit {
 		return originalMap // Return the original map if it's already within the limit
 	}
 
 	truncatedMap := make(map[K]V, limit)
-	count := 0
+	count := uint(0)
 	for key, value := range originalMap {
 		if count >= limit {
 			break
@@ -96,6 +96,14 @@ func TruncateMap[K comparable, V any](originalMap map[K]V, limit int) map[K]V {
 		count++
 	}
 	return truncatedMap
+}
+
+func TruncateList[T any](originalList []T, limit uint) []T {
+	if uint(len(originalList)) <= limit {
+		return originalList // Return the original list if it's already within the limit
+	}
+
+	return originalList[:limit]
 }
 
 func WriteStateFile(iom IOManager, path string) {

--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -51,6 +51,48 @@ func TestTruncateMap(t *testing.T) {
 	assert.Equal(t, 0, len(truncatedErrMap), "Truncated map should have no elements when limit is 0.")
 }
 
+func TestTruncateList(t *testing.T) {
+	tests := []struct {
+		Name       string
+		Array      []int
+		TruncateTo uint
+		ExpArray   []int
+	}{
+		{
+			Name:       "Empty",
+			Array:      []int{},
+			TruncateTo: 10,
+			ExpArray:   []int{},
+		},
+		{
+			Name:       "Below Limit",
+			Array:      []int{0},
+			TruncateTo: 10,
+			ExpArray:   []int{0},
+		},
+		{
+			Name:       "At Limit",
+			Array:      []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			TruncateTo: 10,
+			ExpArray:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			Name:       "Above Limit",
+			Array:      []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			TruncateTo: 5,
+			ExpArray:   []int{0, 1, 2, 3, 4},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			truncated := TruncateList(test.Array, test.TruncateTo)
+			assert.Equal(t, test.ExpArray, truncated)
+		})
+	}
+}
+
 func TestDetermineWaitTimeNoState(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mio := mock.NewMockIOManager(ctrl)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1669,17 +1669,29 @@ func (e *ElastAlertEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) 
 
 	deployedButNotEnabled, enabledButNotDeployed, _ = detections.DiffLists(deployed, enabled)
 
-	report := logger.WithFields(log.Fields{
+	deployedButNotEnabledCount := len(deployedButNotEnabled)
+	if len(deployedButNotEnabled) > 20 {
+		deployedButNotEnabled = deployedButNotEnabled[:20]
+	}
+
+	enabledButNotDeployedCount := len(enabledButNotDeployed)
+	if len(enabledButNotDeployed) > 20 {
+		enabledButNotDeployed = enabledButNotDeployed[:20]
+	}
+
+	intCheckReport := logger.WithFields(log.Fields{
 		"deployedButNotEnabled": deployedButNotEnabled,
 		"enabledButNotDeployed": enabledButNotDeployed,
+		"deployedButNotEnabledCount": deployedButNotEnabledCount,
+		"enabledButNotDeployedCount": enabledButNotDeployedCount,
 	})
 
 	if len(deployedButNotEnabled) > 0 || len(enabledButNotDeployed) > 0 {
-		report.Warn("integrity check failed")
+		intCheckReport.Warn("integrity check failed")
 		return deployedButNotEnabled, enabledButNotDeployed, detections.ErrIntCheckFailed
 	}
 
-	report.Info("integrity check passed")
+	intCheckReport.Info("integrity check passed")
 
 	return deployedButNotEnabled, enabledButNotDeployed, nil
 }

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1669,21 +1669,11 @@ func (e *ElastAlertEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) 
 
 	deployedButNotEnabled, enabledButNotDeployed, _ = detections.DiffLists(deployed, enabled)
 
-	deployedButNotEnabledCount := len(deployedButNotEnabled)
-	if len(deployedButNotEnabled) > 20 {
-		deployedButNotEnabled = deployedButNotEnabled[:20]
-	}
-
-	enabledButNotDeployedCount := len(enabledButNotDeployed)
-	if len(enabledButNotDeployed) > 20 {
-		enabledButNotDeployed = enabledButNotDeployed[:20]
-	}
-
 	intCheckReport := logger.WithFields(log.Fields{
-		"deployedButNotEnabled": deployedButNotEnabled,
-		"enabledButNotDeployed": enabledButNotDeployed,
-		"deployedButNotEnabledCount": deployedButNotEnabledCount,
-		"enabledButNotDeployedCount": enabledButNotDeployedCount,
+		"deployedButNotEnabled":      detections.TruncateList(deployedButNotEnabled, 20),
+		"enabledButNotDeployed":      detections.TruncateList(enabledButNotDeployed, 20),
+		"deployedButNotEnabledCount": len(deployedButNotEnabled),
+		"enabledButNotDeployedCount": len(enabledButNotDeployed),
 	})
 
 	if len(deployedButNotEnabled) > 0 || len(enabledButNotDeployed) > 0 {

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -566,7 +566,7 @@ func (store *ElasticDetectionstore) GetAllDetections(ctx context.Context, opts .
 
 	_, err := store.esClient.Indices.Refresh(
 		store.esClient.Indices.Refresh.WithContext(ctx),
-		store.esClient.Indices.Refresh.WithIndex(store.index),
+		store.esClient.Indices.Refresh.WithIndex(store.disableCrossClusterIndex(store.index)),
 	)
 	if err != nil {
 		return nil, err

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -788,7 +788,7 @@ func (store *ElasticDetectionstore) DeleteComment(ctx context.Context, id string
 func (store *ElasticDetectionstore) BuildBulkIndexer(ctx context.Context, logger *log.Entry) (esutil.BulkIndexer, error) {
 	bulk, err := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
 		Client:     store.esClient,
-		Refresh:    "true",
+		Refresh:    "wait_for",
 		NumWorkers: store.bulkIndexerWorkerCount,
 		OnError: func(ctx context.Context, err error) {
 			logger.WithError(err).Error("error during bulk import")

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -564,14 +564,6 @@ func (store *ElasticDetectionstore) GetAllDetections(ctx context.Context, opts .
 		query = opt(query, store.schemaPrefix)
 	}
 
-	_, err := store.esClient.Indices.Refresh(
-		store.esClient.Indices.Refresh.WithContext(ctx),
-		store.esClient.Indices.Refresh.WithIndex(store.disableCrossClusterIndex(store.index)),
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	all, err := store.Query(ctx, query, -1)
 	if err != nil {
 		return nil, err

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -1174,21 +1174,11 @@ func (e *StrelkaEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) (de
 
 	deployedButNotEnabled, enabledButNotDeployed, _ = detections.DiffLists(deployed, enabled)
 
-	deployedButNotEnabledCount := len(deployedButNotEnabled)
-	if len(deployedButNotEnabled) > 20 {
-		deployedButNotEnabled = deployedButNotEnabled[:20]
-	}
-
-	enabledButNotDeployedCount := len(enabledButNotDeployed)
-	if len(enabledButNotDeployed) > 20 {
-		enabledButNotDeployed = enabledButNotDeployed[:20]
-	}
-
 	intCheckReport := logger.WithFields(log.Fields{
-		"deployedButNotEnabled": deployedButNotEnabled,
-		"enabledButNotDeployed": enabledButNotDeployed,
-		"deployedButNotEnabledCount": deployedButNotEnabledCount,
-		"enabledButNotDeployedCount": enabledButNotDeployedCount,
+		"deployedButNotEnabled":      detections.TruncateList(deployedButNotEnabled, 20),
+		"enabledButNotDeployed":      detections.TruncateList(enabledButNotDeployed, 20),
+		"deployedButNotEnabledCount": len(deployedButNotEnabled),
+		"enabledButNotDeployedCount": len(enabledButNotDeployed),
 	})
 
 	if len(deployedButNotEnabled) > 0 || len(enabledButNotDeployed) > 0 {

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -1174,9 +1174,21 @@ func (e *StrelkaEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) (de
 
 	deployedButNotEnabled, enabledButNotDeployed, _ = detections.DiffLists(deployed, enabled)
 
+	deployedButNotEnabledCount := len(deployedButNotEnabled)
+	if len(deployedButNotEnabled) > 20 {
+		deployedButNotEnabled = deployedButNotEnabled[:20]
+	}
+
+	enabledButNotDeployedCount := len(enabledButNotDeployed)
+	if len(enabledButNotDeployed) > 20 {
+		enabledButNotDeployed = enabledButNotDeployed[:20]
+	}
+
 	intCheckReport := logger.WithFields(log.Fields{
 		"deployedButNotEnabled": deployedButNotEnabled,
 		"enabledButNotDeployed": enabledButNotDeployed,
+		"deployedButNotEnabledCount": deployedButNotEnabledCount,
+		"enabledButNotDeployedCount": enabledButNotDeployedCount,
 	})
 
 	if len(deployedButNotEnabled) > 0 || len(enabledButNotDeployed) > 0 {

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1811,17 +1811,29 @@ func (e *SuricataEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) (d
 
 	deployedButNotEnabled, enabledButNotDeployed, _ = detections.DiffLists(deployed, enabled)
 
-	report := logger.WithFields(log.Fields{
-		"deployedButNotEnabled": deployedButNotEnabled,
-		"enabledButNotDeployed": enabledButNotDeployed,
+	deployedButNotEnabledCount := len(deployedButNotEnabled)
+	if len(deployedButNotEnabled) > 20 {
+		deployedButNotEnabled = deployedButNotEnabled[:20]
+	}
+
+	enabledButNotDeployedCount := len(enabledButNotDeployed)
+	if len(enabledButNotDeployed) > 20 {
+		enabledButNotDeployed = enabledButNotDeployed[:20]
+	}
+
+	intCheckReport := logger.WithFields(log.Fields{
+		"deployedButNotEnabled":      deployedButNotEnabled,
+		"enabledButNotDeployed":      enabledButNotDeployed,
+		"deployedButNotEnabledCount": deployedButNotEnabledCount,
+		"enabledButNotDeployedCount": enabledButNotDeployedCount,
 	})
 
 	if len(deployedButNotEnabled) > 0 || len(enabledButNotDeployed) > 0 {
-		report.Warn("integrity check failed")
+		intCheckReport.Warn("integrity check failed")
 		return deployedButNotEnabled, enabledButNotDeployed, detections.ErrIntCheckFailed
 	}
 
-	report.Info("integrity check passed")
+	intCheckReport.Info("integrity check passed")
 
 	return deployedButNotEnabled, enabledButNotDeployed, nil
 }

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1811,21 +1811,11 @@ func (e *SuricataEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) (d
 
 	deployedButNotEnabled, enabledButNotDeployed, _ = detections.DiffLists(deployed, enabled)
 
-	deployedButNotEnabledCount := len(deployedButNotEnabled)
-	if len(deployedButNotEnabled) > 20 {
-		deployedButNotEnabled = deployedButNotEnabled[:20]
-	}
-
-	enabledButNotDeployedCount := len(enabledButNotDeployed)
-	if len(enabledButNotDeployed) > 20 {
-		enabledButNotDeployed = enabledButNotDeployed[:20]
-	}
-
 	intCheckReport := logger.WithFields(log.Fields{
-		"deployedButNotEnabled":      deployedButNotEnabled,
-		"enabledButNotDeployed":      enabledButNotDeployed,
-		"deployedButNotEnabledCount": deployedButNotEnabledCount,
-		"enabledButNotDeployedCount": enabledButNotDeployedCount,
+		"deployedButNotEnabled":      detections.TruncateList(deployedButNotEnabled, 20),
+		"enabledButNotDeployed":      detections.TruncateList(enabledButNotDeployed, 20),
+		"deployedButNotEnabledCount": len(deployedButNotEnabled),
+		"enabledButNotDeployedCount": len(enabledButNotDeployed),
 	})
 
 	if len(deployedButNotEnabled) > 0 || len(enabledButNotDeployed) > 0 {


### PR DESCRIPTION
Previously the response from the refresh index request in GetAllDetections was "successful" (i.e. not returning an error) but returning:

```
{
  "shards": 0,
  "successful": 0,
  "failed": 0
}
```

It wasn't failing, but it also wasn't refreshing. After adding the call to disableCrossClusterIndex, the response now comes back with `"shards": 1, "successful": 1`. This should fix post-soup scrolling not finding anything.

Too many publicIds was making the log message too large to ingest in the integrity check report. Instead, truncate down to 20 and include the untruncated count.
