### PR TITLE
ES Lookup of IPs

### DIFF
--- a/model/event.go
+++ b/model/event.go
@@ -224,3 +224,38 @@ func NewEventScrollCriteria() *EventScrollCriteria {
 	criteria.initScrollCriteria()
 	return criteria
 }
+
+type EventMSearchCriteria struct {
+	Index       string
+	RawQuery    string
+	ParsedQuery *Query
+}
+
+func NewEventMSearchCriteria() *EventMSearchCriteria {
+	criteria := &EventMSearchCriteria{}
+	criteria.ParsedQuery = NewQuery()
+
+	return criteria
+}
+
+func (criteria *EventMSearchCriteria) Populate(index string, query string) error {
+	criteria.Index = index
+
+	criteria.RawQuery = strings.TrimSpace(query)
+	err := criteria.ParsedQuery.Parse(query)
+
+	return err
+}
+
+type EventMSearchResults struct {
+	ElapsedMs int                   `json:"elapsedMs"`
+	Responses []*EventSearchResults `json:"responses"`
+}
+
+func NewEventMSearchResults() *EventMSearchResults {
+	results := &EventMSearchResults{
+		Responses: make([]*EventSearchResults, 0),
+	}
+
+	return results
+}

--- a/server/eventstore.go
+++ b/server/eventstore.go
@@ -15,6 +15,7 @@ import (
 type Eventstore interface {
 	EventSearch(context context.Context, criteria *model.EventSearchCriteria) (*model.EventSearchResults, error)
 	Search(context context.Context, criteria *model.EventSearchCriteria) (*model.EventSearchResults, error)
+	MSearch(context context.Context, criteria []*model.EventMSearchCriteria) (*model.EventMSearchResults, error)
 	Scroll(context context.Context, criteria *model.EventScrollCriteria, indexes []string) (*model.EventScrollResults, error)
 	Index(ctx context.Context, index string, document map[string]interface{}, id string) (*model.EventIndexResults, error)
 	Update(context context.Context, criteria *model.EventUpdateCriteria) (*model.EventUpdateResults, error)

--- a/server/eventstore_fake.go
+++ b/server/eventstore_fake.go
@@ -13,24 +13,27 @@ import (
 )
 
 type FakeEventstore struct {
-	InputDocuments       []map[string]interface{}
-	InputContexts        []context.Context
-	InputIndexes         []string
-	InputIds             []string
-	InputSearchCriterias []*model.EventSearchCriteria
-	InputUpdateCriterias []*model.EventUpdateCriteria
-	InputAckCriterias    []*model.EventAckCriteria
-	InputScrollCriterias []*model.EventScrollCriteria
-	InputScrollIndexes   [][]string
-	Err                  error
-	SearchResults        []*model.EventSearchResults
-	IndexResults         []*model.EventIndexResults
-	UpdateResults        []*model.EventUpdateResults
-	ScrollResults        []*model.EventScrollResults
-	searchCount          int
-	indexCount           int
-	updateCount          int
-	scrollCount          int
+	InputDocuments        []map[string]interface{}
+	InputContexts         []context.Context
+	InputIndexes          []string
+	InputIds              []string
+	InputSearchCriterias  []*model.EventSearchCriteria
+	InputMSearchCriterias [][]*model.EventMSearchCriteria
+	InputUpdateCriterias  []*model.EventUpdateCriteria
+	InputAckCriterias     []*model.EventAckCriteria
+	InputScrollCriterias  []*model.EventScrollCriteria
+	InputScrollIndexes    [][]string
+	Err                   error
+	SearchResults         []*model.EventSearchResults
+	MSearchResults        []*model.EventMSearchResults
+	IndexResults          []*model.EventIndexResults
+	UpdateResults         []*model.EventUpdateResults
+	ScrollResults         []*model.EventScrollResults
+	searchCount           int
+	msearchCount          int
+	indexCount            int
+	updateCount           int
+	scrollCount           int
 }
 
 func NewFakeEventstore() *FakeEventstore {
@@ -62,6 +65,17 @@ func (store *FakeEventstore) Search(context context.Context, criteria *model.Eve
 	}
 	result := store.SearchResults[store.searchCount]
 	store.searchCount += 1
+	return result, store.Err
+}
+
+func (store *FakeEventstore) MSearch(context context.Context, criteria []*model.EventMSearchCriteria) (*model.EventMSearchResults, error) {
+	store.InputContexts = append(store.InputContexts, context)
+	store.InputMSearchCriterias = append(store.InputMSearchCriterias, criteria)
+	if store.msearchCount >= len(store.MSearchResults) {
+		store.msearchCount = len(store.MSearchResults) - 1
+	}
+	result := store.MSearchResults[store.msearchCount]
+	store.msearchCount += 1
 	return result, store.Err
 }
 

--- a/server/utilhandler.go
+++ b/server/utilhandler.go
@@ -12,12 +12,15 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/web"
 
 	"github.com/apex/log"
 	"github.com/go-chi/chi/v5"
 	lop "github.com/samber/lo/parallel"
-	"github.com/security-onion-solutions/securityonion-soc/web"
 )
 
 type UtilHandler struct {
@@ -35,73 +38,137 @@ func RegisterUtilRoutes(srv *Server, r chi.Router, prefix string) {
 }
 
 func (h *UtilHandler) putReverseLookup(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	logger := log.WithField("handler", "putReverseLookup")
+
 	var body []string
 	results := map[string][]string{}
 
 	err := json.NewDecoder(r.Body).Decode(&body)
 	if err != nil {
+		logger.WithError(err).Error("failed to decode request body")
 		web.Respond(w, r, http.StatusBadRequest, err)
+
 		return
 	}
 
+	// ensure we only look up each IP once
 	dedup := map[string]struct{}{}
 	for _, ip := range body {
-		dedup[ip] = struct{}{}
+		if net.ParseIP(ip) != nil {
+			dedup[ip] = struct{}{}
+		}
 	}
 
+	msearchRequests := make([]*model.EventMSearchCriteria, 0, len(dedup))
+
+	// build search criteria for ES lookup
+	for ip := range dedup {
+		criteria := model.NewEventMSearchCriteria()
+
+		err = criteria.Populate("so-ip-mappings", "so.ip_address:"+ip)
+		if err != nil {
+			logger.WithError(err).Error("failed to populate search criteria")
+			web.Respond(w, r, http.StatusInternalServerError, err)
+
+			return
+		}
+
+		msearchRequests = append(msearchRequests, criteria)
+	}
+
+	logger.WithField("ipsToLookup", len(msearchRequests)).Info("starting ES lookup")
+
+	result, err := h.server.Eventstore.MSearch(ctx, msearchRequests)
+	if err != nil {
+		logger.WithError(err).Error("failed to perform ES lookup")
+		web.Respond(w, r, http.StatusInternalServerError, err)
+
+		return
+	}
+
+	// parse results from ES lookup and remove results from dedup
+	for _, response := range result.Responses {
+		for _, result := range response.Events {
+			ip, ok := result.Payload["so.ip_address"].(string)
+			if !ok {
+				continue
+			}
+
+			desc, ok := result.Payload["so.description"].(string)
+			if !ok {
+				continue
+			}
+
+			results[ip] = []string{desc}
+
+			delete(dedup, ip)
+		}
+	}
+
+	logger.WithFields(log.Fields{
+		"ipsFoundInES":     len(results),
+		"esSearchTimeInMS": result.ElapsedMs,
+	}).Info("completed ES lookup")
+
+	// build list of IPs to lookup with DNS
 	ips := make([]string, 0, len(dedup))
 	for ip := range dedup {
 		ips = append(ips, ip)
 	}
 
-	var resolver *net.Resolver
+	if len(ips) != 0 {
+		logger.WithField("ipsToLookup", len(ips)).Info("starting DNS lookup")
 
-	if h.server.Config.Dns != "" {
-		dnsServer := h.server.Config.Dns
+		var resolver *net.Resolver
 
-		_, _, err = net.SplitHostPort(dnsServer)
-		if err != nil && err.Error() == "missing port in address" {
-			dnsServer = net.JoinHostPort(dnsServer, "53")
-			err = nil
-		}
+		if h.server.Config.Dns != "" {
+			dnsServer := h.server.Config.Dns
 
-		if err == nil {
-			resolver = &net.Resolver{
-				PreferGo: true,
-				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-					d := net.Dialer{
-						Timeout: time.Millisecond * time.Duration(3000),
-					}
-					return d.DialContext(ctx, network, dnsServer)
-				},
+			_, _, err = net.SplitHostPort(dnsServer)
+			if err != nil && err.Error() == "missing port in address" {
+				dnsServer = net.JoinHostPort(dnsServer, "53")
+				err = nil
+			}
+
+			if err == nil {
+				resolver = &net.Resolver{
+					PreferGo: true,
+					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+						d := net.Dialer{
+							Timeout: time.Millisecond * time.Duration(3000),
+						}
+						return d.DialContext(ctx, network, dnsServer)
+					},
+				}
 			}
 		}
-	}
 
-	if resolver == nil {
-		resolver = net.DefaultResolver
-	}
-
-	mapLock := sync.Mutex{}
-	lop.ForEach(ips, func(ip string, _ int) {
-		addrs, err := resolver.LookupAddr(context.Background(), ip)
-		if err != nil && !strings.Contains(err.Error(), "Name or service not known") {
-			log.WithField("ip", ip).WithError(err).Warn("Failed to lookup address")
-		}
-		if addrs == nil {
-			addrs = []string{}
+		if resolver == nil {
+			resolver = net.DefaultResolver
 		}
 
-		mapLock.Lock()
-		results[ip] = addrs
-		mapLock.Unlock()
-	})
+		mapLock := sync.Mutex{}
+		resolved := int32(0)
 
-	// every entry gets something, even if it's just the original IP
-	for k, v := range results {
-		if len(v) == 0 {
-			results[k] = []string{k}
-		}
+		lop.ForEach(ips, func(ip string, _ int) {
+			addrs, err := resolver.LookupAddr(ctx, ip)
+			if err != nil && !strings.Contains(err.Error(), "Name or service not known") {
+				log.WithField("ip", ip).WithError(err).Warn("Failed to lookup address")
+			}
+			if len(addrs) == 0 {
+				addrs = []string{ip}
+			} else {
+				atomic.AddInt32(&resolved, 1)
+			}
+
+			mapLock.Lock()
+			results[ip] = addrs
+			mapLock.Unlock()
+		})
+
+		logger.WithField("ipsResolvedByDNS", resolved).Info("completed DNS lookup")
 	}
 
 	web.Respond(w, r, http.StatusOK, results)


### PR DESCRIPTION
Implemented MSearch on the EventStore as a quick way to execute many back-to-back simple searches. This was implemented generically so it can be used for non-IP-lookup searches in the future.

The /reverse-lookup endpoint has been updated to first execute an MSearch then any IPs not discovered in the index go on to be resolved by the DNS server. If everything was resolved, it doesn't setup the DNS resolver. Added logging.

Updated tests.