### PR TITLE
Remove Allow/Deny Regex from Strelka and ElastAlert

### DIFF
--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -15,7 +15,6 @@ import (
 	"io/fs"
 	"net/http"
 	"os/exec"
-	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -553,8 +552,6 @@ level: high
 		isRunning:         true,
 		sigmaRulePackages: []string{"all_rules"},
 	}
-	engine.allowRegex = regexp.MustCompile("00000000-0000-0000-0000-00000000")
-	engine.denyRegex = regexp.MustCompile("deny")
 
 	expected := &model.Detection{
 		Author:      "Corey Ogburn",
@@ -623,8 +620,6 @@ license: Elastic-2.0
 		isRunning: true,
 		IOManager: iom,
 	}
-	engine.allowRegex = regexp.MustCompile("bf86ef21-41e6-417b-9a05-b9ea6bf28a38")
-	engine.denyRegex = regexp.MustCompile("deny")
 
 	expected := &model.Detection{
 		Author:      "Security Onion Solutions",

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -550,23 +550,13 @@ func TestParseRule(t *testing.T) {
 			ExpectedError: util.Ptr("unexpected end of rule"),
 		},
 		{
-			Name: "Filter Out",
-			// BasicRule doesn't match either filter and will be left out,
-			// DeniedRule will be filtered out by the denyRegex.
-			Input:         BasicRule + "\n\n" + DeniedRule,
-			ExpectedRules: []*YaraRule{},
-		},
-		{
 			Name:          "Space in Identifier",
 			Input:         MyBasic_Rule,
 			ExpectedError: util.Ptr("unexpected character in rule identifier around 18"),
 		},
 	}
 
-	e := &StrelkaEngine{
-		allowRegex: regexp.MustCompile("my"),
-		denyRegex:  regexp.MustCompile("Deny"), // case sensitive
-	}
+	e := &StrelkaEngine{}
 
 	for _, test := range table {
 		test := test

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -484,7 +484,7 @@ func TestParse(t *testing.T) {
 				"# Comment",
 				SimpleRule,
 				"",
-				`# alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \\\"tricky\"\;\\ msg";)`, // allowRegex has the SID, should allow
+				`# alert  http any any  <>   any any (metadata:signature_severity   Informational; sid: "20000"; msg:"a \\\"tricky\"\;\\ msg";)`,
 				" # " + FlowbitsRuleA,
 				FlowbitsRuleB,
 			},


### PR DESCRIPTION
Allow/Deny regexes were removed from the config, annotations for the config, and suricata's engine but were left behind in Strelka and ElastAlert. Removed them, their config parsing, their implementation, and refactored any tests that relied on them.