### PR TITLE
Fixed Err Management around UpdateRepos

### DIFF
--- a/server/modules/detections/ai_summary.go
+++ b/server/modules/detections/ai_summary.go
@@ -35,6 +35,8 @@ func RefreshAiSummaries(eng AiLoader, lang model.SigLanguage, isRunning *bool, a
 			"aiRepoUrl":  aiRepoUrl,
 			"aiRepoPath": aiRepoPath,
 		}).Error("unable to update AI repo")
+
+		return err
 	}
 
 	parser, err := url.Parse(aiRepoUrl)

--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -195,8 +195,8 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 
 			err = iom.CloneRepo(ctx, repoPath, repo.Repo, repo.Branch)
 			if err != nil {
-				log.WithError(err).WithField("repoPath", repoPath).Error("failed to clone repo, doing nothing with it")
-				continue
+				log.WithError(err).WithField("repoPath", repoPath).Error("failed to clone repo")
+				return nil, false, err
 			}
 
 			anythingNew = true

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1209,10 +1209,7 @@ func TestSyncChanges(t *testing.T) {
 			IsRunning: true,
 		},
 		IOManager:       iom,
-		showAiSummaries: true,
-		aiRepoUrl:       "aiRepoUrl",
-		aiRepoBranch:    "aiRepoBranch",
-		aiRepoPath:      "aiRepoPath",
+		showAiSummaries: false,
 	}
 
 	logger := log.WithField("detectionEngine", "test-elastalert")
@@ -1220,10 +1217,6 @@ func TestSyncChanges(t *testing.T) {
 	workItems := []esutil.BulkIndexerItem{}
 	auditItems := []esutil.BulkIndexerItem{}
 
-	// RefreshAiSummaries
-	iom.EXPECT().ReadDir("aiRepoPath").Return([]fs.DirEntry{}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "aiRepoPath/aiRepoUrl", "aiRepoUrl", util.Ptr("aiRepoBranch")).Return(nil)
-	iom.EXPECT().ReadFile("aiRepoPath/aiRepoUrl/detections-ai/sigma_summaries.yaml").Return([]byte("{}"), nil)
 	// checkSigmaPipelines
 	iom.EXPECT().ReadFile("sigmaPipelineFinal").Return([]byte("data"), nil)
 	iom.EXPECT().ReadFile("sigmaPipelineSO").Return([]byte("data"), nil)

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1089,10 +1089,7 @@ func TestSyncChanges(t *testing.T) {
 			IsRunning: true,
 		},
 		IOManager:       iom,
-		showAiSummaries: true,
-		aiRepoUrl:       "aiRepoUrl",
-		aiRepoBranch:    "aiRepoBranch",
-		aiRepoPath:      "aiRepoPath",
+		showAiSummaries: false,
 	}
 
 	logger := log.WithField("detectionEngine", "test-strelka")
@@ -1100,10 +1097,6 @@ func TestSyncChanges(t *testing.T) {
 	workItems := []esutil.BulkIndexerItem{}
 	auditItems := []esutil.BulkIndexerItem{}
 
-	// RefreshAiSummaries
-	iom.EXPECT().ReadDir("aiRepoPath").Return([]fs.DirEntry{}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "aiRepoPath/aiRepoUrl", "aiRepoUrl", util.Ptr("aiRepoBranch")).Return(nil)
-	iom.EXPECT().ReadFile("aiRepoPath/aiRepoUrl/detections-ai/yara_summaries.yaml").Return([]byte("{}"), nil)
 	// UpdateRepos
 	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -2263,10 +2263,7 @@ func TestSyncChanges(t *testing.T) {
 			IsRunning: true,
 		},
 		IOManager:       iom,
-		showAiSummaries: true,
-		aiRepoUrl:       "aiRepoUrl",
-		aiRepoBranch:    "aiRepoBranch",
-		aiRepoPath:      "aiRepoPath",
+		showAiSummaries: false,
 	}
 
 	logger := log.WithField("detectionEngine", "test-suricata")
@@ -2274,10 +2271,6 @@ func TestSyncChanges(t *testing.T) {
 	workItems := []esutil.BulkIndexerItem{}
 	auditItems := []esutil.BulkIndexerItem{}
 
-	// RefreshAiSummaries
-	iom.EXPECT().ReadDir("aiRepoPath").Return([]fs.DirEntry{}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "aiRepoPath/aiRepoUrl", "aiRepoUrl", util.Ptr("aiRepoBranch")).Return(nil)
-	iom.EXPECT().ReadFile("aiRepoPath/aiRepoUrl/detections-ai/suricata_summaries.yaml").Return([]byte("{}"), nil)
 	// readAndHash
 	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule+"\n"+FlowbitsRuleA), nil)
 	// syncCommunityDetections


### PR DESCRIPTION
RefreshAiSummaries now returns any repo errors it gets. They get logged, but won't impact the Sync.

When cloning a repo fails, return the error instead of only logging it. Not returning the error risks deleting "unreferenced" rules from that repo.

Sync tests no longer have `showAiSummaries` set to true. The `lastSuccessfulAiUpdate` variable wasn't being reset between tests and was wrecking havoc.