### PR TITLE
Allow Empty Repos or Repos without Remotes to be Skipped during Sync

### DIFF
--- a/server/modules/detections/mock/mock_iomanager.go
+++ b/server/modules/detections/mock/mock_iomanager.go
@@ -103,12 +103,13 @@ func (mr *MockIOManagerMockRecorder) MakeRequest(arg0 any) *gomock.Call {
 }
 
 // PullRepo mocks base method.
-func (m *MockIOManager) PullRepo(arg0 context.Context, arg1 string, arg2 *string) (bool, bool) {
+func (m *MockIOManager) PullRepo(arg0 context.Context, arg1 string, arg2 *string) (bool, bool, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullRepo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
 }
 
 // PullRepo indicates an expected call of PullRepo.

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1523,7 +1523,7 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
 	// check for changes before sync
 	iom.EXPECT().ReadFile("rulesFingerprintFile").Return([]byte(`{"core+": "c6OTI9nTQxGEeeNkSZZB9+OESMNvfMXrb+XLtMiVhf0="}`), nil)
 	// WriteStateFile
@@ -1620,7 +1620,7 @@ func TestSyncChanges(t *testing.T) {
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
 	// parseRepoRules
 	iom.EXPECT().WalkDir("repos/repo", gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
 		files := []fs.DirEntry{

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1029,7 +1029,7 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
 	// WriteStateFile
 	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
 	// IntegrityCheck
@@ -1099,7 +1099,7 @@ func TestSyncChanges(t *testing.T) {
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(true, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(true, false, false)
 	// Sync
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		"dummy": {


### PR DESCRIPTION
If a Pull results in a "repository not found" the sync is failed without deleting. As the local files may be the only copy of the rules, we want to allow the user time to adapt.

If a never-before-seen repo comes back as "empty remote" or "not found" then don't stop the sync. There's nothing to add and nothing to remove from these situations.

Updated tests and mocks.