### PR TITLE
Respond to IndexNotFound Exception

### DIFF
--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -566,6 +566,13 @@ func (store *ElasticDetectionstore) GetAllDetections(ctx context.Context, opts .
 
 	all, err := store.Query(ctx, query, -1)
 	if err != nil {
+		if strings.Contains(err.Error(), "index_not_found_exception") {
+			// the index doesn't exist yet, so we can't have any detections
+			// return as empty set without error
+			log.Info("index not found during call to GetAllDetections, returning empty set")
+			return map[string]*model.Detection{}, nil
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
On first run, the so-detection index won't be created until the first detection is inserted. This means all calls to GetAllDetections were erroring out. A recent refactor limited the number of indexes on this query and ensured any errors were definitely being captured and as a result this new exception was bubbling up and causing all syncs to fail.

Now when we run into this case, we log that we noticed the error but we return an empty result set without any error. This will allow syncs to continue and insert their first batch, afterwards everything returns to normal.

Added a test for this use case.