### PR TITLE
Remove Sigma Rule When Deleting Unreferenced

### DIFF
--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1118,8 +1118,17 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 			},
 		})
 		if err != nil {
-			errMap[publicId] = fmt.Errorf("unable to delete detection: %s", err)
+			errMap[publicId] = fmt.Errorf("unable to delete unreferenced detection: %s", err)
 			continue
+		}
+
+		path, ok := existing[publicId]
+		if ok {
+			err = e.DeleteFile(path)
+			if err != nil && !os.IsNotExist(err) {
+				errMap[publicId] = fmt.Errorf("unable to remove deleted detection file: %s", err)
+				continue
+			}
 		}
 	}
 

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1289,6 +1289,7 @@ func TestSyncChanges(t *testing.T) {
 
 		return nil
 	}).Times(3)
+	iom.EXPECT().DeleteFile("elastAlertRulesFolder/00000000-0000-0000-0000-000000000000.yml").Return(nil)
 	bim.EXPECT().Close(gomock.Any()).Return(nil)
 	bim.EXPECT().Stats().Return(esutil.BulkIndexerStats{})
 	iom.EXPECT().ExecCommand(gomock.Any()).Return([]byte("\n[query]"), 0, time.Duration(time.Second), nil) // sigmaToElastAlert


### PR DESCRIPTION
When a rule is no longer referenced in the community sync, it should be removed. We're currently only removing them from ES, and not the rules folder. This change attempts to delete unreferenced rules from the rules folder in addition to ES. Updated test.