### PR TITLE
Don't Specify Chart Width

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -538,12 +538,11 @@ td {
 }
 
 .chart-container {
-  max-width: 528px;
-  max-height: 400px;
   height: 100%;
 }
 
 .chart-container [id^="group-"] {
+  max-height: 475px;
   height: 100%;
 }
 

--- a/html/index.html
+++ b/html/index.html
@@ -582,19 +582,19 @@
                                 </span>
                                 <span class="table-header-actions ml-2">
                                   <router-link v-if="header.value == 'count' && isAdvanced()" :to="buildGroupOptionRoute(groupIdx, [], 'pie')" :title="i18n.showPieChart" style="text-decoration: none; cursor: 'pointer'" :data-aid="'groups_pie_toggle_' + category">
-                                    <v-icon class="text-white">fa-chart-pie</v-icon>
+                                    <v-icon class="theme-icon">fa-chart-pie</v-icon>
                                   </router-link>
                                   <router-link v-if="header.value == 'count' && isAdvanced()" :to="buildGroupOptionRoute(groupIdx, [], 'bar')" :title="i18n.showBarChart" style="text-decoration: none; cursor: 'pointer'" :data-aid="'groups_bar_toggle_' + category">
-                                    <v-icon class="text-white">fa-chart-column</v-icon>
+                                    <v-icon class="theme-icon">fa-chart-column</v-icon>
                                   </router-link>
                                   <router-link v-if="header.value == 'count' && isAdvanced() && isGroupSankeyCapable(group, groupIdx)" icon x-small :to="buildGroupOptionRoute(groupIdx, [], 'sankey')" :title="i18n.showSankeyChart" style="text-decoration: none; cursor: 'pointer'" :data-aid="'groups_sankey_toggle_' + category">
-                                    <v-icon class="text-white">fa-diagram-project</v-icon>
+                                    <v-icon class="theme-icon">fa-diagram-project</v-icon>
                                   </router-link>
                                   <router-link v-if="header.value == 'count' && isAdvanced()" class="mx-1" :to="buildMaximizeRoute(group, groupIdx)" :title="i18n.maximize" style="text-decoration: none; cursor: 'pointer'" :data-aid="'groups_maximize_toggle_' + category">
-                                    <v-icon class="text-white">fa-expand</v-icon>
+                                    <v-icon class="theme-icon">fa-expand</v-icon>
                                   </router-link>
                                   <v-btn v-if="header.value != 'count' && header.value != ''" variant="text" size="x-small" @click.stop="removeGroupBy(groupIdx,headerIdx - getGroupByFieldStartIndex())" :title="i18n.remove" :data-aid="'groups_table_remove_' + category">
-                                    <v-icon class="text-white tiny-icon">fa-circle-xmark</v-icon>
+                                    <v-icon class="theme-icon tiny-icon">fa-circle-xmark</v-icon>
                                   </v-btn>
                                 </span>
                                 <template v-if="isSorted(header)">


### PR DESCRIPTION
Some charts were appearing narrower than they should. instead of specifying both a height and a width for the charts to fit themselves to, only specify the height. This should fix the old issue of charts erroneously growing to take up all available vertical space in a bad way, and instead should ensure the chart takes up all available horizontal space in a good way. The choice to specify the height on the group div allows for the height to be specified while not maximized, but when the maximized class is applied the max-height value is overwritten.

Also fixed some icons who's styles had them hardcoded as white. They disappeared in the white theme.