### PR TITLE
Add Indexes as a parameter to scrolling

### DIFF
--- a/server/eventstore.go
+++ b/server/eventstore.go
@@ -15,7 +15,7 @@ import (
 type Eventstore interface {
 	EventSearch(context context.Context, criteria *model.EventSearchCriteria) (*model.EventSearchResults, error)
 	Search(context context.Context, criteria *model.EventSearchCriteria) (*model.EventSearchResults, error)
-	Scroll(context context.Context, criteria *model.EventScrollCriteria) (*model.EventScrollResults, error)
+	Scroll(context context.Context, criteria *model.EventScrollCriteria, indexes []string) (*model.EventScrollResults, error)
 	Index(ctx context.Context, index string, document map[string]interface{}, id string) (*model.EventIndexResults, error)
 	Update(context context.Context, criteria *model.EventUpdateCriteria) (*model.EventUpdateResults, error)
 	Delete(context context.Context, index string, id string) error

--- a/server/eventstore_fake.go
+++ b/server/eventstore_fake.go
@@ -21,6 +21,7 @@ type FakeEventstore struct {
 	InputUpdateCriterias []*model.EventUpdateCriteria
 	InputAckCriterias    []*model.EventAckCriteria
 	InputScrollCriterias []*model.EventScrollCriteria
+	InputScrollIndexes   [][]string
 	Err                  error
 	SearchResults        []*model.EventSearchResults
 	IndexResults         []*model.EventIndexResults
@@ -117,9 +118,10 @@ func (store *FakeEventstore) Acknowledge(context context.Context, criteria *mode
 	return result, store.Err
 }
 
-func (store *FakeEventstore) Scroll(context context.Context, criteria *model.EventScrollCriteria) (*model.EventScrollResults, error) {
+func (store *FakeEventstore) Scroll(context context.Context, criteria *model.EventScrollCriteria, indexes []string) (*model.EventScrollResults, error) {
 	store.InputContexts = append(store.InputContexts, context)
 	store.InputScrollCriterias = append(store.InputScrollCriterias, criteria)
+	store.InputScrollIndexes = append(store.InputScrollIndexes, indexes)
 	if store.scrollCount >= len(store.ScrollResults) {
 		store.scrollCount = len(store.ScrollResults) - 1
 	}

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -422,7 +422,7 @@ func (store *ElasticDetectionstore) DetectionScroll(ctx context.Context, criteri
 		return nil, err
 	}
 
-	return store.server.Eventstore.Scroll(ctx, criteria)
+	return store.server.Eventstore.Scroll(ctx, criteria, []string{store.index})
 }
 
 func (store *ElasticDetectionstore) prepareForSave(ctx context.Context, obj *model.Auditable) string {

--- a/server/modules/elastic/elasticeventstore.go
+++ b/server/modules/elastic/elasticeventstore.go
@@ -210,7 +210,7 @@ func (store *ElasticEventstore) Search(ctx context.Context, criteria *model.Even
 	return results, err
 }
 
-func (store *ElasticEventstore) Scroll(ctx context.Context, criteria *model.EventScrollCriteria) (*model.EventScrollResults, error) {
+func (store *ElasticEventstore) Scroll(ctx context.Context, criteria *model.EventScrollCriteria, indexes []string) (*model.EventScrollResults, error) {
 	var err error
 	finalResults := model.NewEventScrollResults()
 
@@ -226,7 +226,10 @@ func (store *ElasticEventstore) Scroll(ctx context.Context, criteria *model.Even
 		}).Info("scrolling Elasticsearch")
 
 		var json string
-		indexes := strings.Split(store.index, ",")
+
+		if len(indexes) == 0 {
+			indexes = strings.Split(store.index, ",")
+		}
 
 		res, err := store.esClient.Search(
 			store.esClient.Search.WithContext(ctx),


### PR DESCRIPTION
Instead of scrolling with all the indexes the Eventstore knows about, allow Scrolling to use specified indexes. Should result in a much smaller scrollID and a much more efficient search.