### PR TITLE
Cogburn/fix duplicate config

### DIFF
--- a/html/js/routes/config.js
+++ b/html/js/routes/config.js
@@ -558,7 +558,7 @@ routes.push({
         this.$root.showWarning(this.i18n.settingDuplicateInvalid);
         return
       }
-      var new_setting = structuredClone(setting);
+      var new_setting = structuredClone(Vue.toRaw(setting));
       new_setting.id = new_id;
       new_setting.name = new_name;
       this.settings.push(new_setting);

--- a/html/js/routes/config.test.js
+++ b/html/js/routes/config.test.js
@@ -599,10 +599,16 @@ test('duplicate', () => {
     name: "c",
     duplicates: true,
   }
+
+  Vue = {
+    toRaw: jest.fn().mockReturnValueOnce(setting),
+  };
   global.structuredClone = jest.fn().mockReturnValueOnce(setting2);
+
   comp.settings = [setting];
   comp.duplicateId = "foo"
   expect(comp.settings.length).toBe(1);
+
   comp.duplicate(setting);
   expect(comp.settings.length).toBe(2);
   expect(comp.settings[1].id).toBe("a.b.foo");


### PR DESCRIPTION
Fixes a exception in the duplicate config button handler. Vue 3 uses Proxy objects for reactivity and in most places that doesn't have a negative impact but when duplicating a setting we pass the setting through structuredClone() and that function does not work on proxy objects (you throw DataCloneError). Vue comes with a helper function to unwrap these proxies and give us the plain old object which can be passed successfully to structuredClone().