### PR TITLE
V-Btn-Toggle Changes

### DIFF
--- a/html/js/routes/job.js
+++ b/html/js/routes/job.js
@@ -149,10 +149,13 @@ routes.push({ path: '/job/:jobId', name: 'job', component: {
       return this.packetOptions.indexOf(option) != -1;
     },
     captureLayoutAsStream() {
-      if (!this.isOptionEnabled('packets')) return;
+      // wait for v-btn-toggle to update model
+      this.$nextTick(() => {
+        if (!this.isOptionEnabled('packets')) return;
 
-      this.expandPackets(true);
-      this.sortBy = [{ key: 'number', order: 'asc' }];
+        this.expandPackets(true);
+        this.sortBy = [{ key: 'number', order: 'asc' }];
+      });
     },
     packetsUpdated() {
       if (this.expandAll) {


### PR DESCRIPTION
In Vuetify 2, a v-btn-toggle updated it's model before executing it's childrens' events, in Vuetify 3 that's swapped to better align with Vue's reactivity rules. That means captureLayoutAsStream on the PCAP page is seeing an out-of-date model when it references packetOptions causing the button to act exactly backwards from it's indicated state. Waiting for nextTick allows the model to be updated and the correct state to be observed.