### PR TITLE
Account for missing index

### DIFF
--- a/server/modules/elastic/converter.go
+++ b/server/modules/elastic/converter.go
@@ -522,6 +522,16 @@ func convertFromElasticMSearchResults(fieldDefs map[string]*FieldDefinition, esJ
 		response := gjson.Get(esJson, fmt.Sprintf("responses.%d", i))
 		res := model.NewEventSearchResults()
 
+		errField := response.Get("error")
+		if errField.String() != "" {
+			msg := response.Get("error.reason").String()
+			if msg == "" {
+				msg = errField.String()
+			}
+
+			return errors.New(msg)
+		}
+
 		err = convertFromElasticResults(fieldDefs, response.String(), res)
 		if err != nil {
 			return err
@@ -530,7 +540,7 @@ func convertFromElasticMSearchResults(fieldDefs map[string]*FieldDefinition, esJ
 		results.Responses = append(results.Responses, res)
 	}
 
-	return err
+	return nil
 }
 
 func parseTime(fieldmap map[string]interface{}, key string) *time.Time {

--- a/server/utilhandler.go
+++ b/server/utilhandler.go
@@ -82,10 +82,14 @@ func (h *UtilHandler) putReverseLookup(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.server.Eventstore.MSearch(ctx, msearchRequests)
 	if err != nil {
-		logger.WithError(err).Error("failed to perform ES lookup")
-		web.Respond(w, r, http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "no such index") {
+			logger.WithError(err).Warn("index not found, skipping ES lookup")
+		} else {
+			logger.WithError(err).Error("failed to perform ES lookup")
+			web.Respond(w, r, http.StatusInternalServerError, err)
 
-		return
+			return
+		}
 	}
 
 	// parse results from ES lookup and remove results from dedup


### PR DESCRIPTION
During testing our machines don't have a mapping specified at /nsm/custom-mappings/ip-descriptions.csv so the index won't exist.

MSearch has been refactored to return the first search response error as an error. If we need to support individual response errors in the future we'll cross that bridge when we come to it.

The utilhandler has been updated to ignore "no such index" errors as that is not a sign of failure for the IP lookup. We now log that the index was not found before continuing.