### PR TITLE
Cogburn/suricata regex support

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -665,3 +665,11 @@ code {
 .theme--dark .key-changed {
   color: rgb(204, 153, 205)
 }
+
+.warning-message a {
+  color: white;
+}
+
+.warning-message a:visited {
+  color: white;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -278,7 +278,7 @@
               <v-icon>fa-times</v-icon>
             </v-btn>
           </template>
-          {{ warningMessage }}
+          <div class="warning-message" v-html="warningMessage"></div>
         </v-snackbar>
         <v-alert dismissible type="info" icon="fa-info" v-model="info" transition="scale-transition" v-html="infoMessage" data-aid="banner_info"></v-alert>
         <v-snackbar id="tip" top centered rounded close :timeout="tipTimeout" v-model="tip" color="info" data-aid="banner_tip">

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -669,9 +669,13 @@ $(document).ready(function() {
           console.log(msg.stack);
         }
       },
-      showWarning(msg) {
+      showWarning(msg, skipLocalization) {
         this.warning = true;
-        this.warningMessage = this.localizeMessage(msg);
+        if (skipLocalization) {
+          this.warningMessage = msg;
+        } else {
+          this.warningMessage = this.localizeMessage(msg);
+        }
       },
       showInfo(msg) {
         this.info = true;

--- a/html/js/app.test.js
+++ b/html/js/app.test.js
@@ -759,10 +759,27 @@ test('licenseExpiringSoon', () => {
   const date = new Date();
   app.licenseKey = { expiration: date.toISOString() };
   expect(app.isLicenseExpiringSoon()).toBe(true);
-  
+
   app.licenseKey = { expiration: "2024-01-01T01:01:01Z" };
   expect(app.isLicenseExpiringSoon()).toBe(true);
 
   app.licenseKey = { expiration: "2054-01-01T01:01:01Z" };
   expect(app.isLicenseExpiringSoon()).toBe(false);
+});
+
+test('showWarning', () => {
+  var longString = 'x';
+  for (var i = 0; i < 8; i++) {
+    longString += longString;
+  }
+
+  app.showWarning(longString);
+
+  expect(app.warning).toBe(true);
+  expect(app.warningMessage.length).toBe(203); // truncate to 200, add "..."
+
+  app.showWarning(longString, true);
+
+  expect(app.warning).toBe(true);
+  expect(app.warningMessage.length).toBe(longString.length);
 });

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -131,6 +131,7 @@ const i18n = {
       bulkActionStarted: 'Updating {total} detections. This may take awhile.',
       bulkActionDeleteStarted: 'Deleting {total} detections. This may take awhile.',
       bulkError: '',
+      bulkSuccessFiltered: `Bulk update successfully updated {modified} of {total} events. However, the statuses of {filtered} of the updated detections are controlled by the current regex filter settings and were reverted. <a href="/#/config?s=soc.config.server.modules.suricataengine" data-aid="warning_bulk_update_configure_filters">Click here to configure those filters.</a> ({time})`,
       bulkSuccessUpdate: 'Bulk update successfully updated {modified} of {total} events. ({time})',
       bulkSuccessDelete: 'Bulk delete successfully deleted {modified} of {total} events. ({time})',
       bytes: 'Bytes',
@@ -961,6 +962,8 @@ const i18n = {
       yes: 'Yes',
       zeekLoss: 'Zeek Loss',
       zeekLossAbbr: 'Zeek Loss',
+
+      WARN_STATUS_EFFECTED_BY_FILTER: 'Saved successfully but the status of this detection is controlled by the current regex filter settings and was reverted. <a href="/#/config?s=soc.config.server.modules.suricataengine" data-aid="warning_update_configure_filters">Click here to configure those filters.</a>',
 
       ERROR_CASE_EVENT_ALREADY_ATTACHED: 'The event is already attached to the selected case.',
       ERROR_CASE_MODULE_NOT_ENABLED: 'A case module has not been configured for this installation. Unable to proceed with request.',

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -130,7 +130,7 @@ const i18n = {
       bulkAction: 'Bulk Action:',
       bulkActionStarted: 'Updating {total} detections. This may take awhile.',
       bulkActionDeleteStarted: 'Deleting {total} detections. This may take awhile.',
-      bulkError: '',
+      bulkError: '{error} of the detections during the last bulk update failed. Please check the SOC logs for more information.',
       bulkSuccessFiltered: `Bulk update successfully updated {modified} of {total} events. However, the statuses of {filtered} of the updated detections are controlled by the current regex filter settings and were reverted. <a href="/#/config?s=soc.config.server.modules.suricataengine" data-aid="warning_bulk_update_configure_filters">Click here to configure those filters.</a> ({time})`,
       bulkSuccessUpdate: 'Bulk update successfully updated {modified} of {total} events. ({time})',
       bulkSuccessDelete: 'Bulk delete successfully deleted {modified} of {total} events. ({time})',

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -744,7 +744,7 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 
 				switch (response.status) {
 					case 205:
-						this.$root.showWarning(this.WARN_STATUS_EFFECTED_BY_FILTER, true);
+						this.$root.showWarning(this.i18n.WARN_STATUS_EFFECTED_BY_FILTER, true);
 						break;
 					case 206:
 						this.$root.showWarning(this.i18n.disabledFailedSync);

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -743,6 +743,9 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 				this.extractDetection(response);
 
 				switch (response.status) {
+					case 205:
+						this.$root.showWarning(this.WARN_STATUS_EFFECTED_BY_FILTER, true);
+						break;
 					case 206:
 						this.$root.showWarning(this.i18n.disabledFailedSync);
 						break;

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -868,3 +868,16 @@ test('extractDetection', () => {
 	expect(comp.loadAssociations).toHaveBeenCalledTimes(1);
 	expect(comp.$root.populateUserDetails).toHaveBeenCalledTimes(1);
 });
+
+test('saveDetection - statusEffectedByFilter', async () => {
+	resetPapi().mockPapi('put', {status:205}, null);
+	comp.detect = { content: "" };
+	comp.origDetect = { content: "" };
+	comp.extractDetection = jest.fn();
+
+	await comp.saveDetection(false, false);
+
+	expect(comp.$root.warning).toBe(true);
+	expect(comp.$root.warningMessage).toBe(comp.i18n.WARN_STATUS_EFFECTED_BY_FILTER);
+	expect(comp.extractDetection).toHaveBeenCalledTimes(1);
+});

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2276,9 +2276,7 @@ const huntComponent = {
     },
     bulkUpdateReport(stats) {
       if (stats.error > 0) {
-        let msg = this.i18n.bulkError;
-        msg += ' ' + stats.error.toLocaleString() + ' ' + (stats.error == 1 ? this.i18n.errorSingular : this.i18n.errorPlural) + '.';
-
+        let msg = this.i18n.bulkError.replace('{error}', stats.error.toLocaleString());
         this.$root.showError(msg);
       } else {
         let seconds = Math.floor(stats.time);

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2303,13 +2303,23 @@ const huntComponent = {
 
         t += seconds.toFixed(0) + 's';
 
-        let msg = stats.verb === 'delete' ? this.i18n.bulkSuccessDelete : this.i18n.bulkSuccessUpdate;
+        if (stats.filtered) {
+          let msg = this.i18n.bulkSuccessFiltered;
+          msg = msg.replaceAll('{filtered}', stats.filtered.toLocaleString());
+          msg = msg.replaceAll('{modified}', stats.modified.toLocaleString());
+          msg = msg.replaceAll('{total}', stats.total.toLocaleString());
+          msg = msg.replaceAll('{time}', t);
 
-        msg = msg.replaceAll('{modified}', stats.modified.toLocaleString());
-        msg = msg.replaceAll('{total}', stats.total.toLocaleString());
-        msg = msg.replaceAll('{time}', t);
+          this.$root.showWarning(msg, true);
+        } else {
+          let msg = stats.verb === 'delete' ? this.i18n.bulkSuccessDelete : this.i18n.bulkSuccessUpdate;
 
-        this.$root.showInfo(msg);
+          msg = msg.replaceAll('{modified}', stats.modified.toLocaleString());
+          msg = msg.replaceAll('{total}', stats.total.toLocaleString());
+          msg = msg.replaceAll('{time}', t);
+
+          this.$root.showInfo(msg, true);
+        }
       }
     },
     startManualSync(engine, type) {

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1283,7 +1283,6 @@ test('bulkAction - delete - confirm - failure', async () => {
   comp.selectedCount = 2;
   comp.selectAllState = 'indeterminate';
   comp.eventData = [{ _isSelected: true, soc_id: "1" }, { _isSelected: false, soc_id: "2" }, { _isSelected: true, soc_id: "3" }];
-  comp.$root.showError = jest.fn();
   const err = { response: { data: "ERROR_BULK_COMMUNITY" } }
   const mock = resetPapi().mockPapi('post', null, err);
 
@@ -1294,8 +1293,8 @@ test('bulkAction - delete - confirm - failure', async () => {
   expect(comp.selectedCount).toBe(2);
   expect(mock).toHaveBeenCalledTimes(1);
   expect(mock).toHaveBeenCalledWith('detection/bulk/delete', { ids: ["1", "3"] });
-  expect(comp.$root.showError).toHaveBeenCalledTimes(1);
-  expect(comp.$root.showError).toHaveBeenCalledWith(err);
+  expect(comp.$root.error).toBe(true);
+  expect(comp.$root.errorMessage).toBe(comp.i18n.ERROR_BULK_COMMUNITY);
 });
 
 test('reconstructQuery', () => {
@@ -1344,4 +1343,61 @@ test('getDisplayedQueryVar', () => {
   comp.advanced = true;
   comp.showFullQuery = false;
   expect(comp.getDisplayedQueryVar()).toBe('querySearch');
+});
+
+test('bulkUpdateReport - error', () => {
+  let stats = {
+    error: 1,
+  };
+
+  comp.bulkUpdateReport(stats)
+
+  expect(comp.$root.error).toBe(true);
+  expect(comp.$root.errorMessage).toBe('1 of the detections during the last bulk update failed. Please check the SOC logs for more information.');
+});
+
+test('bulkUpdateReport - update success', () => {
+  let stats = {
+    time: 10,
+    filtered: 0,
+    verb: 'update',
+    modified: 2,
+    total: 2,
+  };
+
+  comp.bulkUpdateReport(stats)
+
+  expect(comp.$root.info).toBe(true);
+  expect(comp.$root.infoMessage).toBe('Bulk update successfully updated 2 of 2 events. (10s)');
+});
+
+test('bulkUpdateReport - delete success', () => {
+  let stats = {
+    time: 1000,
+    filtered: 0,
+    verb: 'delete',
+    modified: 200,
+    total: 200,
+  };
+
+  comp.bulkUpdateReport(stats)
+
+  expect(comp.$root.info).toBe(true);
+  expect(comp.$root.infoMessage).toBe('Bulk delete successfully deleted 200 of 200 events. (16m 40s)');
+});
+
+test('bulkUpdateReport - filtered success', () => {
+  let stats = {
+    time: 200,
+    filtered: 1,
+    verb: 'update',
+    modified: 20,
+    total: 20,
+  };
+
+  comp.bulkUpdateReport(stats)
+
+  expect(comp.$root.warning).toBe(true);
+  expect(comp.$root.warningMessage).toBe('Bulk update successfully updated 20 of 20 events. However, the statuses of 1 of the updated detections are controlled by the current regex filter settings and were reverted. <a href="/#/config?s=soc.config.server.modules.suricataengine" data-aid="warning_bulk_update_configure_filters">Click here to configure those filters.</a> (3m 20s)'
+);
 });

--- a/server/detectionengine.go
+++ b/server/detectionengine.go
@@ -20,6 +20,7 @@ type DetectionEngine interface {
 	DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error)
 	GetState() *model.EngineState
 	GenerateUnusedPublicId(ctx context.Context) (string, error)
+	ApplyFilters(detect *model.Detection) (didFilterAct bool, err error)
 }
 
 type SyncStatus struct {

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -271,6 +271,10 @@ func (e *ElastAlertEngine) ValidateRule(data string) (string, error) {
 	return string(data), nil
 }
 
+func (e *ElastAlertEngine) ApplyFilters(detect *model.Detection) (bool, error) {
+	return false, nil
+}
+
 func (e *ElastAlertEngine) ConvertRule(ctx context.Context, detect *model.Detection) (string, error) {
 	return e.sigmaToElastAlert(ctx, detect)
 }
@@ -921,6 +925,12 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 		} else {
 			detect.CreateTime = util.Ptr(time.Now())
 			checkRulesetEnabled(e, detect)
+		}
+
+		_, err = e.ApplyFilters(detect)
+		if err != nil {
+			errMap[detect.PublicID] = err
+			continue
 		}
 
 		document, index, err := e.srv.Detectionstore.ConvertObjectToDocument(ctx, "detection", detect, &detect.Auditable, exists, nil, nil)

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -221,6 +221,10 @@ func (e *StrelkaEngine) ValidateRule(data string) (string, error) {
 	return string(data), nil
 }
 
+func (e *StrelkaEngine) ApplyFilters(detect *model.Detection) (bool, error) {
+	return false, nil
+}
+
 func (e *StrelkaEngine) ConvertRule(ctx context.Context, detect *model.Detection) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
@@ -450,6 +454,12 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 		} else {
 			detect.CreateTime = util.Ptr(time.Now())
 			checkRulesetEnabled(e, detect)
+		}
+
+		_, err = e.ApplyFilters(detect)
+		if err != nil {
+			errMap[detect.PublicID] = err
+			continue
 		}
 
 		document, index, err := e.srv.Detectionstore.ConvertObjectToDocument(e.srv.Context, "detection", detect, &detect.Auditable, exists, nil, nil)

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -52,13 +52,16 @@ const (
 	DEFAULT_RULES_FINGERPRINT_FILE                = "/opt/sensoroni/fingerprints/emerging-all.fingerprint"
 	DEFAULT_COMMUNITY_RULES_IMPORT_FREQUENCY_SECS = 86400
 	DEFAULT_STATE_FILE_PATH                       = "/opt/sensoroni/fingerprints/suricataengine.state"
-	DEFAULT_ALLOW_REGEX                           = ""
-	DEFAULT_DENY_REGEX                            = ""
 	DEFAULT_COMMUNITY_RULES_IMPORT_ERROR_SECS     = 300
 	DEFAULT_FAIL_AFTER_CONSECUTIVE_ERROR_COUNT    = 10
 	DEFAULT_INTEGRITY_CHECK_FREQUENCY_SECONDS     = 600
 
 	CUSTOM_RULE_LOC = "/nsm/rules/detect-suricata/custom_temp"
+)
+
+var ( // treat as constants
+	DEFAULT_ENABLE_REGEX  = []string{}
+	DEFAULT_DISABLE_REGEX = []string{}
 )
 
 type SuricataEngine struct {
@@ -69,13 +72,13 @@ type SuricataEngine struct {
 	failAfterConsecutiveErrorCount int
 	isRunning                      bool
 	interm                         sync.Mutex
-	allowRegex                     *regexp.Regexp
-	denyRegex                      *regexp.Regexp
 	notify                         bool
 	migrations                     map[string]func(string) error
 	customRulesets                 []*model.CustomRuleset
 	writeNoRead                    *string
 	checkMigrationsOnce            func()
+	enableRegex                    []*regexp.Regexp
+	disableRegex                   []*regexp.Regexp
 	detections.SyncSchedulerParams
 	detections.IntegrityCheckerData
 	detections.IOManager
@@ -119,22 +122,30 @@ func (e *SuricataEngine) Init(config module.ModuleConfig) (err error) {
 	e.failAfterConsecutiveErrorCount = module.GetIntDefault(config, "failAfterConsecutiveErrorCount", DEFAULT_FAIL_AFTER_CONSECUTIVE_ERROR_COUNT)
 	e.IntegrityCheckerData.FrequencySeconds = module.GetIntDefault(config, "integrityCheckFrequencySeconds", DEFAULT_INTEGRITY_CHECK_FREQUENCY_SECONDS)
 
-	allow := module.GetStringDefault(config, "allowRegex", DEFAULT_ALLOW_REGEX)
-	deny := module.GetStringDefault(config, "denyRegex", DEFAULT_DENY_REGEX)
+	enable := module.GetStringArrayDefault(config, "enableRegex", DEFAULT_ENABLE_REGEX)
+	disable := module.GetStringArrayDefault(config, "disableRegex", DEFAULT_DISABLE_REGEX)
 
-	if allow != "" {
-		var err error
-		e.allowRegex, err = regexp.Compile(allow)
-		if err != nil {
-			return fmt.Errorf("unable to compile Suricata's allowRegex: %w", err)
+	if len(enable) != 0 {
+		e.enableRegex = make([]*regexp.Regexp, 0, len(enable))
+		for _, str := range enable {
+			re, err := regexp.Compile(str)
+			if err != nil {
+				return fmt.Errorf("unable to compile Suricata's enableRegex: %s - %w", str, err)
+			}
+
+			e.enableRegex = append(e.enableRegex, re)
 		}
 	}
 
-	if deny != "" {
-		var err error
-		e.denyRegex, err = regexp.Compile(deny)
-		if err != nil {
-			return fmt.Errorf("unable to compile Suricata's denyRegex: %w", err)
+	if len(disable) != 0 {
+		e.disableRegex = make([]*regexp.Regexp, 0, len(disable))
+		for _, str := range disable {
+			re, err := regexp.Compile(str)
+			if err != nil {
+				return fmt.Errorf("unable to compile Suricata's disableRegex: %s - %w", str, err)
+			}
+
+			e.disableRegex = append(e.disableRegex, re)
 		}
 	}
 
@@ -380,7 +391,7 @@ func (e *SuricataEngine) Sync(logger *log.Entry, forceSync bool) error {
 
 	ruleset := settingByID(allSettings, "idstools.config.ruleset")
 
-	commDetections, err := e.ParseRules(rules, ruleset.Value, true)
+	commDetections, err := e.ParseRules(rules, ruleset.Value)
 	if err != nil {
 		if e.notify {
 			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
@@ -599,7 +610,13 @@ func (e *SuricataEngine) ValidateRule(rule string) (string, error) {
 	return parsed.String(), nil
 }
 
-func (e *SuricataEngine) ParseRules(content string, ruleset string, applyFilters bool) ([]*model.Detection, error) {
+func (e *SuricataEngine) ApplyFilters(detect *model.Detection) (bool, error) {
+	modified := e.applyStatusRegexes(detect)
+
+	return modified, nil
+}
+
+func (e *SuricataEngine) ParseRules(content string, ruleset string) ([]*model.Detection, error) {
 	// expecting one rule per line
 	lines := strings.Split(content, "\n")
 	dets := []*model.Detection{}
@@ -627,18 +644,6 @@ func (e *SuricataEngine) ParseRules(content string, ruleset string, applyFilters
 				wasCommented = true
 			} else {
 				// actual comment, skip line
-				continue
-			}
-		}
-
-		if applyFilters {
-			if e.denyRegex != nil && e.denyRegex.MatchString(line) {
-				log.WithField("suricataDenyRegex", line).Debug("content matched suricata's denyRegex")
-				continue
-			}
-
-			if e.allowRegex != nil && !e.allowRegex.MatchString(line) {
-				log.WithField("suricataAllowRegex", line).Debug("content didn't match suricata's allowRegex")
 				continue
 			}
 		}
@@ -796,6 +801,12 @@ func (e *SuricataEngine) SyncLocalDetections(ctx context.Context, detects []*mod
 	for _, detect := range localDets {
 		if !e.isRunning {
 			return nil, detections.ErrModuleStopped
+		}
+
+		_, err = e.ApplyFilters(detect)
+		if err != nil {
+			errMap[detect.PublicID] = fmt.Sprintf("unable to apply filters; reason=%s", err.Error())
+			continue
 		}
 
 		parsedRule, err := ParseSuricataRule(detect.Content)
@@ -1172,10 +1183,12 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *lo
 		sid := *opt
 		_, isFlowbits := parsedRule.GetOption("flowbits")
 
+		modifiedByFilter := e.applyStatusRegexes(detect)
+
 		_, inEnabled := enabledIndex[sid]
 		_, inDisabled := disabledIndex[sid]
 
-		if changedByUser || inEnabled || inDisabled {
+		if changedByUser || inEnabled || inDisabled || modifiedByFilter {
 			// update enabled
 			enabledLines = updateEnabled(enabledLines, enabledIndex, sid, isFlowbits, detect)
 
@@ -1496,6 +1509,24 @@ func extractSID(rule string) *string {
 	return util.Ptr(strings.TrimSpace(sids[0][1]))
 }
 
+func (e *SuricataEngine) applyStatusRegexes(detect *model.Detection) (affectedByFilter bool) {
+	for _, disable := range e.disableRegex {
+		if disable.MatchString(detect.Content) {
+			detect.IsEnabled = false
+			return true
+		}
+	}
+
+	for _, enable := range e.enableRegex {
+		if enable.MatchString(detect.Content) {
+			detect.IsEnabled = true
+			return true
+		}
+	}
+
+	return false
+}
+
 func indexLocal(lines []string) map[string]int {
 	index := map[string]int{}
 
@@ -1630,7 +1661,7 @@ func (e *SuricataEngine) DuplicateDetection(ctx context.Context, detection *mode
 
 	rule.UpdateForDuplication(id)
 
-	dets, err := e.ParseRules(rule.String(), detections.RULESET_CUSTOM, false)
+	dets, err := e.ParseRules(rule.String(), detections.RULESET_CUSTOM)
 	if err != nil {
 		return nil, err
 	}
@@ -1692,7 +1723,7 @@ func (e *SuricataEngine) ReadCustomRulesets() (detects []*model.Detection, err e
 			return nil, errors.New("invalid custom ruleset")
 		}
 
-		dets, err := e.ParseRules(string(content), custom.Ruleset, false)
+		dets, err := e.ParseRules(string(content), custom.Ruleset)
 		if err != nil {
 			log.WithError(err).WithField("customRulesetName", custom.Ruleset).Error("unable to parse custom ruleset, skipping")
 

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1510,16 +1510,16 @@ func extractSID(rule string) *string {
 }
 
 func (e *SuricataEngine) applyStatusRegexes(detect *model.Detection) (affectedByFilter bool) {
-	for _, disable := range e.disableRegex {
-		if disable.MatchString(detect.Content) {
-			detect.IsEnabled = false
+	for _, enable := range e.enableRegex {
+		if enable.MatchString(detect.Content) {
+			detect.IsEnabled = true
 			return true
 		}
 	}
 
-	for _, enable := range e.enableRegex {
-		if enable.MatchString(detect.Content) {
-			detect.IsEnabled = true
+	for _, disable := range e.disableRegex {
+		if disable.MatchString(detect.Content) {
+			detect.IsEnabled = false
 			return true
 		}
 	}

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -2440,6 +2440,16 @@ func TestApplyFilters(t *testing.T) {
 			ExpStatus:        false,
 			ExpFilterApplied: true,
 		},
+		{
+			Name:         "Prioritize EnableRegex",
+			EnableRegex:  toRegex(`alert`),
+			DisableRegex: toRegex(`alert`),
+			Detection: &model.Detection{
+				Content: "alert",
+			},
+			ExpStatus:        true,
+			ExpFilterApplied: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -482,12 +482,11 @@ func TestParse(t *testing.T) {
 			Name: "Sunny Day Path with Edge Cases",
 			Lines: []string{
 				"# Comment",
-				SimpleRule, // allowRegex has the SID, should allow
+				SimpleRule,
 				"",
 				`# alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \\\"tricky\"\;\\ msg";)`, // allowRegex has the SID, should allow
 				" # " + FlowbitsRuleA,
-				FlowbitsRuleB, // denyRegex will prevent this from being parsed
-				"alert http any any -> any any (msg:\"This rule doesn't have a SID\";)", // doesn't match either regex, will be left out
+				FlowbitsRuleB,
 			},
 			ExpectedDetections: []*model.Detection{
 				{
@@ -515,13 +514,34 @@ func TestParse(t *testing.T) {
 					Ruleset:  ruleset,
 					License:  "Unknown",
 				},
+				{
+					Author:   ruleset,
+					PublicID: FlowbitsRuleASID,
+					Title:    "RULE A",
+					Severity: model.SeverityUnknown,
+					Content:  FlowbitsRuleA,
+					Engine:   model.EngineNameSuricata,
+					Language: model.SigLangSuricata,
+					Ruleset:  ruleset,
+					License:  "Unknown",
+				},
+				{
+					Author:    ruleset,
+					PublicID:  FlowbitsRuleBSID,
+					Title:     "RULE B",
+					Severity:  model.SeverityUnknown,
+					Content:   FlowbitsRuleB,
+					IsEnabled: true,
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+					Ruleset:   ruleset,
+					License:   "Unknown",
+				},
 			},
 		},
 	}
 
 	mod := NewSuricataEngine(&server.Server{})
-	mod.allowRegex = regexp.MustCompile("[12]0000")
-	mod.denyRegex = regexp.MustCompile("flowbits")
 
 	mod.isRunning = true
 
@@ -532,7 +552,7 @@ func TestParse(t *testing.T) {
 
 			data := strings.Join(test.Lines, "\n")
 
-			detections, err := mod.ParseRules(data, ruleset, true)
+			detections, err := mod.ParseRules(data, ruleset)
 			if test.ExpectedError == nil {
 				assert.NoError(t, err)
 				assert.Equal(t, test.ExpectedDetections, detections)
@@ -2351,4 +2371,106 @@ func TestSyncChanges(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"abc", "", "deleteme"}, workDocIds) // update has an id, create does not, delete does
+}
+
+func TestApplyFilters(t *testing.T) {
+	tests := []struct {
+		Name             string
+		EnableRegex      []*regexp.Regexp
+		DisableRegex     []*regexp.Regexp
+		Detection        *model.Detection
+		ExpStatus        bool
+		ExpFilterApplied bool
+		ExpError         string
+	}{
+		{
+			Name:             "No Filters, Disabled",
+			Detection:        &model.Detection{},
+			ExpStatus:        false,
+			ExpFilterApplied: false,
+		},
+		{
+			Name: "No Filters, Enabled",
+			Detection: &model.Detection{
+				IsEnabled: true,
+			},
+			ExpStatus:        true,
+			ExpFilterApplied: false,
+		},
+		{
+			Name:         "Unmodified, Disabled",
+			EnableRegex:  toRegex(`alert`),
+			DisableRegex: toRegex(`drop`),
+			Detection: &model.Detection{
+				Content: "Hello World",
+			},
+			ExpStatus:        false,
+			ExpFilterApplied: false,
+		},
+		{
+			Name:         "Unmodified, Enabled",
+			EnableRegex:  toRegex(`alert`),
+			DisableRegex: toRegex(`drop`),
+			Detection: &model.Detection{
+				Content:   "Hello World",
+				IsEnabled: true,
+			},
+			ExpStatus:        true,
+			ExpFilterApplied: false,
+		},
+		{
+			Name:         "From Disabled to Enabled",
+			EnableRegex:  toRegex(`alert`),
+			DisableRegex: toRegex(`drop`),
+			Detection: &model.Detection{
+				Content:   "alert",
+				IsEnabled: false,
+			},
+			ExpStatus:        true,
+			ExpFilterApplied: true,
+		},
+		{
+			Name:         "From Enabled to Disabled",
+			EnableRegex:  toRegex(`alert`),
+			DisableRegex: toRegex(`drop`),
+			Detection: &model.Detection{
+				Content:   "drop",
+				IsEnabled: true,
+			},
+			ExpStatus:        false,
+			ExpFilterApplied: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			eng := &SuricataEngine{
+				enableRegex:  test.EnableRegex,
+				disableRegex: test.DisableRegex,
+			}
+
+			applied, err := eng.ApplyFilters(test.Detection)
+
+			if test.ExpError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.ExpFilterApplied, applied)
+			assert.Equal(t, test.ExpStatus, test.Detection.IsEnabled)
+		})
+	}
+}
+
+func toRegex(s ...string) []*regexp.Regexp {
+	r := make([]*regexp.Regexp, len(s))
+
+	for i, v := range s {
+		r[i] = regexp.MustCompile(v)
+	}
+
+	return r
 }


### PR DESCRIPTION
Enable/DisableRegex support in Suricata. Allow/DenyRegex has been removed from every engine. DetectionEngines now have an ApplyFilters function that accepts a single detection. This applies any known filters on a per-engine basis. The only current filters are suricata's new Enable/DisableRegex filters. This new function is called in every engine's Sync, the create detection, the update detection endpoint, and the bulk update endpoint.

Warning messages can now render HTML. No existing error message attempts to do so, but the new warning messages related to regex filters contain links to change those filters.

When a create, update, or bulk update tries to set a detection's status that's controlled by the new regex filter, the UI will display a warning that the status was reverted.

Refactored Suricata test affected by the Allow/DenyRegex removal.

Added a new test for Suricata's ApplyFilters function.

If a rule is specified in both the enabled and disabled pillars then the rule will behave as if enabled. To match suricata's behavior, applyStatusRegexes was refactored to also prefer Enabled. Added new test to check for this.