### PR TITLE
Use Refs for Performant Comments

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -120,7 +120,7 @@ $(document).ready(function () {
       },
     },
   });
-  const router = VueRouter.createRouter({ routes, history: VueRouter.createWebHashHistory() })
+  const router = VueRouter.createRouter({ routes, history: VueRouter.createWebHashHistory() });
 
   const comp = {
     el: '#app',
@@ -1106,7 +1106,11 @@ $(document).ready(function () {
 
           const user = await this.$root.getUserById(id);
           if (user) {
-            obj[outputField] = user.email;
+            if (Vue.isRef(obj[outputField])) {
+              obj[outputField].value = user.email;
+            } else {
+              obj[outputField] = user.email;
+            }
           } else {
             obj[outputField] = id;
           }

--- a/html/js/app.test.js
+++ b/html/js/app.test.js
@@ -124,6 +124,12 @@ test('populateUserDetails', async () => {
   app.usersLoadedTime = new Date().time;
   await app.populateUserDetails(obj, "userId", "owner")
   expect(obj.owner).toBe('hi@there.net');
+
+  delete obj.owner;
+  obj.owner = global.Vue.ref(null);
+
+  await app.populateUserDetails(obj, "userId", "owner")
+  expect(obj.owner.value).toBe('hi@there.net');
 });
 
 test('populateUserDetailsSystem', async () => {

--- a/html/js/routes/case.js
+++ b/html/js/routes/case.js
@@ -288,10 +288,12 @@ routes.push({ path: '/case/:id', name: 'case', component: {
           let batch = [];
           for (var idx = 0; idx < response.data.length; idx++) {
             const obj = response.data[idx];
+            obj.owner = Vue.ref(null);
 
-            await this.$root.populateUserDetails(obj, "userId", "owner");
+            this.$root.populateUserDetails(obj, "userId", "owner");
             if (obj.assigneeId) {
-              await this.$root.populateUserDetails(obj, "assigneeId", "assignee");
+              obj.assignee = Vue.ref(null);
+              this.$root.populateUserDetails(obj, "assigneeId", "assignee");
             }
             obj.kind = this.$root.localizeMessage(this.mapAssociatedKind(obj));
             obj.operation = this.$root.localizeMessage(obj.operation);

--- a/html/js/test_common.js
+++ b/html/js/test_common.js
@@ -14,6 +14,75 @@ global.document.ready = function(fn) { fn(); };
 global.window.scrollTo = jest.fn();
 global.location = { hash: "" };
 ////////////////////////////////////
+// Mock Vue Internals (not exported)
+////////////////////////////////////
+class RefImpl {
+  constructor(value, __v_isShallow) {
+    this.__v_isShallow = __v_isShallow;
+    this.dep = void 0;
+    this.__v_isRef = true;
+    this._rawValue = __v_isShallow ? value : toRaw(value);
+    this._value = __v_isShallow ? value : toReactive(value);
+
+    // Wrap _value in a Proxy (handling primitives correctly)
+    this._value = new Proxy(isObject(this._value) ? this._value : { value: this._value }, {
+      get: (target, prop, receiver) => {
+        if (prop === 'value') {
+          return target.value;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      set: (target, prop, value, receiver) => {
+        if (prop === 'value') {
+          target.value = value;
+          return true;
+        }
+        return Reflect.set(target, prop, value, receiver);
+      }
+    });
+  }
+  toJSON() {
+    return this.value;
+  }
+  get value() {
+    return this._value;
+  }
+  set value(newVal) {
+    const useDirectValue = this.__v_isShallow || isShallow(newVal) || isReadonly(newVal);
+    newVal = useDirectValue ? newVal : toRaw(newVal);
+    if (hasChanged(newVal, this._rawValue)) {
+      this._rawValue = newVal;
+      this._value = useDirectValue ? newVal : toReactive(newVal);
+    }
+  }
+}
+const hasChanged = (value, oldValue) => !Object.is(value, oldValue);
+const toReactive = (value) => isObject(value) ? reactive(value) : value;
+const isObject = (val) => val !== null && typeof val === "object";
+function isReadonly(value) {
+  return !!(value && value["__v_isReadonly"]);
+}
+function isShallow(value) {
+  return !!(value && value["__v_isShallow"]);
+}
+function toRaw(observed) {
+  const raw = observed && observed["__v_raw"];
+  return raw ? toRaw(raw) : observed;
+}
+function createRef(rawValue, shallow) {
+  if (isRef(rawValue)) {
+    return rawValue;
+  }
+  return new RefImpl(rawValue, shallow);
+}
+function isRef(r) {
+  return !!(r && r.__v_isRef === true);
+}
+function ref(value) {
+  return createRef(value, false);
+}
+
+////////////////////////////////////
 // Mock Vue
 ////////////////////////////////////
 var app = null;
@@ -41,12 +110,8 @@ global.Vue.createApp = function(obj) {
 
   return app;
 };
-global.Vue.delete = function(data, i) {
-  data.splice(i, 1);
-};
-global.Vue.set = function(array, idx, value) {
-  array[idx] = value;
-};
+global.Vue.ref = ref;
+global.Vue.isRef = isRef;
 global.Vuetify = {
   components: { VClassIcon: {} },
   createVuetify: () => { },


### PR DESCRIPTION
Before a case looks up the owner or assignee for one of it's associations, pre-load the field with a ref. This provides a much faster way to add the owner asynchronously if we have to look it up.

Update populateUserDetails to support Refs by properly assigning the value to `.value` when the target field is a ref and directly to the target field when it's not a ref.

Updated an app test to pass in a ref and non-ref object to it's populateUserDetails test and test both outcomes accordingly. Updated test_common to include all the work necessary to support Vue.ref and Vue.isRef through re-implementing them.