### PR TITLE
Fix for Custom Action Navigation Failure

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -982,7 +982,7 @@
               <template v-for="action in actions">
                 <v-list-item v-if="action.enabled" density="compact" class="custom-quick-action-button" :key="action.name"
                   :href="action.background ? '' : action.linkFormatted" v-bind:title.attr="$root.localizeMessage(action.description)"
-                  :target="$root.target(action.target)" @click="performAction($event, action) || $root.performAction($event, action)"
+                  :target="$root.target(action.target)" @click="performAction($event, action)"
                   :data-aid="'context_menu_quickaction_' + category + '_' + action.name">
                     <template #prepend>
                       <v-icon :alt="action.name" class="solid" class="theme-icon">{{ action.icon }}</v-icon>

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -218,7 +218,7 @@ $(document).ready(function () {
         return content;
       },
       performAction(event, action) {
-        if (action && !action.background) return false;
+        if (action && !action.background) return true;
         const options = action.options ? action.options : { mode: 'no-cors' };
         options.method = action.method;
         if (action.method != 'GET') {
@@ -251,6 +251,7 @@ $(document).ready(function () {
             route.$root.showTip(route.i18n.actionFailure + route.$root.localizeMessage(action.name));
           }
         });
+        return true;
       },
       base64encode(content) {
         try {

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2067,7 +2067,13 @@ const huntComponent = {
     },
     performAction($event, action) {
       if (action && action.jsCall && this[action.jsCall]) {
+        this.quickActionVisible = false;
         this[action.jsCall](action);
+        return false;
+      }
+
+      if (!this.$root.performAction($event, action) && action && !action.background) {
+        this.quickActionVisible = false;
         return true;
       }
 

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2066,18 +2066,19 @@ const huntComponent = {
       this.$router.push(this.buildFilterRoute(this.quickActionField, range, FILTER_INCLUDE, true));
     },
     performAction($event, action) {
+      let shouldNavigate = true;
+
       if (action && action.jsCall && this[action.jsCall]) {
-        this.quickActionVisible = false;
+        // no need to navigate, made JS call instead
         this[action.jsCall](action);
-        return false;
+        shouldNavigate = false;
       }
 
-      if (!this.$root.performAction($event, action) && action && !action.background) {
-        this.quickActionVisible = false;
-        return true;
-      }
+      this.$root.performAction($event, action);
 
-      return false;
+      this.quickActionVisible = false;
+
+      return shouldNavigate;
     },
     async openAddToCaseDialog() {
       // this function is meant to be called by performAction($event, action)

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -971,7 +971,7 @@ test('performAction', () => {
   let result = comp.performAction(undefined, action);
 
   expect(mock).toHaveBeenCalledTimes(0);
-  expect(result).toBe(false);
+  expect(result).toBe(true); // true means allow the href property to navigate
 
   action.jsCall = 'testFunc';
 
@@ -979,7 +979,7 @@ test('performAction', () => {
 
   expect(mock).toHaveBeenCalledTimes(1);
   expect(mock).toHaveBeenCalledWith(action);
-  expect(result).toBe(true);
+  expect(result).toBe(false);
 
   delete comp.testFunc;
 });


### PR DESCRIPTION
Simplified the @click handler for quick actions. It can act like a nav guard for the href attribute. Updated tests.