### PR TITLE
Fixes for running multiple tests

### DIFF
--- a/server/modules/detections/ai_summary_test.go
+++ b/server/modules/detections/ai_summary_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
@@ -54,6 +55,8 @@ func TestRefreshAiSummaries(t *testing.T) {
 	})
 
 	logger := log.WithField("test", true)
+
+	lastSuccessfulAiUpdate = time.Time{}
 
 	err := RefreshAiSummaries(loader, model.SigLangSigma, &isRunning, "baseRepoFolder", repo, branch, logger, iom)
 	assert.NoError(t, err)

--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -394,6 +394,8 @@ func TestCheckTemplate(t *testing.T) {
 	detStore.EXPECT().DoesTemplateExist(ctx, "so-detection").Return(false, nil)
 	detStore.EXPECT().DoesTemplateExist(ctx, "so-detection").Return(true, nil).Times(1)
 
+	templateFound = false
+
 	results := []bool{}
 	for i := 0; i < 10; i++ {
 		result := CheckTemplate(ctx, detStore)
@@ -401,6 +403,7 @@ func TestCheckTemplate(t *testing.T) {
 	}
 
 	assert.Equal(t, []bool{false, true, true, true, true, true, true, true, true, true}, results)
+	assert.Equal(t, true, templateFound)
 }
 
 func TestUpdateRepos(t *testing.T) {


### PR DESCRIPTION
When tests are run multiple times the state of package level variables are retained. Made some adjustments so the tests still pass in this scenario.