### PR TITLE
Fix UI Behavior Around User Admin Rows

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -2396,7 +2396,7 @@
               <template #item="{ item, isExpanded, toggleExpand, internalItem }">
                 <tr>
                   <td v-if="$root.isUserAdmin()">
-                    <v-btn id="expandNode" icon variant="text" size="small" @click="if (!isExpanded(internalItem)) updateForm(item); toggleExpand(internalItem)" data-aid="users_details_expand">
+                    <v-btn id="expandNode" icon variant="text" size="small" @click="if (!isExpanded(internalItem)) { updateForm(item); } toggleExpand(internalItem)" data-aid="users_details_expand">
                       <v-icon v-if="isExpanded(internalItem)" :alt="i18n.expand" :title="i18n.nodeExpandHelp" data-aid="users_details_collapse">fa-angle-down</v-icon>
                       <v-icon v-else :alt="i18n.expand" :title="i18n.nodeExpandHelp" data-aid="users_details_expand">fa-angle-right</v-icon>
                     </v-btn>

--- a/html/index.html
+++ b/html/index.html
@@ -2376,7 +2376,7 @@
               </v-card>
             </v-dialog>
             <v-data-table :sort-by="sortBy" @update:sort-by="val => sortBy = val" :footer-props="footerProps" data-aid="users_details"
-              :items-per-page.sync="itemsPerPage" must-sort :headers="headers" :items="users">
+              :items-per-page.sync="itemsPerPage" must-sort :headers="headers" :items="users" v-model:expanded="expanded">
               <template #headers="{ columns, isSorted, getSortIcon, toggleSort }">
                 <tr>
                   <template v-for="header in columns" :key="header.key">
@@ -2396,7 +2396,7 @@
               <template #item="{ item, isExpanded, toggleExpand, internalItem }">
                 <tr>
                   <td v-if="$root.isUserAdmin()">
-                    <v-btn id="expandNode" icon variant="text" size="small" @click="toggleExpand(internalItem); if (isExpanded(internalItem)) updateForm(item)" data-aid="users_details_expand">
+                    <v-btn id="expandNode" icon variant="text" size="small" @click="toggleExpand(internalItem); if (!isExpanded(internalItem)) updateForm(item)" data-aid="users_details_expand">
                       <v-icon v-if="isExpanded(internalItem)" :alt="i18n.expand" :title="i18n.nodeExpandHelp" data-aid="users_details_collapse">fa-angle-down</v-icon>
                       <v-icon v-else :alt="i18n.expand" :title="i18n.nodeExpandHelp" data-aid="users_details_expand">fa-angle-right</v-icon>
                     </v-btn>

--- a/html/index.html
+++ b/html/index.html
@@ -2396,7 +2396,7 @@
               <template #item="{ item, isExpanded, toggleExpand, internalItem }">
                 <tr>
                   <td v-if="$root.isUserAdmin()">
-                    <v-btn id="expandNode" icon variant="text" size="small" @click="toggleExpand(internalItem); if (!isExpanded(internalItem)) updateForm(item)" data-aid="users_details_expand">
+                    <v-btn id="expandNode" icon variant="text" size="small" @click="if (!isExpanded(internalItem)) updateForm(item); toggleExpand(internalItem)" data-aid="users_details_expand">
                       <v-icon v-if="isExpanded(internalItem)" :alt="i18n.expand" :title="i18n.nodeExpandHelp" data-aid="users_details_collapse">fa-angle-down</v-icon>
                       <v-icon v-else :alt="i18n.expand" :title="i18n.nodeExpandHelp" data-aid="users_details_expand">fa-angle-right</v-icon>
                     </v-btn>

--- a/html/js/routes/users.js
+++ b/html/js/routes/users.js
@@ -50,6 +50,7 @@ routes.push({ path: '/users', name: 'users', component: {
     '$route': 'loadData',
     'sortBy': 'saveLocalSettings',
     'itemsPerPage': 'saveLocalSettings',
+    'expanded': 'onlyExpandOneRow',
   },
   methods: {
     async loadData() {
@@ -249,6 +250,11 @@ routes.push({ path: '/users', name: 'users', component: {
     },
     countUsers() {
       return this.users.length;
+    },
+    onlyExpandOneRow() {
+      if (this.expanded.length > 1) {
+        this.expanded = [this.expanded[this.expanded.length - 1]];
+      }
     },
   }
 }});

--- a/html/js/routes/users.test.js
+++ b/html/js/routes/users.test.js
@@ -100,3 +100,21 @@ test('hasRole', () => {
   expect(comp.hasRole({roles: ['foo']}, 'test')).toBe(false);
   expect(comp.hasRole({roles: ['foo','test']}, 'test')).toBe(true);
 });
+
+test('onlyExpandOneRow', () => {
+  comp.expanded = [];
+  comp.onlyExpandOneRow();
+  expect(comp.expanded).toEqual([]);
+
+  comp.expanded = ['1'];
+  comp.onlyExpandOneRow();
+  expect(comp.expanded).toEqual(['1']);
+
+  comp.expanded = ['1', '2'];
+  comp.onlyExpandOneRow();
+  expect(comp.expanded).toEqual(['2']);
+
+  comp.expanded = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
+  comp.onlyExpandOneRow();
+  expect(comp.expanded).toEqual(['10']);
+});


### PR DESCRIPTION
Expanding multiple users at once was resulting in the edit forms under each expanded row containing the values of the last row expanded. Reverted the behavior back to how it worked in Vue 2 where only 1 row could be expanded at a time.

Similar to the above, if you expanded a row for an existing user and clicked the Create User button, then the data in the expanded row would be cleared out. Now when you click the Create User button, we close any expanded rows.

Added a test.