### PR TITLE
Rename Hooks

### DIFF
--- a/html/js/routes/case.js
+++ b/html/js/routes/case.js
@@ -173,10 +173,10 @@ routes.push({ path: '/case/:id', name: 'case', component: {
         this.loadUrlParameters();
       });
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.$root.setSubtitle("");
   },
-  destroyed() {
+  unmounted() {
     this.$root.unsubscribe("case", this.updateCase);
     this.$root.unsubscribe("job", this.updateJob);
   },

--- a/html/js/routes/downloads.js
+++ b/html/js/routes/downloads.js
@@ -13,7 +13,7 @@ routes.push({ path: '/downloads', name: 'downloads', component: {
   created() {
     this.$root.subscribe("node", this.updateNode);
   },
-  destroyed() {
+  unmounted() {
     this.$root.unsubscribe("node", this.updateNode);
   },
   watch: {

--- a/html/js/routes/grid.js
+++ b/html/js/routes/grid.js
@@ -76,9 +76,7 @@ routes.push({ path: '/grid', name: 'grid', component: {
   }},
   created() {
   },
-  beforeDestroy() {
-  },
-  destroyed() {
+  unmounted() {
     this.$root.unsubscribe("node", this.updateNode);
     this.$root.unsubscribe("status", this.updateStatus);
   },

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -196,7 +196,7 @@ const huntComponent = {
       { title: this.i18n.interval24h, value: 86400 },
     ];
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.$root.setSubtitle("");
     this.stopRefreshTimer();
     this.$root.unsubscribe('detections:bulkUpdate', this.bulkUpdateReport);

--- a/html/js/routes/job.js
+++ b/html/js/routes/job.js
@@ -186,6 +186,8 @@ routes.push({ path: '/job/:jobId', name: 'job', component: {
       setTimeout(function() { route.loadPackets(unwrap); }, 0); // run async to this event
     },
     async loadPackets(unwrap) {
+      if (!this.job || !this.job.id) return;
+
       this.packetsLoading = true;
       try {
         const response = await this.$root.papi.get('packets', { params: {

--- a/html/js/routes/job.js
+++ b/html/js/routes/job.js
@@ -44,10 +44,10 @@ routes.push({ path: '/job/:jobId', name: 'job', component: {
     this.loadData();
     this.$root.loadParameters('job', this.initActions);
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.$root.setSubtitle("");
   },
-  destroyed() {
+  unmounted() {
     this.$root.unsubscribe("job", this.updateJob);
   },
   watch: {
@@ -189,7 +189,7 @@ routes.push({ path: '/job/:jobId', name: 'job', component: {
       this.packetsLoading = true;
       try {
         const response = await this.$root.papi.get('packets', { params: {
-          jobId: this.$route.params.jobId,
+          jobId: this.job.id,
           offset: this.packets.length,
           count: this.count,
           unwrap: unwrap

--- a/html/js/routes/jobs.js
+++ b/html/js/routes/jobs.js
@@ -44,7 +44,7 @@ routes.push({ path: '/jobs', name: 'jobs', component: {
   created() {
     this.loadData();
   },
-  destroyed() {
+  unmounted() {
     this.$root.unsubscribe("job", this.updateJob);
   },
   watch: {


### PR DESCRIPTION
`beforeDestroy` and `destroyed` have been renamed to `beforeUnmount` and `unmounted` to match the new lifecycle names Vue 3 uses. These are the only hooks to be renamed. Updated multiple routes.

In job.js, loadPackets now uses the saved job object rather than the route parameter when building params for the packets request.