### PR TITLE
Detection Status and Delete Button

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1940,14 +1940,14 @@
                       {{ i18n.status }}: {{ detect.isEnabled ? i18n.enabled : i18n.disabled }}
                     </div>
                     <div data-aid="detection_metadata_enabled_toggle">
-                      <v-switch id="detection-enabled-edit" inset v-model="detect.isEnabled" @change="saveDetection(false)"></v-switch>
+                      <v-switch id="detection-enabled-edit" inset v-model="detect.isEnabled" color="primary" @change="saveDetection(false)"></v-switch>
                     </div>
                   </span>
                   <div id="ops-buttons">
                     <v-btn id="detection-duplicate" color="primary" @click="duplicateDetection()" data-aid="detection_metadata_duplicate" class="flex-basis-50">
                       {{i18n.duplicate}}
                     </v-btn>
-                    <v-btn :disabled="detect.isCommunity" id="detection-delete" color="error" @click="deleteDetection()" data-aid="detection_metadata_delete" class="flex-basis-50">
+                    <v-btn :disabled="detect.isCommunity" id="detection-delete" :color="detect.isCommunity ? 'black' : 'error'" @click="deleteDetection()" data-aid="detection_metadata_delete" class="flex-basis-50">
                       {{i18n.delete}}
                     </v-btn>
                   </div>

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -349,7 +349,7 @@ const i18n = {
       diskUsageRootAbbr: 'Root',
       downloads: 'Downloads',
       downloadsAgentUnavailable: 'Evaluation installs and Import installs do not support remote elastic agents. The links below are shown for demonstration purposes only.',
-      downloadsFirewallTip: 'When installing the Elastic Agent onto remote systems, be sure to <a href="/#/config?s=firewall.hostgroups.elastic_agent_endpoint">allow network access through the firewall</a>.',
+      downloadsFirewallTip: '<span class="d-block">When installing the Elastic Agent onto remote systems, be sure to <a class="text-white" href="/#/config?s=firewall.hostgroups.elastic_agent_endpoint">allow network access through the firewall</a>.</span>',
       downloadsInfo: 'These <a href="/docs/elastic-agent.html">Elastic Agent</a> installers are customized for this specific <a href="/docs/elastic-fleet.html">Elastic Fleet</a> installation. These files are not signed. If you need signed non-customized Elastic Agent installers, you can get them from <a href="https://www.elastic.co/downloads/elastic-agent">elastic.co</a>.',
       downloadsElasticAgent: 'Elastic Agent Installers',
       downloadPackets: 'Download the packets as a PCAP file',


### PR DESCRIPTION
The status switch was never colored so looked gray in both states. Set the color to primary to match the same Blue color from Vue 2.

The delete button, when disabled, looked a lot like the duplicate button giving the appearance that both buttons were disabled. Now the color of the delete button changes to black when disabled to give a better user experience.

On the Downloads page, the banner contains a hyperlink resulting in 2 problems: the spacing was broken up and the link turned the exact same blue as the banner color virtually disappearing. Both were fixed by updating the i18n string with a little HTML.