### PR TITLE
Specific Queries for Detection Engine State

### DIFF
--- a/config/clientparameters.go
+++ b/config/clientparameters.go
@@ -121,6 +121,7 @@ type HuntingParameters struct {
 	ChartLabelOtherLimit         int                 `json:"chartLabelOtherLimit"`
 	ChartLabelFieldSeparator     string              `json:"chartLabelFieldSeparator"`
 	AggregationActionsEnabled    bool                `json:"aggregationActionsEnabled"`
+	DetectionEngineStatusQueries string              `json:"detectionEngineStatusQueries"`
 }
 
 func (params *HuntingParameters) Verify() error {

--- a/html/index.html
+++ b/html/index.html
@@ -370,7 +370,7 @@
             <div v-if="isCategory('detections') && loaded" :data-aid="'event_health_' + category">
               <h5 v-for="engine in $root.getDetectionEngines()">
                 {{ i18n['cc_' + engine] }}:
-                <router-link :to="{ name: 'hunt', query: {q: `tags:so-soc AND ` + engine + ` | groupby log.level | groupby event.action | groupby soc.fields.error`, t: moment().subtract(1, 'hours').format(i18n.timePickerFormat) + ' - ' + moment().format(i18n.timePickerFormat), socExcludeToggle: false }}" style="text-decoration: none; cursor: 'pointer'" :class="$root.getDetectionEngineStatusClass(engine)" :data-aid="'detection_engine_status_' + engine" :title="i18n['detectionEngine' + $root.getDetectionEngineStatus(engine) + 'Help']">
+                <router-link :to="{ name: 'hunt', query: {q: buildDetectionEngineHuntQuery(engine), t: moment().subtract(1, 'hours').format(i18n.timePickerFormat) + ' - ' + moment().format(i18n.timePickerFormat), socExcludeToggle: false, detectionsExcludeToggle: false }}" style="text-decoration: none; cursor: 'pointer'" :class="$root.getDetectionEngineStatusClass(engine)" :data-aid="'detection_engine_status_' + engine" :title="i18n['detectionEngine' + $root.getDetectionEngineStatus(engine) + 'Help']">
                   {{ i18n['detectionEngine' + $root.getDetectionEngineStatus(engine)] }}
                 </router-link>
               </h5>


### PR DESCRIPTION
The config holds a YAML string, parse it, and use the dictionary to lookup hunt queries when a user clicks a Detection Engine's status on the detections page.

Clicking on these links now creates a url that toggles the "exclude detections" toggle to false.