### PR TITLE
Fix "Create Case" Error

### DIFF
--- a/html/js/routes/case.js
+++ b/html/js/routes/case.js
@@ -451,7 +451,7 @@ routes.push({ path: '/case/:id', name: 'case', component: {
           description: this.i18n.caseDefaultDescription,
         });
         if (response && response.data && response.data.id) {
-          this.$router.replace({ name: 'case', params: { id: response.data.id }, query: this.$route.query });
+          await this.$router.replace({ name: 'case', params: { id: response.data.id }, query: this.$route.query });
         } else {
           this.$root.showError(i18n.createFailed);
         }


### PR DESCRIPTION
When creating a case, we 1) make a call to create a case, 2) $router.replace to update the url with the new case ID, 3) use the route params to load the case. Step 2 is async so step 3 used the old ID param of `create`. Adding an await on step 2 ensures that the new route params are used in step 3 and we don't attempt to retrieve a case with a bad ID.

In Vue 2, $router.replace was effectively synchronous as it updated the $route without the need of await.