### PR TITLE
Grid Spacing and Multiline Config Resizing

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -310,6 +310,7 @@ a#title, a#title:visited, a#title:active, a#title:hover {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  margin-left: 4px;
 }
 
 .case.summary {

--- a/html/index.html
+++ b/html/index.html
@@ -5261,7 +5261,7 @@
                           </v-btn>
                         </div>
                         <div v-if="isMultiline(selected)">
-                          <v-textarea v-if="form.key != selected.id" id="value-output" variant="outlined" :label="i18n.settingGlobal" @focus="edit(selected)" v-model="selected.value" readonly :disabled="isReadOnly(selected)" class="config-editor" data-aid="config_item_customize_multiline_display" />
+                          <v-textarea v-if="form.key != selected.id" id="value-output" variant="outlined" :label="i18n.settingGlobal" @focus="edit(selected)" v-model="selected.value" readonly :disabled="isReadOnly(selected)" :no-resize="!isReadOnly(selected)" class="config-editor" data-aid="config_item_customize_multiline_display" />
                           <v-textarea v-else id="value-input" variant="outlined" :label="i18n.settingGlobal" v-model="form.value" class="editing config-editor" data-aid="config_item_customize_multiline_input" />
                         </div>
                         <div v-else>


### PR DESCRIPTION
Grid values now have a 4px gutter between them and their labels.

On the config screen, a multiline textarea won't be resizable until it has been focused on unless it's readonly.