### PR TITLE
Only Test Ai Summaries in TestRefreshAiSummaries

### DIFF
--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -83,6 +83,8 @@ func TestElastAlertModule(t *testing.T) {
 	err := mod.Init(nil)
 	assert.NoError(t, err)
 
+	mod.showAiSummaries = false
+
 	err = mod.Start()
 	assert.NoError(t, err)
 

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -236,6 +236,8 @@ func TestStrelkaModule(t *testing.T) {
 	err := mod.Init(nil)
 	assert.NoError(t, err)
 
+	mod.showAiSummaries = false
+
 	err = mod.Start()
 	assert.NoError(t, err)
 

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -64,6 +64,8 @@ func TestSuricataModule(t *testing.T) {
 	err := mod.Init(nil)
 	assert.NoError(t, err)
 
+	mod.showAiSummaries = false
+
 	err = mod.Start()
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Because `showAiSummaries` defaults to true when the config value is missing, each of these tests was calling `RefreshAiSummaries` and thus setting `lastSuccessfulAiUpdate` and causing other tests to fail.