### PR TITLE
No More Overshadowing Error

### DIFF
--- a/server/modules/elastic/elasticeventstore.go
+++ b/server/modules/elastic/elasticeventstore.go
@@ -231,7 +231,9 @@ func (store *ElasticEventstore) Scroll(ctx context.Context, criteria *model.Even
 			indexes = strings.Split(store.index, ",")
 		}
 
-		res, err := store.esClient.Search(
+		var res *esapi.Response
+
+		res, err = store.esClient.Search(
 			store.esClient.Search.WithContext(ctx),
 			store.esClient.Search.WithIndex(indexes...),
 			store.esClient.Search.WithBody(strings.NewReader(query)),


### PR DESCRIPTION
When making the initial search, if an error was returned we put it in a variable with a limited, shadowing scope. By the time the function has returned, that error has gone out of scope and is not reported. This caused an empty result set to appear to not be an error.