### PR TITLE
Logger on Context

### DIFF
--- a/server/casehandler.go
+++ b/server/casehandler.go
@@ -144,12 +144,13 @@ func (h *CaseHandler) createComment(w http.ResponseWriter, r *http.Request) {
 
 func (h *CaseHandler) createArtifact(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
 	inputArtifact := model.NewArtifact()
 
 	contentType, ok := r.Header["Content-Type"]
 	if !ok || !strings.Contains(contentType[0], "multipart") {
 		// Fallback to plain JSON
-		log.WithField("contentType", contentType).Debug("Multipart content type not found")
+		logger.WithField("contentType", contentType).Debug("Multipart content type not found")
 		err := json.NewDecoder(r.Body).Decode(&inputArtifact)
 		if err != nil {
 			web.Respond(w, r, http.StatusBadRequest, err)
@@ -169,7 +170,7 @@ func (h *CaseHandler) createArtifact(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		log.Debug("Successfully parsed multipart form")
+		logger.Debug("Successfully parsed multipart form")
 
 		// Try pulling an attachment file
 		file, handler, err := r.FormFile("attachment")
@@ -183,7 +184,7 @@ func (h *CaseHandler) createArtifact(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		log.Debug("Found attachment")
+		logger.Debug("Found attachment")
 		defer file.Close()
 
 		if len(inputArtifact.Value) > 0 {
@@ -202,14 +203,14 @@ func (h *CaseHandler) createArtifact(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if inputArtifact.StreamLen != int(handler.Size) {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"requestId": ctx.Value(web.ContextKeyRequestId),
 				"mimeType":  inputArtifact.MimeType,
 				"formLen":   handler.Size,
 				"copyLen":   inputArtifact.StreamLen,
 			}).Warn("Mismatch of stream size detected")
 		} else {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"requestId":   ctx.Value(web.ContextKeyRequestId),
 				"formFileLen": handler.Size,
 				"streamLen":   inputArtifact.StreamLen,
@@ -447,6 +448,8 @@ func (h *CaseHandler) getHistory(w http.ResponseWriter, r *http.Request) {
 }
 
 func (caseHandler *CaseHandler) copyArtifactStream(ctx context.Context, writer http.ResponseWriter, artifactId string) error {
+	logger := log.FromContext(ctx)
+
 	artifact, err := caseHandler.server.Casestore.GetArtifact(ctx, artifactId)
 	if err != nil {
 		return err
@@ -492,7 +495,7 @@ func (caseHandler *CaseHandler) copyArtifactStream(ctx context.Context, writer h
 
 	written, err := io.Copy(writer, content)
 	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		logger.WithError(err).WithFields(log.Fields{
 			"artifactName": artifact.Value,
 			"artifactId":   artifactId,
 		}).Error("Failed to copy artifact stream")
@@ -500,7 +503,7 @@ func (caseHandler *CaseHandler) copyArtifactStream(ctx context.Context, writer h
 		return err
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"artifactName":      artifact.Value,
 		"artifactSize":      written,
 		"artifactId":        artifactId,

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -78,6 +78,7 @@ func RegisterDetectionRoutes(srv *Server, r chi.Router, prefix string) {
 
 func (h *DetectionHandler) getDetection(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	detectId := chi.URLParam(r, "id")
 
@@ -94,14 +95,14 @@ func (h *DetectionHandler) getDetection(w http.ResponseWriter, r *http.Request) 
 
 	eng, ok := h.server.DetectionEngines[detect.Engine]
 	if !ok {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"detectionEngine":   detect.Engine,
 			"detectionPublicId": detectId,
 		}).Error("retrieved detection with unsupported engine")
 	} else {
 		err = eng.MergeAuxiliaryData(detect)
 		if err != nil {
-			log.WithError(err).WithFields(log.Fields{
+			logger.WithError(err).WithFields(log.Fields{
 				"detectionEngine":   detect.Engine,
 				"detectionPublicId": detectId,
 			}).Error("unable to merge auxiliary data into detection")
@@ -303,6 +304,7 @@ func (h *DetectionHandler) duplicateDetection(w http.ResponseWriter, r *http.Req
 
 func (h *DetectionHandler) updateDetection(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	detect := &model.Detection{}
 
@@ -386,7 +388,7 @@ func (h *DetectionHandler) updateDetection(w http.ResponseWriter, r *http.Reques
 		fixed := false
 		if detect.IsEnabled && !filterApplied {
 			var uerr error
-			log.WithError(err).WithField("detection", detect).Error("unable to sync detection; attempting to disable and resync")
+			logger.WithError(err).WithField("detection", detect).Error("unable to sync detection; attempting to disable and resync")
 
 			detect.IsEnabled = false
 			detect.Kind = ""
@@ -491,6 +493,7 @@ func (h *DetectionHandler) deleteDetection(w http.ResponseWriter, r *http.Reques
 
 func (h *DetectionHandler) bulkUpdateDetection(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	newStatus := chi.URLParam(r, "newStatus") // "enable" or "disable"
 
@@ -522,7 +525,7 @@ func (h *DetectionHandler) bulkUpdateDetection(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	logger := log.WithField("bulkUpdate", true)
+	logger = logger.WithField("bulkUpdate", true)
 
 	detects := []*model.Detection{}
 	containsCommunity := false
@@ -581,7 +584,7 @@ func (h *DetectionHandler) bulkUpdateDetection(w http.ResponseWriter, r *http.Re
 	})
 }
 
-func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *BulkOp, detects []*model.Detection, logger *log.Entry) {
+func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *BulkOp, detects []*model.Detection, logger log.Interface) {
 	totalTimeStart := time.Now()
 	errMap := map[string]string{}
 	updated := 0
@@ -595,7 +598,7 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 	defer func() {
 		totalTime := time.Since(totalTimeStart)
 
-		withStats := log.WithFields(log.Fields{
+		withStats := logger.WithFields(log.Fields{
 			"errMap":     detections.TruncateMap(errMap, 5),
 			"total":      len(detects),
 			"modified":   updated,
@@ -1036,6 +1039,8 @@ func (h *DetectionHandler) genPublicId(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *DetectionHandler) PrepareForSave(ctx context.Context, detect *model.Detection, e DetectionEngine) error {
+	logger := log.FromContext(ctx)
+
 	err := e.ExtractDetails(detect)
 	if err != nil {
 		return err
@@ -1113,7 +1118,7 @@ func (h *DetectionHandler) PrepareForSave(ctx context.Context, detect *model.Det
 
 		*detect = *old
 
-		log.Infof("existing detection %s is a community rule, only updating select fields", detect.Id)
+		logger.Infof("existing detection %s is a community rule, only updating select fields", detect.Id)
 	} else if detect.IsCommunity {
 		return errors.New("cannot update an existing non-community detection to make it a community detection")
 	}

--- a/server/detectionstore.go
+++ b/server/detectionstore.go
@@ -31,7 +31,7 @@ type Detectionstore interface {
 	DeleteComment(ctx context.Context, id string) error
 
 	DoesTemplateExist(ctx context.Context, tmpl string) (bool, error)
-	BuildBulkIndexer(ctx context.Context, logger *log.Entry) (esutil.BulkIndexer, error)
+	BuildBulkIndexer(ctx context.Context, logger log.Interface) (esutil.BulkIndexer, error)
 	ConvertObjectToDocument(ctx context.Context, kind string, obj any, auditable *model.Auditable, isEdit bool, auditDocId *string, op *string) (doc []byte, index string, err error)
 }
 

--- a/server/mock/mock_detectionstore.go
+++ b/server/mock/mock_detectionstore.go
@@ -42,7 +42,7 @@ func (m *MockDetectionstore) EXPECT() *MockDetectionstoreMockRecorder {
 }
 
 // BuildBulkIndexer mocks base method.
-func (m *MockDetectionstore) BuildBulkIndexer(arg0 context.Context, arg1 *log.Entry) (esutil.BulkIndexer, error) {
+func (m *MockDetectionstore) BuildBulkIndexer(arg0 context.Context, arg1 log.Interface) (esutil.BulkIndexer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildBulkIndexer", arg0, arg1)
 	ret0, _ := ret[0].(esutil.BulkIndexer)

--- a/server/modules/elastic/elasticcasestore.go
+++ b/server/modules/elastic/elasticcasestore.go
@@ -285,9 +285,8 @@ func (store *ElasticCasestore) prepareForSave(ctx context.Context, obj *model.Au
 	return id
 }
 
-func (store *ElasticCasestore) save(ctx context.Context, obj interface{}, kind string, id string) (*model.EventIndexResults, error) {
-	var results *model.EventIndexResults
-	var err error
+func (store *ElasticCasestore) save(ctx context.Context, obj interface{}, kind string, id string) (results *model.EventIndexResults, err error) {
+	logger := log.FromContext(ctx)
 
 	if err = store.server.CheckAuthorized(ctx, "write", "cases"); err == nil {
 		document := ConvertObjectToDocumentMap(kind, obj, store.schemaPrefix)
@@ -302,7 +301,7 @@ func (store *ElasticCasestore) save(ctx context.Context, obj interface{}, kind s
 			}
 			_, err = store.server.Eventstore.Index(ctx, store.auditIndex, document, "")
 			if err != nil {
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"documentId": results.DocumentId,
 					"kind":       kind,
 				}).WithError(err).Error("Object indexed successfully however audit record failed to index")
@@ -313,8 +312,8 @@ func (store *ElasticCasestore) save(ctx context.Context, obj interface{}, kind s
 	return results, err
 }
 
-func (store *ElasticCasestore) delete(ctx context.Context, obj interface{}, kind string, id string) error {
-	var err error
+func (store *ElasticCasestore) delete(ctx context.Context, obj interface{}, kind string, id string) (err error) {
+	logger := log.FromContext(ctx)
 
 	if err = store.server.CheckAuthorized(ctx, "write", "cases"); err == nil {
 		err = store.server.Eventstore.Delete(ctx, store.index, id)
@@ -325,7 +324,7 @@ func (store *ElasticCasestore) delete(ctx context.Context, obj interface{}, kind
 			document[store.schemaPrefix+"operation"] = "delete"
 			_, err = store.server.Eventstore.Index(ctx, store.auditIndex, document, "")
 			if err != nil {
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"documentId": id,
 					"kind":       kind,
 				}).WithError(err).Error("Object deleted successfully however audit record failed to index")
@@ -348,9 +347,8 @@ func (store *ElasticCasestore) get(ctx context.Context, id string, kind string) 
 	return nil, err
 }
 
-func (store *ElasticCasestore) getAll(ctx context.Context, query string, max int) ([]interface{}, error) {
-	var err error
-	var objects []interface{}
+func (store *ElasticCasestore) getAll(ctx context.Context, query string, max int) (objects []interface{}, err error) {
+	logger := log.FromContext(ctx)
 
 	if err = store.server.CheckAuthorized(ctx, "read", "cases"); err == nil {
 		criteria := model.NewEventSearchCriteria()
@@ -377,7 +375,7 @@ func (store *ElasticCasestore) getAll(ctx context.Context, query string, max int
 					if err == nil {
 						objects = append(objects, obj)
 					} else {
-						log.WithField("event", event).WithError(err).Error("Unable to convert case object")
+						logger.WithField("event", event).WithError(err).Error("Unable to convert case object")
 					}
 				}
 			}
@@ -789,12 +787,14 @@ func (store *ElasticCasestore) UpdateArtifact(ctx context.Context, artifact *mod
 }
 
 func (store *ElasticCasestore) DeleteArtifact(ctx context.Context, id string) error {
+	logger := log.FromContext(ctx)
+
 	artifact, err := store.GetArtifact(ctx, id)
 	if err == nil {
 		if len(artifact.StreamId) > 0 {
 			err = store.DeleteArtifactStream(ctx, artifact.StreamId)
 			if err != nil {
-				log.WithError(err).WithFields(log.Fields{
+				logger.WithError(err).WithFields(log.Fields{
 					"artifactStreamId": artifact.StreamId,
 					"artifactId":       artifact.Id,
 				}).Error("Unable to delete artifact stream; proceeding with artifact deletion anyway")
@@ -811,7 +811,7 @@ func (store *ElasticCasestore) DeleteArtifact(ctx context.Context, id string) er
 			for _, job := range jobs {
 				job, err := store.server.Datastore.DeleteJob(ctx, job.Id)
 				if err != nil {
-					log.WithError(err).WithFields(log.Fields{
+					logger.WithError(err).WithFields(log.Fields{
 						"artifactId": artifact.Id,
 						"jobId":      job.Id,
 					}).Error("Unable to delete analyze job; continuing")
@@ -869,6 +869,8 @@ func (store *ElasticCasestore) DeleteArtifactStream(ctx context.Context, id stri
 }
 
 func (store *ElasticCasestore) ExtractCommonObservables(ctx context.Context, event *model.RelatedEvent) error {
+	logger := log.FromContext(ctx)
+
 	existingArtifacts, _ := store.GetArtifacts(ctx, event.CaseId, "evidence", "")
 	existingValueMap := make(map[string]bool)
 	for _, artifact := range existingArtifacts {
@@ -889,7 +891,7 @@ func (store *ElasticCasestore) ExtractCommonObservables(ctx context.Context, eve
 				artifact.GroupType = "evidence"
 				_, err := store.CreateArtifact(ctx, artifact)
 				if err != nil {
-					log.WithFields(log.Fields{
+					logger.WithFields(log.Fields{
 						"key":          key,
 						"caseId":       event.CaseId,
 						"artifactType": artifact.ArtifactType,

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -184,6 +184,8 @@ func (store *ElasticDetectionstore) validateDetection(detect *model.Detection) e
 }
 
 func (store *ElasticDetectionstore) save(ctx context.Context, obj interface{}, kind string, id string) (*model.EventIndexResults, error) {
+	logger := log.FromContext(ctx)
+
 	if err := store.server.CheckAuthorized(ctx, "write", "detections"); err != nil {
 		return nil, err
 	}
@@ -205,7 +207,7 @@ func (store *ElasticDetectionstore) save(ctx context.Context, obj interface{}, k
 
 		_, err = store.Index(ctx, store.auditIndex, document, "")
 		if err != nil {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"documentId":   results.DocumentId,
 				"documentKind": kind,
 			}).WithError(err).Error("Object indexed successfully however audit record failed to index")
@@ -216,21 +218,23 @@ func (store *ElasticDetectionstore) save(ctx context.Context, obj interface{}, k
 }
 
 func (store *ElasticDetectionstore) Index(ctx context.Context, index string, document map[string]interface{}, id string) (*model.EventIndexResults, error) {
+	logger := log.FromContext(ctx)
+
 	results := model.NewEventIndexResults()
 
 	request, err := convertToElasticIndexRequest(document)
 	if err == nil {
 		var response string
 
-		log.Debug("Sending index request to primary Elasticsearch client")
+		logger.Debug("Sending index request to primary Elasticsearch client")
 		response, err = store.indexDocument(ctx, store.disableCrossClusterIndex(index), request, id)
 		if err == nil {
 			err = convertFromElasticIndexResults(response, results)
 			if err != nil {
-				log.WithError(err).Error("Encountered error while converting document index results")
+				logger.WithError(err).Error("Encountered error while converting document index results")
 			}
 		} else {
-			log.WithError(err).Error("Encountered error while indexing document into elasticsearch")
+			logger.WithError(err).Error("Encountered error while indexing document into elasticsearch")
 		}
 	}
 
@@ -238,12 +242,14 @@ func (store *ElasticDetectionstore) Index(ctx context.Context, index string, doc
 }
 
 func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index string, obj interface{}, kind string, id string) (string, error) {
+	logger := log.FromContext(ctx)
+
 	err := store.server.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
 		return "", err
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"deleteIndex": index,
 		"documentId":  id,
 		"requestId":   ctx.Value(web.ContextKeyRequestId),
@@ -252,7 +258,7 @@ func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index st
 	res, err := store.esClient.Delete(transformIndex(index), id, store.esClient.Delete.WithContext(ctx))
 
 	if err != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"deleteIndex": index,
 			"documentId":  id,
 			"requestId":   ctx.Value(web.ContextKeyRequestId),
@@ -267,7 +273,7 @@ func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index st
 	document[store.schemaPrefix+"operation"] = "delete"
 	err = store.audit(ctx, document, id)
 	if err != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"documentId":    id,
 			"detectionKind": kind,
 		}).WithError(err).Error("Object deleted successfully however audit record failed to index")
@@ -275,7 +281,7 @@ func (store *ElasticDetectionstore) deleteDocument(ctx context.Context, index st
 
 	json, err := readJsonFromResponse(res)
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"deleteIndex": index,
 		"documentId":  id,
 		"response":    store.truncate(json),
@@ -300,6 +306,8 @@ func (store *ElasticDetectionstore) get(ctx context.Context, id string, kind str
 }
 
 func (store *ElasticDetectionstore) getAll(ctx context.Context, query string, max int) ([]interface{}, error) {
+	logger := log.FromContext(ctx)
+
 	criteria := model.NewEventSearchCriteria()
 	format := "2006-01-02 3:04:05 PM"
 
@@ -329,7 +337,7 @@ func (store *ElasticDetectionstore) getAll(ctx context.Context, query string, ma
 	for _, event := range results.Events {
 		obj, err := convertElasticEventToObject(event, store.schemaPrefix)
 		if err != nil {
-			log.WithField("returnedEvent", event).WithError(err).Error("Unable to convert detection object")
+			logger.WithField("returnedEvent", event).WithError(err).Error("Unable to convert detection object")
 			continue
 		}
 
@@ -339,10 +347,10 @@ func (store *ElasticDetectionstore) getAll(ctx context.Context, query string, ma
 	return objects, err
 }
 
-func (store *ElasticDetectionstore) Query(ctx context.Context, query string, max int) ([]interface{}, error) {
-	var objects []interface{}
+func (store *ElasticDetectionstore) Query(ctx context.Context, query string, max int) (objects []interface{}, err error) {
+	logger := log.FromContext(ctx)
 
-	err := store.server.CheckAuthorized(ctx, "read", "detections")
+	err = store.server.CheckAuthorized(ctx, "read", "detections")
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +411,7 @@ func (store *ElasticDetectionstore) Query(ctx context.Context, query string, max
 		if err == nil {
 			objects = append(objects, obj)
 		} else {
-			log.WithField("returnedEvent", event).WithError(err).Error("Unable to convert case object")
+			logger.WithField("returnedEvent", event).WithError(err).Error("Unable to convert case object")
 		}
 	}
 
@@ -540,6 +548,8 @@ func (store *ElasticDetectionstore) UpdateDetection(ctx context.Context, detect 
 }
 
 func (store *ElasticDetectionstore) DeleteDetection(ctx context.Context, id string) (*model.Detection, error) {
+	logger := log.FromContext(ctx)
+
 	detect, err := store.GetDetection(ctx, id)
 	if err != nil {
 		return nil, err
@@ -548,7 +558,7 @@ func (store *ElasticDetectionstore) DeleteDetection(ctx context.Context, id stri
 	_, err = store.deleteDocument(ctx, store.disableCrossClusterIndex(store.index), detect, "detection", id)
 
 	if err == nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"ruleId":       id,
 			"rulePublicId": detect.PublicID,
 			"ruleName":     detect.Title,
@@ -589,12 +599,14 @@ func (store *ElasticDetectionstore) GetDetectionHistory(ctx context.Context, det
 }
 
 func (store *ElasticDetectionstore) audit(ctx context.Context, document map[string]interface{}, id string) error {
+	logger := log.FromContext(ctx)
+
 	request, err := convertToElasticIndexRequest(document)
 	if err == nil {
-		log.Debug("Sending index request to primary Elasticsearch client")
+		logger.Debug("Sending index request to primary Elasticsearch client")
 		_, err = store.indexDocument(ctx, store.disableCrossClusterIndex(store.auditIndex), request, id)
 		if err != nil {
-			log.WithError(err).Error("Encountered error while indexing document into elasticsearch")
+			logger.WithError(err).Error("Encountered error while indexing document into elasticsearch")
 		}
 	}
 
@@ -602,12 +614,14 @@ func (store *ElasticDetectionstore) audit(ctx context.Context, document map[stri
 }
 
 func (store *ElasticDetectionstore) indexDocument(ctx context.Context, index string, document string, id string) (string, error) {
+	logger := log.FromContext(ctx)
+
 	err := store.server.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
 		return "", err
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"documentIndex": index,
 		"documentId":    id,
 		"document":      store.truncate(document),
@@ -622,16 +636,18 @@ func (store *ElasticDetectionstore) indexDocument(ctx context.Context, index str
 	)
 
 	if err != nil {
-		log.WithError(err).Error("Unable to index document into Elasticsearch")
+		logger.WithError(err).Error("Unable to index document into Elasticsearch")
 		return "", err
 	}
 	defer res.Body.Close()
+
 	json, err := readJsonFromResponse(res)
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"response":  store.truncate(json),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Debug("Index new document finished")
+
 	return json, err
 }
 
@@ -780,7 +796,7 @@ func (store *ElasticDetectionstore) DeleteComment(ctx context.Context, id string
 	return err
 }
 
-func (store *ElasticDetectionstore) BuildBulkIndexer(ctx context.Context, logger *log.Entry) (esutil.BulkIndexer, error) {
+func (store *ElasticDetectionstore) BuildBulkIndexer(ctx context.Context, logger log.Interface) (esutil.BulkIndexer, error) {
 	bulk, err := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
 		Client:     store.esClient,
 		Refresh:    "wait_for",

--- a/server/modules/elastic/elasticeventstore.go
+++ b/server/modules/elastic/elasticeventstore.go
@@ -392,9 +392,10 @@ func (store *ElasticEventstore) disableCrossClusterIndexing(indexes []string) []
 	return indexes
 }
 
-func (store *ElasticEventstore) Update(ctx context.Context, criteria *model.EventUpdateCriteria) (*model.EventUpdateResults, error) {
-	var err error
-	results := model.NewEventUpdateResults()
+func (store *ElasticEventstore) Update(ctx context.Context, criteria *model.EventUpdateCriteria) (results *model.EventUpdateResults, err error) {
+	logger := log.FromContext(ctx)
+
+	results = model.NewEventUpdateResults()
 	if err = store.server.CheckAuthorized(ctx, "write", "events"); err == nil {
 		store.refreshCache(ctx)
 
@@ -405,7 +406,7 @@ func (store *ElasticEventstore) Update(ctx context.Context, criteria *model.Even
 			var response string
 
 			for idx, client := range store.esAllClients {
-				log.WithField("clientHost", store.hostUrls[idx]).Debug("Sending request to client")
+				logger.WithField("clientHost", store.hostUrls[idx]).Debug("Sending request to client")
 				response, err = store.updateDocuments(ctx, client, query, store.disableCrossClusterIndexing(strings.Split(store.index, ",")), !criteria.Asynchronous)
 				if err == nil {
 					if !criteria.Asynchronous {
@@ -414,12 +415,12 @@ func (store *ElasticEventstore) Update(ctx context.Context, criteria *model.Even
 						if err == nil {
 							results.AddEventUpdateResults(currentResults)
 						} else {
-							log.WithError(err).WithField("clientHost", store.hostUrls[idx]).Error("Encountered error while updating elasticsearch")
+							logger.WithError(err).WithField("clientHost", store.hostUrls[idx]).Error("Encountered error while updating elasticsearch")
 							results.Errors = append(results.Errors, err.Error())
 						}
 					}
 				} else {
-					log.WithError(err).WithField("clientHost", store.hostUrls[idx]).Error("Encountered error while updating elasticsearch")
+					logger.WithError(err).WithField("clientHost", store.hostUrls[idx]).Error("Encountered error while updating elasticsearch")
 					results.Errors = append(results.Errors, err.Error())
 				}
 			}
@@ -436,9 +437,10 @@ func (store *ElasticEventstore) Update(ctx context.Context, criteria *model.Even
 	return results, err
 }
 
-func (store *ElasticEventstore) Index(ctx context.Context, index string, document map[string]interface{}, id string) (*model.EventIndexResults, error) {
-	var err error
-	results := model.NewEventIndexResults()
+func (store *ElasticEventstore) Index(ctx context.Context, index string, document map[string]interface{}, id string) (results *model.EventIndexResults, err error) {
+	logger := log.FromContext(ctx)
+
+	results = model.NewEventIndexResults()
 	if err = store.server.CheckAuthorized(ctx, "write", "events"); err == nil {
 		store.refreshCache(ctx)
 
@@ -447,35 +449,36 @@ func (store *ElasticEventstore) Index(ctx context.Context, index string, documen
 		if err == nil {
 			var response string
 
-			log.Debug("Sending index request to primary Elasticsearch client")
+			logger.Debug("Sending index request to primary Elasticsearch client")
 			response, err = store.indexDocument(ctx, store.disableCrossClusterIndex(index), request, id)
 			if err == nil {
 				err = convertFromElasticIndexResults(response, results)
 				if err != nil {
-					log.WithError(err).Error("Encountered error while converting document index results")
+					logger.WithError(err).Error("Encountered error while converting document index results")
 				}
 			} else {
-				log.WithError(err).Error("Encountered error while indexing document into elasticsearch")
+				logger.WithError(err).Error("Encountered error while indexing document into elasticsearch")
 			}
 		}
 	}
 	return results, err
 }
 
-func (store *ElasticEventstore) Delete(ctx context.Context, index string, id string) error {
-	var err error
+func (store *ElasticEventstore) Delete(ctx context.Context, index string, id string) (err error) {
+	logger := log.FromContext(ctx)
+
 	results := model.NewEventIndexResults()
 	if err = store.server.CheckAuthorized(ctx, "write", "events"); err == nil {
 		var response string
-		log.Debug("Sending delete request to primary Elasticsearch client")
+		logger.Debug("Sending delete request to primary Elasticsearch client")
 		response, err = store.deleteDocument(ctx, store.disableCrossClusterIndex(index), id)
 		if err == nil {
 			err = convertFromElasticIndexResults(response, results)
 			if err != nil {
-				log.WithError(err).Error("Encountered error while converting document index results")
+				logger.WithError(err).Error("Encountered error while converting document index results")
 			}
 		} else {
-			log.WithError(err).Error("Encountered error while deleting document from elasticsearch")
+			logger.WithError(err).Error("Encountered error while deleting document from elasticsearch")
 		}
 	}
 	return err
@@ -514,7 +517,9 @@ func readJsonFromResponse(res *esapi.Response) (string, error) {
 }
 
 func (store *ElasticEventstore) indexSearch(ctx context.Context, query string, indexes []string) (string, error) {
-	log.WithFields(log.Fields{
+	logger := log.FromContext(ctx)
+
+	logger.WithFields(log.Fields{
 		"query":     store.truncate(query),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Info("Searching Elasticsearch")
@@ -533,15 +538,19 @@ func (store *ElasticEventstore) indexSearch(ctx context.Context, query string, i
 		defer res.Body.Close()
 		json, err = readJsonFromResponse(res)
 	}
-	log.WithFields(log.Fields{
+
+	logger.WithFields(log.Fields{
 		"response":  store.truncate(json),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Debug("Search finished")
+
 	return json, err
 }
 
 func (store *ElasticEventstore) indexDocument(ctx context.Context, index string, document string, id string) (string, error) {
-	log.WithFields(log.Fields{
+	logger := log.FromContext(ctx)
+
+	logger.WithFields(log.Fields{
 		"index":     index,
 		"id":        id,
 		"document":  store.truncate(document),
@@ -556,21 +565,25 @@ func (store *ElasticEventstore) indexDocument(ctx context.Context, index string,
 	)
 
 	if err != nil {
-		log.WithError(err).Error("Unable to index document into Elasticsearch")
+		logger.WithError(err).Error("Unable to index document into Elasticsearch")
 		return "", err
 	}
 	defer res.Body.Close()
+
 	json, err := readJsonFromResponse(res)
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"response":  store.truncate(json),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Debug("Index new document finished")
+
 	return json, err
 }
 
 func (store *ElasticEventstore) deleteDocument(ctx context.Context, index string, id string) (string, error) {
-	log.WithFields(log.Fields{
+	logger := log.FromContext(ctx)
+
+	logger.WithFields(log.Fields{
 		"index":     index,
 		"id":        id,
 		"requestId": ctx.Value(web.ContextKeyRequestId),
@@ -579,7 +592,7 @@ func (store *ElasticEventstore) deleteDocument(ctx context.Context, index string
 	res, err := store.esClient.Delete(transformIndex(index), id, store.esClient.Delete.WithContext(ctx))
 
 	if err != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"index":     index,
 			"id":        id,
 			"requestId": ctx.Value(web.ContextKeyRequestId),
@@ -587,19 +600,23 @@ func (store *ElasticEventstore) deleteDocument(ctx context.Context, index string
 		return "", err
 	}
 	defer res.Body.Close()
+
 	json, err := readJsonFromResponse(res)
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"index":     index,
 		"id":        id,
 		"response":  store.truncate(json),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Debug("Delete document finished")
+
 	return json, err
 }
 
 func (store *ElasticEventstore) updateDocuments(ctx context.Context, client *elasticsearch.Client, query string, indexes []string, waitForCompletion bool) (string, error) {
-	log.WithFields(log.Fields{
+	logger := log.FromContext(ctx)
+
+	logger.WithFields(log.Fields{
 		"query":     store.truncate(query),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Debug("Updating documents in Elasticsearch")
@@ -617,10 +634,12 @@ func (store *ElasticEventstore) updateDocuments(ctx context.Context, client *ela
 		defer res.Body.Close()
 		json, err = readJsonFromResponse(res)
 	}
-	log.WithFields(log.Fields{
+
+	logger.WithFields(log.Fields{
 		"response":  store.truncate(json),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Debug("Update finished")
+
 	return json, err
 }
 
@@ -636,7 +655,9 @@ func (store *ElasticEventstore) refreshCache(ctx context.Context) {
 }
 
 func (store *ElasticEventstore) refreshCacheFromFieldCaps(ctx context.Context) error {
-	log.Info("Fetching Field Capabilities from Elasticsearch")
+	logger := log.FromContext(ctx)
+
+	logger.Info("Fetching Field Capabilities from Elasticsearch")
 	indexes := strings.Split(store.index, ",")
 	var json string
 	res, err := store.esClient.FieldCaps(
@@ -648,11 +669,12 @@ func (store *ElasticEventstore) refreshCacheFromFieldCaps(ctx context.Context) e
 	if err == nil {
 		defer res.Body.Close()
 		json, err = readJsonFromResponse(res)
-		log.WithFields(log.Fields{"response": store.truncate(json)}).Debug("Fetch finished")
+		logger.WithFields(log.Fields{"response": store.truncate(json)}).Debug("Fetch finished")
 		store.cacheFieldsFromJson(json)
 	} else {
-		log.WithError(err).Error("Failed to refresh cache from index patterns")
+		logger.WithError(err).Error("Failed to refresh cache from index patterns")
 	}
+
 	return err
 }
 
@@ -697,7 +719,9 @@ func cacheFields(fieldDefs map[string]*FieldDefinition, name gjson.Result, detai
 }
 
 func (store *ElasticEventstore) clusterState(ctx context.Context) (string, error) {
-	log.WithField("cacheMs", store.cacheMs).Debug("Refreshing field definitions")
+	logger := log.FromContext(ctx)
+
+	logger.WithField("cacheMs", store.cacheMs).Debug("Refreshing field definitions")
 	indexes := strings.Split(store.index, ",")
 	var json string
 	res, err := store.esClient.Cluster.State(
@@ -721,7 +745,9 @@ func (store *ElasticEventstore) clusterState(ctx context.Context) (string, error
 			err = errors.New(errorType + ": " + errorReason + " -> " + errorDetails)
 		}
 	}
-	log.WithFields(log.Fields{"response": store.truncate(json)}).Debug("Refresh Finished")
+
+	logger.WithFields(log.Fields{"response": store.truncate(json)}).Debug("Refresh Finished")
+
 	return json, err
 }
 
@@ -763,6 +789,8 @@ func (store *ElasticEventstore) buildRangeFilter(timestampStr string) (string, t
     to the original ES ID record and use the IP/port details as the filter.
 */
 func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idField string, idValue string, timestampStr string, job *model.Job) error {
+	logger := log.FromContext(ctx)
+
 	rangeFilter, timestamp := store.buildRangeFilter(timestampStr)
 
 	query := fmt.Sprintf(`
@@ -779,19 +807,19 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 	var outputSensorId string
 	filter := model.NewFilter()
 	json, err := store.luceneSearch(ctx, query)
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"query":     store.truncate(query),
 		"response":  store.truncate(json),
 		"requestId": ctx.Value(web.ContextKeyRequestId),
 	}).Debug("Elasticsearch primary search finished")
 	if err != nil {
-		log.WithField("query", store.truncate(query)).WithError(err).Error("Unable to lookup initial document record")
+		logger.WithField("query", store.truncate(query)).WithError(err).Error("Unable to lookup initial document record")
 		return err
 	}
 
 	hits := gjson.Get(json, "hits.total.value").Int()
 	if hits == 0 {
-		log.WithField("query", store.truncate(query)).Error("Pivoted document record was not found")
+		logger.WithField("query", store.truncate(query)).Error("Pivoted document record was not found")
 		return errors.New("Unable to locate document record")
 	}
 
@@ -806,7 +834,7 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 		// can do in this situation is respond with the tunnel PCAP data, which could be excessive.
 		tunnelParent := gjson.Get(json, "hits.hits.0._source.log.id.tunnel_parents").String()
 		if len(tunnelParent) > 0 {
-			log.Info("Document is inside of a tunnel; attempting to lookup tunnel connection log")
+			logger.Info("Document is inside of a tunnel; attempting to lookup tunnel connection log")
 			if tunnelParent[0] == '[' {
 				tunnelParent = gjson.Get(json, "hits.hits.0._source.log.id.tunnel_parents.0").String()
 			}
@@ -822,17 +850,17 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 		}`, tunnelParent, rangeFilter)
 
 			json, err = store.luceneSearch(ctx, query)
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"query":    store.truncate(query),
 				"response": store.truncate(json),
 			}).Debug("Elasticsearch tunnel search finished")
 			if err != nil {
-				log.WithField("query", store.truncate(query)).WithError(err).Error("Unable to lookup tunnel record")
+				logger.WithField("query", store.truncate(query)).WithError(err).Error("Unable to lookup tunnel record")
 				return err
 			}
 			hits := gjson.Get(json, "hits.total.value").Int()
 			if hits == 0 {
-				log.WithField("query", store.truncate(query)).Error("Tunnel record was not found")
+				logger.WithField("query", store.truncate(query)).Error("Tunnel record was not found")
 				return errors.New("Unable to locate encapsulating tunnel record")
 			}
 		}
@@ -864,14 +892,14 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 				query = fmt.Sprintf(`{"query":{"bool":{"must":[{"query_string":{"query":"event.dataset:zeek.file AND %s","analyze_wildcard":true}}%s]}}}`,
 					zeekFileQuery, rangeFilter)
 				json, err = store.luceneSearch(ctx, query)
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"query":     store.truncate(query),
 					"response":  store.truncate(json),
 					"requestId": ctx.Value(web.ContextKeyRequestId),
 				}).Debug("Elasticsearch Zeek File search finished")
 
 				if err != nil {
-					log.WithFields(log.Fields{
+					logger.WithFields(log.Fields{
 						"query":         store.truncate(query),
 						"zeekFileQuery": store.truncate(zeekFileQuery),
 						"requestId":     ctx.Value(web.ContextKeyRequestId),
@@ -881,7 +909,7 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 
 				hits = gjson.Get(json, "hits.total.value").Int()
 				if hits == 0 {
-					log.WithFields(log.Fields{
+					logger.WithFields(log.Fields{
 						"query":         store.truncate(query),
 						"zeekFileQuery": store.truncate(zeekFileQuery),
 						"requestId":     ctx.Value(web.ContextKeyRequestId),
@@ -893,7 +921,7 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 			}
 
 			if len(uid) == 0 {
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"query":         store.truncate(query),
 					"zeekFileQuery": store.truncate(zeekFileQuery),
 					"requestId":     ctx.Value(web.ContextKeyRequestId),
@@ -906,14 +934,14 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 		query = fmt.Sprintf(`{"query":{"bool":{"must":[{"query_string":{"query":"event.module:zeek AND %s","analyze_wildcard":true}}%s]}}}`,
 			uid, rangeFilter)
 		json, err = store.luceneSearch(ctx, query)
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"query":     store.truncate(query),
 			"response":  store.truncate(json),
 			"requestId": ctx.Value(web.ContextKeyRequestId),
 		}).Debug("Elasticsearch Zeek search finished")
 
 		if err != nil {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"query":     store.truncate(query),
 				"uid":       uid,
 				"requestId": ctx.Value(web.ContextKeyRequestId),
@@ -923,7 +951,7 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 
 		hits = gjson.Get(json, "hits.total.value").Int()
 		if hits == 0 {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"query":     store.truncate(query),
 				"uid":       uid,
 				"requestId": ctx.Value(web.ContextKeyRequestId),
@@ -969,14 +997,14 @@ func (store *ElasticEventstore) PopulateJobFromDocQuery(ctx context.Context, idF
 			}
 		}
 
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"sensorId":  outputSensorId,
 			"requestId": ctx.Value(web.ContextKeyRequestId),
 		}).Info("Obtained output parameters")
 	}
 
 	if len(filter.SrcIp) == 0 || len(filter.DstIp) == 0 || ((filter.SrcPort == 0 || filter.DstPort == 0) && filter.Protocol != model.PROTOCOL_ICMP) {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"query":     store.truncate(query),
 			"uid":       uid,
 			"requestId": ctx.Value(web.ContextKeyRequestId),
@@ -1030,12 +1058,12 @@ func (store *ElasticEventstore) addUpdateScripts(updateCriteria *model.EventUpda
 	}
 }
 
-func (store *ElasticEventstore) Acknowledge(ctx context.Context, ackCriteria *model.EventAckCriteria) (*model.EventUpdateResults, error) {
-	var results *model.EventUpdateResults
-	var err error
+func (store *ElasticEventstore) Acknowledge(ctx context.Context, ackCriteria *model.EventAckCriteria) (results *model.EventUpdateResults, err error) {
+	logger := log.FromContext(ctx)
+
 	if len(ackCriteria.EventFilter) > 0 {
 		if err = store.server.CheckAuthorized(ctx, "ack", "events"); err == nil {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"searchFilter": ackCriteria.SearchFilter,
 				"eventFilter":  ackCriteria.EventFilter,
 				"escalate":     ackCriteria.Escalate,
@@ -1067,7 +1095,7 @@ func (store *ElasticEventstore) Acknowledge(ctx context.Context, ackCriteria *mo
 					valueStr := fmt.Sprintf("%v", value)
 					searchSegment.AddFilter(mapElasticField(store.fieldDefs, key), valueStr, model.IsScalar(value), true, false)
 				} else if int(value.(float64)) > store.asyncThreshold {
-					log.WithFields(log.Fields{
+					logger.WithFields(log.Fields{
 						key:         value,
 						"threshold": store.asyncThreshold,
 						"requestId": ctx.Value(web.ContextKeyRequestId),

--- a/server/modules/elastic/template.go
+++ b/server/modules/elastic/template.go
@@ -15,23 +15,26 @@ import (
 )
 
 func (store *ElasticCasestore) applyTemplate(ctx context.Context, socCase *model.Case) *model.Case {
+	logger := log.FromContext(ctx)
+
 	var err error
 	if socCase.Template != "" {
 		err = store.validateId(socCase.Template, "templateId")
 		if err == nil {
 			var templateCase *model.Case
-			log.WithField("templateId", socCase.Template).Info("Creating case from template case")
+			logger.WithField("templateId", socCase.Template).Info("Creating case from template case")
 			templateCase, err = store.GetCase(ctx, socCase.Template)
 			if err == nil {
 				templateCase.Title = strings.Replace(templateCase.Title, "{}", socCase.Title, 1)
 				templateCase.Description = strings.Replace(templateCase.Description, "{}", socCase.Description, 1)
 				socCase = templateCase
 			} else {
-				log.WithField("templateId", socCase.Template).Warn("Template case ID not found; Creating blank case instead")
+				logger.WithField("templateId", socCase.Template).Warn("Template case ID not found; Creating blank case instead")
 			}
 		} else {
-			log.WithField("templateId", socCase.Template).Warn("Invalid template case ID; Creating blank case instead")
+			logger.WithField("templateId", socCase.Template).Warn("Invalid template case ID; Creating blank case instead")
 		}
 	}
+
 	return socCase
 }

--- a/server/modules/filedatastore/filedatastoreimpl.go
+++ b/server/modules/filedatastore/filedatastoreimpl.go
@@ -92,9 +92,9 @@ func (datastore *FileDatastoreImpl) addNode(node *model.Node) *model.Node {
 	return node
 }
 
-func (datastore *FileDatastoreImpl) UpdateNode(ctx context.Context, newNode *model.Node) (*model.Node, error) {
-	var node *model.Node
-	var err error
+func (datastore *FileDatastoreImpl) UpdateNode(ctx context.Context, newNode *model.Node) (node *model.Node, err error) {
+	logger := log.FromContext(ctx)
+
 	if len(newNode.Id) > 0 {
 		if err = datastore.server.CheckAuthorized(ctx, "write", "nodes"); err == nil {
 			datastore.lock.Lock()
@@ -124,11 +124,12 @@ func (datastore *FileDatastoreImpl) UpdateNode(ctx context.Context, newNode *mod
 			node.UptimeSeconds = int(node.UpdateTime.Sub(node.OnlineTime).Seconds())
 		}
 	} else {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"description": newNode.Description,
 			"requestId":   ctx.Value(web.ContextKeyRequestId),
 		}).Info("Not adding node with missing id")
 	}
+
 	return node, err
 }
 
@@ -153,12 +154,16 @@ func (datastore *FileDatastoreImpl) GetNextJob(ctx context.Context, nodeId strin
 }
 
 func (datastore *FileDatastoreImpl) CreateJob(ctx context.Context) *model.Job {
+	logger := log.FromContext(ctx)
+
 	datastore.lock.Lock()
 	defer datastore.lock.Unlock()
+
 	job := model.NewJob()
 	job.Id = datastore.nextJobId
 	datastore.incrementJobId(job.Id)
-	log.WithFields(log.Fields{
+
+	logger.WithFields(log.Fields{
 		"id":        job.Id,
 		"nextJobId": datastore.nextJobId,
 	}).Debug("Created job")
@@ -309,6 +314,8 @@ func (datastore *FileDatastoreImpl) getJobById(jobId int) *model.Job {
 }
 
 func (datastore *FileDatastoreImpl) DeleteJob(ctx context.Context, jobId int) (*model.Job, error) {
+	logger := log.FromContext(ctx)
+
 	var err error
 	job := datastore.getJobById(jobId)
 	if job != nil {
@@ -326,7 +333,7 @@ func (datastore *FileDatastoreImpl) DeleteJob(ctx context.Context, jobId int) (*
 				filename = fmt.Sprintf("%d.bin.unwrapped", job.Id)
 				os.Remove(filepath.Join(folder, filename))
 
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"id":       job.Id,
 					"folder":   folder,
 					"filename": filename,
@@ -421,16 +428,16 @@ func (datastore *FileDatastoreImpl) loadJobs() error {
 	return err
 }
 
-func (datastore *FileDatastoreImpl) GetPackets(ctx context.Context, jobId int, offset int, count int, unwrap bool) ([]*model.Packet, error) {
-	var packets []*model.Packet
-	var err error
+func (datastore *FileDatastoreImpl) GetPackets(ctx context.Context, jobId int, offset int, count int, unwrap bool) (packets []*model.Packet, err error) {
+	logger := log.FromContext(ctx)
+
 	job := datastore.GetJob(ctx, jobId)
 	if job != nil {
 		if datastore.jobIsAllowed(ctx, job, "read") {
 			if job.Status == model.JobStatusCompleted {
 				packets, err = packet.ParsePcap(datastore.getStreamFilename(job), offset, count, unwrap)
 				if err != nil {
-					log.WithError(err).WithField("jobId", job.Id).Warn("Failed to parse captured packets")
+					logger.WithError(err).WithField("jobId", job.Id).Warn("Failed to parse captured packets")
 					err = nil
 				}
 			}
@@ -444,8 +451,9 @@ func (datastore *FileDatastoreImpl) GetPackets(ctx context.Context, jobId int, o
 	return packets, err
 }
 
-func (datastore *FileDatastoreImpl) SavePacketStream(ctx context.Context, jobId int, reader io.ReadCloser) error {
-	var err error
+func (datastore *FileDatastoreImpl) SavePacketStream(ctx context.Context, jobId int, reader io.ReadCloser) (err error) {
+	logger := log.FromContext(ctx)
+
 	if err = datastore.server.CheckAuthorized(ctx, "process", "jobs"); err == nil {
 		job := datastore.getJobById(jobId)
 		if job != nil {
@@ -457,9 +465,9 @@ func (datastore *FileDatastoreImpl) SavePacketStream(ctx context.Context, jobId 
 					count, err = io.Copy(file, reader)
 				}
 				if err != nil {
-					log.WithError(err).WithField("jobId", jobId).Error("Failed to write packet stream to file")
+					logger.WithError(err).WithField("jobId", jobId).Error("Failed to write packet stream to file")
 				} else {
-					log.WithFields(log.Fields{
+					logger.WithFields(log.Fields{
 						"bytes": count,
 						"jobId": jobId,
 					}).Info("Saved packet stream to file")
@@ -474,11 +482,9 @@ func (datastore *FileDatastoreImpl) SavePacketStream(ctx context.Context, jobId 
 	return err
 }
 
-func (datastore *FileDatastoreImpl) GetPacketStream(ctx context.Context, jobId int, unwrap bool) (io.ReadCloser, string, int64, error) {
-	var reader io.ReadCloser
-	var filename string
-	var length int64
-	var err error
+func (datastore *FileDatastoreImpl) GetPacketStream(ctx context.Context, jobId int, unwrap bool) (reader io.ReadCloser, filename string, length int64, err error) {
+	logger := log.FromContext(ctx)
+
 	job := datastore.GetJob(ctx, jobId)
 	if job != nil {
 		if datastore.jobIsAllowed(ctx, job, "read") {
@@ -487,17 +493,17 @@ func (datastore *FileDatastoreImpl) GetPacketStream(ctx context.Context, jobId i
 				var file *os.File
 				file, err = os.Open(datastore.getModifiedStreamFilename(job, unwrap))
 				if err != nil {
-					log.WithError(err).WithField("jobId", job.Id).Error("Failed to open packet stream")
+					logger.WithError(err).WithField("jobId", job.Id).Error("Failed to open packet stream")
 				} else {
 					reader = file
 					info, err := file.Stat()
 					length = info.Size()
-					log.WithFields(log.Fields{
+					logger.WithFields(log.Fields{
 						"streamSize":     length,
 						"streamFilename": info.Name(),
 					}).Info("Streaming file")
 					if err != nil {
-						log.WithError(err).WithField("jobId", job.Id).Error("Failed to open file stats")
+						logger.WithError(err).WithField("jobId", job.Id).Error("Failed to open file stats")
 					}
 				}
 			}

--- a/server/modules/kratos/kratosuserstore.go
+++ b/server/modules/kratos/kratosuserstore.go
@@ -38,12 +38,11 @@ func (kratos *KratosUserstore) fetchUser(id string) (*KratosUser, error) {
 	return kratosUser, err
 }
 
-func (kratos *KratosUserstore) GetUserById(ctx context.Context, id string) (*model.User, error) {
-	var err error
-	var user *model.User
+func (kratos *KratosUserstore) GetUserById(ctx context.Context, id string) (user *model.User, err error) {
+	logger := log.FromContext(ctx)
 
 	if err = kratos.server.CheckAuthorized(ctx, "read", "users"); err == nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"userId":    id,
 			"requestId": ctx.Value(web.ContextKeyRequestId),
 		}).Debug("Fetching user by ID")
@@ -51,7 +50,7 @@ func (kratos *KratosUserstore) GetUserById(ctx context.Context, id string) (*mod
 		var kratosUser KratosUser
 		_, err = kratos.client.SendObject("GET", "/identities/"+id, "", &kratosUser, false)
 		if err != nil {
-			log.WithError(err).WithFields(log.Fields{
+			logger.WithError(err).WithFields(log.Fields{
 				"userId":    id,
 				"requestId": ctx.Value(web.ContextKeyRequestId),
 			}).Error("Failed to fetch user from Kratos")
@@ -75,15 +74,17 @@ func (kratos *KratosUserstore) GetUserById(ctx context.Context, id string) (*mod
 	return user, err
 }
 
-func (kratos *KratosUserstore) GetUsers(ctx context.Context) ([]*model.User, error) {
-	users := make([]*model.User, 0, 0)
-	myUserOnly := make([]*model.User, 0, 0)
+func (kratos *KratosUserstore) GetUsers(ctx context.Context) (users []*model.User, err error) {
+	logger := log.FromContext(ctx)
+
+	users = []*model.User{}
+	myUserOnly := []*model.User{}
 
 	if requestorId, ok := ctx.Value(web.ContextKeyRequestorId).(string); ok {
-		kratosUsers := make([]*KratosUser, 0, 0)
+		kratosUsers := []*KratosUser{}
 		_, err := kratos.client.SendObject("GET", "/identities", "", &kratosUsers, false)
 		if err != nil {
-			log.WithError(err).WithFields(log.Fields{
+			logger.WithError(err).WithFields(log.Fields{
 				"requestId": ctx.Value(web.ContextKeyRequestId),
 			}).Error("Failed to fetch users from Kratos")
 			return nil, err
@@ -135,10 +136,12 @@ func (kratos *KratosUserstore) shouldPopulateUserDetails(ctx context.Context, kr
 }
 
 func (kratos *KratosUserstore) populateUserDetails(ctx context.Context, kratosUser *KratosUser) {
-	log.Info("Populating user details for " + kratosUser.Id)
+	logger := log.FromContext(ctx)
+
+	logger.Info("Populating user details for " + kratosUser.Id)
 	_, err := kratos.client.SendObject("GET", "/identities/"+kratosUser.Id, "", &kratosUser, false)
 	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		logger.WithError(err).WithFields(log.Fields{
 			"requestId": ctx.Value(web.ContextKeyRequestId),
 		}).Error("Failed to fetch user details from Kratos")
 	}

--- a/server/modules/salt/saltstore.go
+++ b/server/modules/salt/saltstore.go
@@ -55,19 +55,21 @@ func (store *Saltstore) Init(timeoutMs int, longRelayTimeoutMs int, saltstackDir
 }
 
 func (store *Saltstore) execCommand(ctx context.Context, args map[string]string) (string, error) {
+	logger := log.FromContext(ctx)
+
 	reqId := ctx.Value(web.ContextKeyRequestId).(string)
 	cmd := args["command"]
 	id := reqId + "_" + cmd
 	args["command_id"] = id
 
 	filename := filepath.Join(store.queueDir, id)
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"filename": filename,
 	}).Info("Executing command via salt relay")
 
 	err := json.WriteJsonFile(filename, args)
 	if err != nil {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"filename": filename,
 		}).WithError(err).Error("Unable to write to file")
 
@@ -75,7 +77,7 @@ func (store *Saltstore) execCommand(ctx context.Context, args map[string]string)
 	}
 
 	responseFilename := filename + ".response"
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"responseFilename": responseFilename,
 		"timeoutMs":        store.timeoutMs,
 	}).Info("Waiting for response")
@@ -94,7 +96,7 @@ func (store *Saltstore) execCommand(ctx context.Context, args map[string]string)
 			var data []byte
 			data, err = os.ReadFile(responseFilename)
 			if err != nil {
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"filename": responseFilename,
 				}).WithError(err).Error("Failed to read file")
 			} else {
@@ -114,7 +116,7 @@ func (store *Saltstore) execCommand(ctx context.Context, args map[string]string)
 		return "", errors.New("ERROR_SALT_RELAY_DOWN")
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"filename": responseFilename,
 		"response": response,
 	}).Debug("Finished reading response")
@@ -132,6 +134,8 @@ func (store *Saltstore) GetSetting(settings []*model.Setting, id string) *model.
 }
 
 func (store *Saltstore) GetSettings(ctx context.Context, advanced bool) ([]*model.Setting, error) {
+	logger := log.FromContext(ctx)
+
 	var err error
 	if err = store.server.CheckAuthorized(ctx, "read", "config"); err != nil {
 		return nil, err
@@ -151,7 +155,7 @@ func (store *Saltstore) GetSettings(ctx context.Context, advanced bool) ([]*mode
 
 		if store.bypassErrors {
 			if err != nil {
-				log.WithField("path", path).WithError(err).Warn("Bypassing error while parsing defaults")
+				logger.WithField("path", path).WithError(err).Warn("Bypassing error while parsing defaults")
 			}
 			return nil
 		}
@@ -198,7 +202,7 @@ func (store *Saltstore) GetSettings(ctx context.Context, advanced bool) ([]*mode
 
 			if store.bypassErrors {
 				if err != nil {
-					log.WithField("path", path).WithError(err).Warn("Bypassing error while parsing local pillars")
+					logger.WithField("path", path).WithError(err).Warn("Bypassing error while parsing local pillars")
 				}
 				return nil
 			}
@@ -219,7 +223,7 @@ func (store *Saltstore) GetSettings(ctx context.Context, advanced bool) ([]*mode
 
 			if store.bypassErrors {
 				if err != nil {
-					log.WithField("path", path).WithError(err).Warn("Bypassing error while parsing annotations")
+					logger.WithField("path", path).WithError(err).Warn("Bypassing error while parsing annotations")
 				}
 				return nil
 			}
@@ -640,8 +644,9 @@ func (store *Saltstore) deleteSetting(mapped map[string]interface{}, sections []
 	return empty, err
 }
 
-func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Setting, remove bool) error {
-	var err error
+func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Setting, remove bool) (err error) {
+	logger := log.FromContext(ctx)
+
 	if err = store.server.CheckAuthorized(ctx, "write", "config"); err != nil {
 		return err
 	}
@@ -660,7 +665,7 @@ func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Settin
 	} else {
 		settingDef := store.GetSetting(settings, setting.Id)
 		if settingDef == nil {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"settingId": setting.Id,
 			}).Info("Setting definition not found; assuming new, undefined setting")
 		} else {
@@ -694,7 +699,7 @@ func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Settin
 			path = fmt.Sprintf("%s/local/pillar/minions/adv_%s.sls", store.saltstackDir, setting.NodeId)
 		}
 
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"settingId":     setting.Id,
 			"minionId":      setting.NodeId,
 			"settingPath":   path,
@@ -705,7 +710,7 @@ func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Settin
 	} else if setting.File {
 		path := fmt.Sprintf("%s/local/salt/%s", store.saltstackDir, store.relPathFromId(setting.Id))
 		if !remove {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"settingId":     setting.Id,
 				"settingPath":   path,
 				"settingLength": len(setting.Value),
@@ -713,7 +718,7 @@ func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Settin
 
 			err = os.WriteFile(path, []byte(setting.Value), 0600)
 		} else {
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"settingId":     setting.Id,
 				"settingPath":   path,
 				"settingLength": len(setting.Value),
@@ -733,14 +738,14 @@ func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Settin
 		mapped, err = store.parseYaml(path)
 		if err == nil {
 			if !remove {
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"settingId":     setting.Id,
 					"settingPath":   path,
 					"settingLength": len(setting.Value),
 				}).Info("Updating setting to new value")
 				err = store.updateSetting(mapped, sections, setting)
 			} else {
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"settingId":   setting.Id,
 					"settingPath": path,
 				}).Info("Deleting setting")

--- a/server/modules/sostatus/sostatus.go
+++ b/server/modules/sostatus/sostatus.go
@@ -87,13 +87,17 @@ func (status *SoStatus) IsRunning() bool {
 }
 
 func (status *SoStatus) Refresh(ctx context.Context) {
-	log.Debug("Updating grid status")
+	logger := log.FromContext(ctx)
+
+	logger.Debug("Updating grid status")
 	status.refreshGrid(ctx)
 	status.refreshDetections(ctx)
 	status.server.Host.Broadcast("status", "nodes", status.currentStatus)
 }
 
 func (status *SoStatus) refreshGrid(ctx context.Context) {
+	logger := log.FromContext(ctx)
+
 	unhealthyNodes := 0
 	nonCriticalNodes := 0
 	awaitingRebootCount := 0
@@ -104,7 +108,7 @@ func (status *SoStatus) refreshGrid(ctx context.Context) {
 		staleMs := int(time.Since(node.UpdateTime) / time.Millisecond)
 		if staleMs > status.offlineThresholdMs {
 			if node.ConnectionStatus != model.NodeStatusFault {
-				log.WithFields(log.Fields{
+				logger.WithFields(log.Fields{
 					"nodeId":             node.Id,
 					"staleMs":            staleMs,
 					"offlineThresholdMs": status.offlineThresholdMs,
@@ -115,7 +119,7 @@ func (status *SoStatus) refreshGrid(ctx context.Context) {
 
 		updated := status.server.Metrics.UpdateNodeMetrics(ctx, node)
 
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"Id":               node.Id,
 			"processStatus":    node.ProcessStatus,
 			"raidStatus":       node.RaidStatus,
@@ -142,12 +146,12 @@ func (status *SoStatus) refreshGrid(ctx context.Context) {
 	}
 	status.currentStatus.Grid.TotalNodeCount = len(nodes)
 	if status.currentStatus.Grid.UnhealthyNodeCount == 0 && unhealthyNodes > 0 {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"unhealthyNodes": unhealthyNodes,
 			"totalNodes":     len(nodes),
 		}).Warn("Grid has entered an unhealthy state")
 	} else if status.currentStatus.Grid.UnhealthyNodeCount > 0 && unhealthyNodes == 0 {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"unhealthyNodes": unhealthyNodes,
 			"totalNodes":     len(nodes),
 		}).Info("Grid has returned to a healthy state")
@@ -155,7 +159,7 @@ func (status *SoStatus) refreshGrid(ctx context.Context) {
 	status.currentStatus.Grid.UnhealthyNodeCount = unhealthyNodes
 	status.currentStatus.Grid.Eps = status.server.Metrics.GetGridEps(ctx)
 	if status.currentStatus.Grid.AwaitingRebootNodeCount == 0 && awaitingRebootCount > 0 {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"awaitingRebootCount": awaitingRebootCount,
 			"totalNodes":          len(nodes),
 		}).Info("Grid nodes are awaiting reboot")

--- a/server/modules/statickeyauth/statickeyauthimpl.go
+++ b/server/modules/statickeyauth/statickeyauthimpl.go
@@ -71,10 +71,12 @@ func (auth *StaticKeyAuthImpl) IsAuthorized(ctx context.Context, request *http.R
 }
 
 func (auth *StaticKeyAuthImpl) validateAuthorization(ctx context.Context, key string, ipStr string) bool {
+	logger := log.FromContext(ctx)
+
 	// If API key has been provided, it must match
 	if len(key) > 0 {
 		isApiKeyAccepted := auth.validateApiKey(key)
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"isApiKeyAccepted": isApiKeyAccepted,
 			"requestId":        ctx.Value(web.ContextKeyRequestId),
 		}).Debug("Authorization check via API key")
@@ -94,7 +96,7 @@ func (auth *StaticKeyAuthImpl) validateAuthorization(ctx context.Context, key st
 	}
 	remoteIp := net.ParseIP(ipStr)
 	isAnonymousIp := auth.anonymousNetwork.Contains(remoteIp)
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"anonymousNetwork": auth.anonymousNetwork,
 		"remoteIp":         remoteIp,
 		"ipStr":            ipStr,

--- a/server/modules/staticrbac/staticrbacauthorizer.go
+++ b/server/modules/staticrbac/staticrbacauthorizer.go
@@ -69,6 +69,8 @@ func (impl *StaticRbacAuthorizer) identifyUser(user *model.User) string {
 }
 
 func (impl *StaticRbacAuthorizer) GetAssignments(ctx context.Context) (map[string][]string, error) {
+	logger := log.FromContext(ctx)
+
 	userMap := make(map[string][]string)
 
 	if err := impl.CheckContextOperationAuthorized(ctx, "read", "roles"); err != nil {
@@ -83,7 +85,7 @@ func (impl *StaticRbacAuthorizer) GetAssignments(ctx context.Context) (map[strin
 			newRoles := make([]string, len(roles))
 			copy(newRoles, roles)
 			userMap[userIdentifier] = newRoles
-			log.WithFields(log.Fields{
+			logger.WithFields(log.Fields{
 				"user":      userIdentifier,
 				"roles":     roles,
 				"requestId": ctx.Value(web.ContextKeyRequestId),
@@ -125,18 +127,20 @@ func (impl *StaticRbacAuthorizer) GetRoles(ctx context.Context) []string {
 }
 
 func (impl *StaticRbacAuthorizer) PopulateUserRoles(ctx context.Context, user *model.User) error {
+	logger := log.FromContext(ctx)
+
 	// Use the returned roles instead of the struct roles so that they are filtered for access permissions
 	userMap, _ := impl.GetAssignments(ctx)
 
 	userIdentifier := impl.identifyUser(user)
 	if roles, ok := userMap[userIdentifier]; ok {
 		user.Roles = roles
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"user":  userIdentifier,
 			"roles": user.Roles,
 		}).Debug("Populated roles for user")
 	} else {
-		log.WithField("user", userIdentifier).Debug("No roles found")
+		logger.WithField("user", userIdentifier).Debug("No roles found")
 	}
 	return nil
 }
@@ -196,12 +200,13 @@ func (impl *StaticRbacAuthorizer) adjustMap(mp map[string][]string, subject stri
 	mp[subject] = perms
 }
 
-func (impl *StaticRbacAuthorizer) CheckContextOperationAuthorized(ctx context.Context, operation string, target string) error {
-	var err error
+func (impl *StaticRbacAuthorizer) CheckContextOperationAuthorized(ctx context.Context, operation string, target string) (err error) {
+	logger := log.FromContext(ctx)
+
 	if user, ok := ctx.Value(web.ContextKeyRequestor).(*model.User); ok {
 		err = impl.CheckUserOperationAuthorized(user, operation, target)
 	} else {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"requestId": ctx.Value(web.ContextKeyRequestId),
 			"operation": operation,
 			"target":    target,
@@ -212,8 +217,7 @@ func (impl *StaticRbacAuthorizer) CheckContextOperationAuthorized(ctx context.Co
 	return err
 }
 
-func (impl *StaticRbacAuthorizer) CheckUserOperationAuthorized(user *model.User, operation string, target string) error {
-	var err error
+func (impl *StaticRbacAuthorizer) CheckUserOperationAuthorized(user *model.User, operation string, target string) (err error) {
 	permission := target + "/" + operation
 
 	impl.mutex.Lock()

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -1036,6 +1036,8 @@ func buildImportChecker(pkg string) *regexp.Regexp {
 }
 
 func (e *StrelkaEngine) syncDetections(ctx context.Context) (err error) {
+	logger := log.FromContext(ctx)
+
 	results, err := e.srv.Detectionstore.GetAllDetections(ctx, model.WithEngine(model.EngineNameStrelka), model.WithEnabled(true))
 	if err != nil {
 		return err
@@ -1090,7 +1092,7 @@ func (e *StrelkaEngine) syncDetections(ctx context.Context) (err error) {
 
 	raw, code, dur, err := e.ExecCommand(cmd)
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"yaraCommand":  cmd.String(),
 		"yaraOutput":   string(raw),
 		"yaraCode":     code,

--- a/server/server.go
+++ b/server/server.go
@@ -116,13 +116,14 @@ func (server *Server) Wait() {
 	<-server.stoppedChan
 }
 
-func (server *Server) CheckAuthorized(ctx context.Context, operation string, target string) error {
-	var err error
+func (server *Server) CheckAuthorized(ctx context.Context, operation string, target string) (err error) {
+	logger := log.FromContext(ctx)
+
 	if server.Authorizer == nil {
 		if server.Config.DeveloperEnabled {
-			log.Info("Using developer mode; all authorization requests will succeed")
+			logger.Info("Using developer mode; all authorization requests will succeed")
 		} else {
-			log.Warn("No authorizer module has been configured; assuming no authorization")
+			logger.Warn("No authorizer module has been configured; assuming no authorization")
 			err = errors.New("Missing Authorizer module")
 		}
 	} else {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,6 +7,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/security-onion-solutions/securityonion-soc/config"
@@ -37,7 +38,7 @@ func TestDeveloperAuthorization(tester *testing.T) {
 	srv := NewServer(cfg, "")
 	cfg.DeveloperEnabled = true
 
-	authErr := srv.CheckAuthorized(nil, "read", "users")
+	authErr := srv.CheckAuthorized(context.Background(), "read", "users")
 	assert.NoError(tester, authErr)
 }
 
@@ -45,7 +46,7 @@ func TestMissingAuthorization(tester *testing.T) {
 	cfg := &config.ServerConfig{}
 	srv := NewServer(cfg, "")
 
-	authErr := srv.CheckAuthorized(nil, "read", "users")
+	authErr := srv.CheckAuthorized(context.Background(), "read", "users")
 	assert.Error(tester, authErr)
 	assert.Equal(tester, "Missing Authorizer module", authErr.Error())
 }
@@ -53,7 +54,7 @@ func TestMissingAuthorization(tester *testing.T) {
 func TestFailedAuthorization(tester *testing.T) {
 	srv := NewFakeUnauthorizedServer()
 
-	authErr := srv.CheckAuthorized(nil, "read", "users")
+	authErr := srv.CheckAuthorized(context.Background(), "read", "users")
 	assert.Error(tester, authErr)
 	assert.Contains(tester, authErr.Error(), "not authorized to perform operation 'read' on target 'users'")
 }

--- a/server/streamhandler.go
+++ b/server/streamhandler.go
@@ -43,6 +43,7 @@ func RegisterStreamRoutes(srv *Server, r chi.Router, prefix string) {
 
 func (h *StreamHandler) getStream(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	id := chi.URLParam(r, "jobId")
 	if id == "" {
@@ -90,7 +91,7 @@ func (h *StreamHandler) getStream(w http.ResponseWriter, r *http.Request) {
 
 	written, err := io.Copy(w, reader)
 	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		logger.WithError(err).WithFields(log.Fields{
 			"streamFilename": filename,
 		}).Error("Failed to copy stream")
 		web.Respond(nil, r, http.StatusInternalServerError, err)
@@ -98,7 +99,7 @@ func (h *StreamHandler) getStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"streamFilename": filename,
 		"streamSize":     written,
 	}).Info("Copied stream to response")

--- a/server/utilhandler.go
+++ b/server/utilhandler.go
@@ -39,8 +39,7 @@ func RegisterUtilRoutes(srv *Server, r chi.Router, prefix string) {
 
 func (h *UtilHandler) putReverseLookup(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
-	logger := log.WithField("handler", "putReverseLookup")
+	logger := log.FromContext(ctx)
 
 	var body []string
 	results := map[string][]string{}
@@ -159,7 +158,7 @@ func (h *UtilHandler) putReverseLookup(w http.ResponseWriter, r *http.Request) {
 		lop.ForEach(ips, func(ip string, _ int) {
 			addrs, err := resolver.LookupAddr(ctx, ip)
 			if err != nil && !strings.Contains(err.Error(), "Name or service not known") {
-				log.WithField("ip", ip).WithError(err).Warn("Failed to lookup address")
+				logger.WithField("ip", ip).WithError(err).Warn("Failed to lookup address")
 			}
 			if len(addrs) == 0 {
 				addrs = []string{ip}

--- a/web/basepreprocessor.go
+++ b/web/basepreprocessor.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/apex/log"
 	"github.com/google/uuid"
 )
 
@@ -27,5 +28,7 @@ func (Processor *BasePreprocessor) PreprocessPriority() int {
 func (processor *BasePreprocessor) Preprocess(ctx context.Context, req *http.Request) (context.Context, int, error) {
 	uuid := uuid.New().String()
 	ctx = context.WithValue(ctx, ContextKeyRequestId, uuid)
+	ctx = log.NewContext(ctx, log.WithField("requestId", uuid))
+
 	return ctx, 0, nil
 }

--- a/web/middleware.go
+++ b/web/middleware.go
@@ -81,12 +81,14 @@ func Respond(w http.ResponseWriter, r *http.Request, statusCode int, obj interfa
 	var contentLength int
 
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
+	
 	start := ctx.Value(ContextKeyRequestStart).(time.Time)
 	elapsed := time.Since(start).Milliseconds()
 
 	err, isErr := obj.(error)
 	if isErr {
-		log.WithError(err).WithFields(log.Fields{
+		logger.WithError(err).WithFields(log.Fields{
 			"requestId": ctx.Value(ContextKeyRequestId),
 			"requestor": ctx.Value(ContextKeyRequestor),
 		}).Warn("Request did not complete successfully")
@@ -139,7 +141,7 @@ func Respond(w http.ResponseWriter, r *http.Request, statusCode int, obj interfa
 		impl = fmt.Sprintf("%s:%d:%s", file, line, fnc)
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"remoteAddr":    r.RemoteAddr,
 		"sourceIp":      GetSourceIp(r),
 		"requestPath":   r.URL.Path,

--- a/web/websockethandler.go
+++ b/web/websockethandler.go
@@ -42,6 +42,7 @@ func RegisterWebSocketRoutes(host *Host, r chi.Router) {
 
 func (webSocketHandler *WebSocketHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.FromContext(ctx)
 
 	ip := GetSourceIp(r)
 
@@ -49,7 +50,7 @@ func (webSocketHandler *WebSocketHandler) Handle(w http.ResponseWriter, r *http.
 	var ok bool
 	user, ok = ctx.Value(ContextKeyRequestor).(*model.User)
 	if !ok {
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"messageRemoteAddr": r.RemoteAddr,
 			"messageSourceIp":   ip,
 			"messagePath":       r.URL.Path,
@@ -62,7 +63,7 @@ func (webSocketHandler *WebSocketHandler) Handle(w http.ResponseWriter, r *http.
 	upgrader := websocket.Upgrader{}
 	connection, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		logger.WithError(err).WithFields(log.Fields{
 			"messageRemoteAddr": r.RemoteAddr,
 			"messageSourceIp":   ip,
 			"messagePath":       r.URL.Path,
@@ -72,7 +73,7 @@ func (webSocketHandler *WebSocketHandler) Handle(w http.ResponseWriter, r *http.
 		return
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"messageRemoteAddr": r.RemoteAddr,
 		"messageSourceIp":   ip,
 		"messagePath":       r.URL.Path,
@@ -86,7 +87,7 @@ func (webSocketHandler *WebSocketHandler) Handle(w http.ResponseWriter, r *http.
 		if err != nil {
 			break
 		}
-		log.WithFields(log.Fields{
+		logger.WithFields(log.Fields{
 			"messageRemoteAddr": r.RemoteAddr,
 			"messageSourceIp":   ip,
 			"messagePath":       r.URL.Path,
@@ -98,7 +99,7 @@ func (webSocketHandler *WebSocketHandler) Handle(w http.ResponseWriter, r *http.
 		json.LoadJson(messageBytes, msg)
 		webSocketHandler.handleMessage(msg, conn)
 	}
-	log.WithFields(log.Fields{
+	logger.WithFields(log.Fields{
 		"messageRemoteAddr": r.RemoteAddr,
 		"messageSourceIp":   ip,
 		"messagePath":       r.URL.Path,


### PR DESCRIPTION
Instead of creating arbitrary loggers or logging using the namespace name, the basepreprocessor has been updated to add a logger to every request's context that comes through. As we pass the context around, the logger goes with it. The logger gets the requestId field added to it so, similar to intCheckId and syncId, you can follow a request around by all the things logged with the same id.

Because we're using log.FromContext, if the context does not have a logger, we'll fall back to the global logger. This means no change to any log statement that receives a non-request context such as in modules or background processes.

I've updated every reference I could find looking for functions that make log namespace calls that had a context passed into them.

Not only does this give us a traceable requestId to help with debugging, this allows us to mock the logger in unit tests.