### PR TITLE
Tuning YARA Detections

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -855,7 +855,7 @@
                 {{ i18n.filterDrilldown }}
               </v-list-item-title>
             </v-list-item>
-            <v-list-item id="actionTuneDetection" v-if="quickActionDetId && $root.detectionsEnabled && isCategory('alerts')" dense :to='{ name: "detection", params: { id: quickActionDetId }, query: { tab: "tuning" } }' :title="i18n.tuneDetectionHelp" :data-aid="'context_menu_tuning_' + category">
+            <v-list-item id="actionTuneDetection" v-if="quickActionDetId && $root.detectionsEnabled && isCategory('alerts')" dense :to='{ name: "detection", params: { id: quickActionDetId }, query: { tab: tuneDetectionTabTarget } }' :title="i18n.tuneDetectionHelp" :data-aid="'context_menu_tuning_' + category">
               <v-list-item-icon>
                 <v-icon :alt="i18n.tuneDetection" color="white">fa-wrench</v-icon>
               </v-list-item-icon>

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -156,6 +156,7 @@ const huntComponent = {
     presets: {},
     manualSyncTargetEngine: null,
     showBulkDeleteConfirmDialog: false,
+    tuneDetectionTabTarget: null,
   }},
   created() {
     this.$root.initializeCharts();
@@ -1062,11 +1063,16 @@ const huntComponent = {
       if (this.isCategory('alerts')) {
         const id = event["rule.uuid"];
         this.quickActionDetId = null;
+        this.tuneDetectionTabTarget = null;
 
         // don't slow down the UI with this call
         if (id) {
           this.$root.papi.get(`detection/public/${id}`).then(response => {
             this.quickActionDetId = response.data.id;
+            this.tuneDetectionTabTarget = 'tuning';
+            if (response.data.engine === 'strelka') {
+              this.tuneDetectionTabTarget = 'source';
+            }
           });
         }
       }

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1401,3 +1401,42 @@ test('bulkUpdateReport - filtered success', () => {
   expect(comp.$root.warningMessage).toBe('Bulk update successfully updated 20 of 20 events. However, the statuses of 1 of the updated detections are controlled by the current regex filter settings and were reverted. <a href="/#/config?s=soc.config.server.modules.suricataengine" data-aid="warning_bulk_update_configure_filters">Click here to configure those filters.</a> (3m 20s)'
 );
 });
+
+test('toggleQuickAction - Tune Detection, Yara => Source Tab, Other Engines => Tuning Tab', () => {
+  comp.category = 'alerts';
+  comp.escalationMenuVisible = comp.quickActionVisible = false;
+  let event = { "rule.uuid": 'id' }
+
+  let mockPromise = {
+    then: (f) => {
+      f({ data: { id: 'onionId', engine: 'elastalert' } });
+    }
+  };
+  resetPapi().mockPapi('get', mockPromise, null);
+
+  comp.toggleQuickAction({}, event, null, null);
+  expect(comp.quickActionDetId).toBe('onionId');
+  expect(comp.tuneDetectionTabTarget).toBe('tuning');
+
+  mockPromise = {
+    then: (f) => {
+      f({ data: { id: 'onionId', engine: 'suricata' } });
+    }
+  };
+  resetPapi().mockPapi('get', mockPromise, null);
+
+  comp.toggleQuickAction({}, event, null, null);
+  expect(comp.quickActionDetId).toBe('onionId');
+  expect(comp.tuneDetectionTabTarget).toBe('tuning');
+
+  mockPromise = {
+    then: (f) => {
+      f({ data: { id: 'onionId', engine: 'strelka' } });
+    }
+  };
+  resetPapi().mockPapi('get', mockPromise, null);
+
+  comp.toggleQuickAction({}, event, null, null);
+  expect(comp.quickActionDetId).toBe('onionId');
+  expect(comp.tuneDetectionTabTarget).toBe('source');
+});


### PR DESCRIPTION
When clicking "Tune Detection" on the Alerts page for a YARA rule, the user is now taken to the Detection Source tab. Other engines continue to take the user to the Tuning tab. We're doing this because YARA detections don't support overrides.