### PR TITLE
Remove RefreshAiSummaries

### DIFF
--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1108,18 +1108,11 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 			IsRunning: true,
 		},
 		IOManager:       iom,
-		showAiSummaries: true,
-		aiRepoUrl:       "aiRepoUrl",
-		aiRepoBranch:    "aiRepoBranch",
-		aiRepoPath:      "aiRepoPath",
+		showAiSummaries: false,
 	}
 
 	logger := log.WithField("detectionEngine", "test-elastalert")
 
-	// RefreshAiSummaries
-	iom.EXPECT().ReadDir("aiRepoPath").Return([]fs.DirEntry{}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "aiRepoPath/aiRepoUrl", "aiRepoUrl", util.Ptr("aiRepoBranch")).Return(nil)
-	iom.EXPECT().ReadFile("aiRepoPath/aiRepoUrl/detections-ai/sigma_summaries.yaml").Return([]byte("{}"), nil)
 	// checkSigmaPipelines
 	iom.EXPECT().ReadFile("sigmaPipelineFinal").Return([]byte("data"), nil)
 	iom.EXPECT().ReadFile("sigmaPipelineSO").Return([]byte("data"), nil)

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1015,18 +1015,11 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 			IsRunning: true,
 		},
 		IOManager:       iom,
-		showAiSummaries: true,
-		aiRepoUrl:       "aiRepoUrl",
-		aiRepoBranch:    "aiRepoBranch",
-		aiRepoPath:      "aiRepoPath",
+		showAiSummaries: false,
 	}
 
 	logger := log.WithField("detectionEngine", "test-strelka")
 
-	// RefreshAiSummaries
-	iom.EXPECT().ReadDir("aiRepoPath").Return([]fs.DirEntry{}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "aiRepoPath/aiRepoUrl", "aiRepoUrl", util.Ptr("aiRepoBranch")).Return(nil)
-	iom.EXPECT().ReadFile("aiRepoPath/aiRepoUrl/detections-ai/yara_summaries.yaml").Return([]byte("{}"), nil)
 	// UpdateRepos
 	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -2185,18 +2185,11 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 			IsRunning: true,
 		},
 		IOManager:       iom,
-		showAiSummaries: true,
-		aiRepoUrl:       "aiRepoUrl",
-		aiRepoBranch:    "aiRepoBranch",
-		aiRepoPath:      "aiRepoPath",
+		showAiSummaries: false,
 	}
 
 	logger := log.WithField("detectionEngine", "test-suricata")
 
-	// RefreshAiSummaries
-	iom.EXPECT().ReadDir("aiRepoPath").Return([]fs.DirEntry{}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "aiRepoPath/aiRepoUrl", "aiRepoUrl", util.Ptr("aiRepoBranch")).Return(nil)
-	iom.EXPECT().ReadFile("aiRepoPath/aiRepoUrl/detections-ai/suricata_summaries.yaml").Return([]byte("{}"), nil)
 	// readAndHash
 	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule), nil)
 	// readFingerprint


### PR DESCRIPTION
Even SyncNoChanges tests should not try to RefreshAiSummaries.