### PR TITLE
Validate Detection ID

### DIFF
--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -969,7 +969,7 @@ func TestExtractDetails(t *testing.T) {
 		{
 			Name:        "No Public Id",
 			Input:       SimpleRuleNoId,
-			ExpectedErr: util.Ptr("rule does not contain a public Id"),
+			ExpectedErr: util.Ptr("missing required fields: id"),
 		},
 		{
 			Name:             "Minimal Extracted Values, No Error",

--- a/server/modules/elastalert/validate.go
+++ b/server/modules/elastalert/validate.go
@@ -135,6 +135,10 @@ func (e *SigmaRule) Validate() error {
 	// check required fields
 	requiredFields := []string{}
 
+	if e.ID == nil || len(*e.ID) == 0 {
+		requiredFields = append(requiredFields, "id")
+	}
+
 	if len(e.Title) == 0 {
 		requiredFields = append(requiredFields, "title")
 	}

--- a/server/modules/elastalert/validate_test.go
+++ b/server/modules/elastalert/validate_test.go
@@ -51,20 +51,20 @@ func TestParseRule(t *testing.T) {
 		{
 			Name:          "Empty Rule",
 			Input:         `{}`,
-			ExpectedError: util.Ptr("missing required fields: title, logsource, detection.condition"),
+			ExpectedError: util.Ptr("missing required fields: id, title, logsource, detection.condition"),
 		},
 		{
 			Name:          "Detection but No Condition",
-			Input:         `{ title: "title", logsource: { category: "test" }, detection: {}}`,
+			Input:         `{ id: "x", title: "title", logsource: { category: "test" }, detection: {}}`,
 			ExpectedError: util.Ptr("missing required fields: detection.condition"),
 		},
 		{
 			Name:  "Minimal Rule With Single Detection Condition",
-			Input: `{ title: "title", logsource: { category: "test" }, detection: { condition: "condition" }}`,
+			Input: `{ id: "x", title: "title", logsource: { category: "test" }, detection: { condition: "condition" }}`,
 		},
 		{
 			Name:  "Minimal Rule With Multiple Detection Condition",
-			Input: `{ title: "title", logsource: { category: "test" }, detection: { condition: [ "conditionOne", "conditionTwo" ] }}`,
+			Input: `{ id: "x", title: "title", logsource: { category: "test" }, detection: { condition: [ "conditionOne", "conditionTwo" ] }}`,
 		},
 	}
 

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -233,6 +233,10 @@ func (e *StrelkaEngine) ValidateRule(data string) (string, error) {
 		return "", err
 	}
 
+	if len(rules) != 1 {
+		return "", fmt.Errorf("expected exactly 1 rule, got %d", len(rules))
+	}
+
 	return string(data), nil
 }
 

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1322,3 +1322,46 @@ func TestLoadAndMergeAuxiliaryData(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRule(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Input         string
+		ExpectedError string
+	}{
+		{
+			Name:  "Valid Rule",
+			Input: MyBasicRule,
+		},
+		{
+			Name:          "Empty Rule",
+			Input:         "",
+			ExpectedError: "expected exactly 1 rule, got 0",
+		},
+		{
+			Name:          "Empty Rule",
+			Input:         MyBasicRule + "\n" + MyBasicRule,
+			ExpectedError: "expected exactly 1 rule, got 2",
+		},
+		{
+			Name:          "Missing ID",
+			Input:         strings.ReplaceAll(MyBasicRule, "ExampleRule", ""),
+			ExpectedError: "unexpected character in rule identifier around 6",
+		},
+	}
+
+	e := &StrelkaEngine{}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			_, err := e.ValidateRule(test.Input)
+			if test.ExpectedError != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.ExpectedError, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -655,6 +655,11 @@ func (e *SuricataEngine) ValidateRule(rule string) (string, error) {
 		return rule, err
 	}
 
+	_, ok := parsed.GetOption("sid")
+	if !ok {
+		return rule, fmt.Errorf("rule does not contain a SID")
+	}
+
 	return parsed.String(), nil
 }
 

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -395,7 +395,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			Name:  "Valid Rule with Escaped Quotes",
-			Input: `alert http any any -> any any (msg:"This rule has \"escaped quotes\"";)`,
+			Input: `alert http any any -> any any (msg:"This rule has \"escaped quotes\""; sid: 200000;)`,
 		},
 		{
 			Name:        "Invalid Direction",


### PR DESCRIPTION
Ensure each engine requires a publicId. YARA does as part of it's parsing but Suricata and ElastAlert needed explicit checks added. All engines have been updated to make it harder to save a detection without a publicId. Added/Updated tests.