### PR TITLE
Fix Duplicate Hunt on Navigation to Hunt Page

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -289,8 +289,6 @@ const huntComponent = {
       if (this.$route.query.q || (this.shouldAutohunt() && this.query)) {
         this.hunt(true);
       }
-
-      this.loadData();
     },
     applyQuerySubstitutions(queries) {
       if (Array.isArray(queries)) {
@@ -360,7 +358,11 @@ const huntComponent = {
         this.dateRange = this.getStartDate().format(this.i18n.timePickerFormat) + " - " + this.getEndDate().format(this.i18n.timePickerFormat);
       }
       if (replaceHistory === true) {
-        this.$router.replace(this.buildCurrentRoute(), onSuccess, onFail);
+        this.$router.replace(this.buildCurrentRoute(), onSuccess, onFail).then((result) => {
+          if (result?.message?.includes('redundant navigation')) {
+            this.loadData();
+          }
+        });
       } else {
         this.$router.push(this.buildCurrentRoute()).then((result) => {
           if (result?.message?.includes('redundant navigation')) {


### PR DESCRIPTION
In the Vue transition, I added a call to loadData at the end of initHunt because loading the page was not executing the default query and this change seemed to fix it. I didn't know it at the time, but it resulted in the first query when navigating to the hunt page being executed twice.

The actual root of the problem is that navigating to your exact, current route does not navigate. This results in $route not changing, which means the watch for it doesn't call loadData. This was discovered during the Vue transition but the fix was only applied to pushing a new state (hunt.js:367) and was not applied to when we replace the state. The same fix that was applied then has been applied more thoroughly and now there's only 1 hunt executed during page load.