### PR TITLE
Simplify for Clarity and Correctness

### DIFF
--- a/html/js/routes/job.js
+++ b/html/js/routes/job.js
@@ -149,13 +149,10 @@ routes.push({ path: '/job/:jobId', name: 'job', component: {
       return this.packetOptions.indexOf(option) != -1;
     },
     captureLayoutAsStream() {
-      // wait for v-btn-toggle to update model
-      this.$nextTick(() => {
-        if (!this.isOptionEnabled('packets')) return;
+      if (this.isOptionEnabled('packets')) return;
 
-        this.expandPackets(true);
-        this.sortBy = [{ key: 'number', order: 'asc' }];
-      });
+      this.expandPackets(true);
+      this.sortBy = [{ key: 'number', order: 'asc' }];
     },
     packetsUpdated() {
       if (this.expandAll) {


### PR DESCRIPTION
The state wasn't backwards, my understanding was. The button begins enabled and the table rows are visible, toggling it off removes the rows and shows only the packet data in order. NextTick isn't needed as the model is correct. I was wrong about the order of events with the last fix.