### PR TITLE
Stop blurring active element on Hunt

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -372,11 +372,6 @@ const huntComponent = {
 
       this.selectAllState = false;
       this.selectedCount = 0;
-
-      if (document.activeElement) {
-        // Release focus to avoid clicking away causing a second hunt
-        document.activeElement.blur();
-      }
     },
     stopRefreshTimer() {
       if (this.autoRefreshTimer) {


### PR DESCRIPTION
This is causing a recursive loop in Firefox.