### PR TITLE
Detection panel non-AI-summaries now show properly and chart maximizing works again

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -899,10 +899,6 @@ ul ul ul {
   background-color: rgb(var(--v-theme-primary)) !important;
 }
 
-.groupBy {
-  position: relative;
-}
-
 #detection-col {
   top: 70px;
   position: sticky;

--- a/html/js/components/detection-panel.js
+++ b/html/js/components/detection-panel.js
@@ -24,9 +24,6 @@ components.push({
 			},
 		},
 		emits: ['close', 'ack', 'chooseCase', 'highlightPrevAlertDetection', 'highlightNextAlertDetection'],
-		watch: {
-			'detection': 'onDetectionChange',
-		},
 		setup(_, { emit }) {
 			return { emit };
 		},
@@ -115,15 +112,15 @@ components.push({
 		},
 		mounted() {
 			this.$root.loadParameters('detection', this.initParams);
+			this.prepareDetection();
+			this.panels = [0, 1];
 		},
 		methods: {
-			onDetectionChange() {
+			prepareDetection() {
 				if (this.detection) {
 					this.tagOverrides();
 					this.extractSummary();
 				}
-
-				this.panel = [0, 1];
 			},
 			initParams(params) {
 				this.showUnreviewedAiSummaries = !!params?.['showUnreviewedAiSummaries'];

--- a/html/js/components/detection-panel.test.js
+++ b/html/js/components/detection-panel.test.js
@@ -34,13 +34,13 @@ beforeEach(() => {
 
 test('extractSummary for Suricata', () => {
   comp.detection.content = 'alert tcp any any -> any any (msg:"Test"; classtype:test-class; sid:1000;)';
-  comp.onDetectionChange();
+  comp.prepareDetection();
   expect(comp.extractedSummary).toBe('test-class');
 });
 
 test('extractSummary fallback to title', () => {
   comp.detection.content = 'alert tcp any any -> any any (msg:"Test"; sid:1000;)';
-  comp.onDetectionChange();
+  comp.prepareDetection();
   expect(comp.extractedSummary).toBe('Test Detection');
 });
 
@@ -48,7 +48,7 @@ test('extractSummary for ElastAlert with YAML description', () => {
   comp.detection.engine = 'elastalert';
   comp.detection.language = 'sigma';
   comp.detection.content = 'description: Test Description\ndetection:\n  condition: selection';
-  comp.onDetectionChange();
+  comp.prepareDetection();
   expect(comp.extractedSummary).toBe('Test Description');
 });
 
@@ -57,7 +57,7 @@ test('extractSummary for ElastAlert with description field', () => {
   comp.detection.language = 'sigma';
   comp.detection.content = 'title: Test\ndetection:\n  condition: selection';
   comp.detection.description = 'Field Description';
-  comp.onDetectionChange();
+  comp.prepareDetection();
   expect(comp.extractedSummary).toBe('Field Description');
 });
 
@@ -65,7 +65,7 @@ test('extractSummary for ElastAlert fallback to title', () => {
   comp.detection.engine = 'elastalert';
   comp.detection.language = 'sigma';
   comp.detection.content = 'title: Test\ndetection:\n  condition: selection';
-  comp.onDetectionChange();
+  comp.prepareDetection();
   expect(comp.extractedSummary).toBe('Test Detection');
 });
 
@@ -73,14 +73,14 @@ test('extractSummary for Yara with description field', () => {
   comp.detection.engine = 'strelka';
   comp.detection.language = 'yara';
   comp.detection.description = 'Yara Description';
-  comp.onDetectionChange();
+  comp.prepareDetection();
   expect(comp.extractedSummary).toBe('Yara Description');
 });
 
 test('extractSummary for Yara fallback to title', () => {
   comp.detection.engine = 'strelka';
   comp.detection.language = 'yara';
-  comp.onDetectionChange();
+  comp.prepareDetection();
   expect(comp.extractedSummary).toBe('Test Detection');
 });
 


### PR DESCRIPTION
In the detection panel in alerts, a detection without an AI Summary will now properly extract the summary from the rule.

Maximizing charts works again. Also tested with a large table to see if disabling scrolling was hiding details but graphs are forced to fit on-screen and tables have internal scrolling that will allow all data to be visible no matter how tall the table is.