### PR TITLE
await populateUserDetails

### DIFF
--- a/html/js/routes/case.js
+++ b/html/js/routes/case.js
@@ -289,12 +289,9 @@ routes.push({ path: '/case/:id', name: 'case', component: {
           for (var idx = 0; idx < response.data.length; idx++) {
             const obj = response.data[idx];
 
-            // Don't await the user details -- takes too long for the task scheduler to
-            // complete all these futures when looping across hundreds of records. Let
-            // the UI update as they finish, for a better user experience.
-            this.$root.populateUserDetails(obj, "userId", "owner");
+            await this.$root.populateUserDetails(obj, "userId", "owner");
             if (obj.assigneeId) {
-              this.$root.populateUserDetails(obj, "assigneeId", "assignee");
+              await this.$root.populateUserDetails(obj, "assigneeId", "assignee");
             }
             obj.kind = this.$root.localizeMessage(this.mapAssociatedKind(obj));
             obj.operation = this.$root.localizeMessage(obj.operation);


### PR DESCRIPTION
populateUserDetails is async and not finishing before the UI renders. This is causing the `owner` field on comments to render as undefined and when updated asynchronously, the UI isn't reflecting the change. Despite the JS comment saying otherwise, awaiting here is usually not waiting on a request. We cache our user list so repeated calls take trivial amounts of time. Added `await` and removed the comment so all comment owners appear in the UI properly.