### PR TITLE
Fix for Strelka Rule Duplication

### DIFF
--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -776,10 +776,14 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			}
 		},
 		async duplicateDetection() {
-			const response = await this.$root.papi.post('/detection/' + encodeURIComponent(this.$route.params.id) + '/duplicate');
-			this.extractDetection(response);
+			try {
+				const response = await this.$root.papi.post('/detection/' + encodeURIComponent(this.$route.params.id) + '/duplicate');
+				this.extractDetection(response);
 
-			this.$router.push({ name: 'detection', params: { id: response.data.id } });
+				this.$router.push({ name: 'detection', params: { id: response.data.id } });
+			} catch (error) {
+				this.$root.showError(error);
+			}
 		},
 		deleteDetection() {
 			this.confirmDeleteDialog = true;

--- a/server/modules/strelka/validate_test.go
+++ b/server/modules/strelka/validate_test.go
@@ -132,9 +132,14 @@ func TestDuplicateDetection(t *testing.T) {
 		LastName:  "Levinson",
 	}, nil)
 
+	detStore := mock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().GetDetectionByPublicId(ctx, "mimikatz_kirbi_ticket_copy").Return(det, nil)
+	detStore.EXPECT().GetDetectionByPublicId(ctx, "mimikatz_kirbi_ticket_copy1").Return(nil, nil)
+
 	eng := StrelkaEngine{
 		srv: &server.Server{
-			Userstore: mUser,
+			Userstore:      mUser,
+			Detectionstore: detStore,
 		},
 		isRunning: true,
 	}
@@ -148,7 +153,7 @@ func TestDuplicateDetection(t *testing.T) {
 
 	// expected differences
 	assert.NotEqual(t, det.Title, dupe.Title)
-	assert.Equal(t, det.Title, dupe.Title[:len(dupe.Title)-len("_copy")])
+	assert.Equal(t, dupe.Title, "mimikatz_kirbi_ticket_copy1")
 	assert.NotEqual(t, det.PublicID, dupe.PublicID)
 	assert.NotEmpty(t, dupe.PublicID)
 	assert.NotEqual(t, det.IsCommunity, dupe.IsCommunity)


### PR DESCRIPTION
The titleUpdater regex didn't account for comments between the identifier and the opening curly bracket of the rule. Updated the regex so that's no longer a problem.

When building a new title for the rule, check against ES to see if the new publicId is taken, if so increment a tailing number up to 10 times before giving up.

Updated the UI to report any errors during the duplication request.