### PR TITLE
Reduce Padding

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -99,6 +99,10 @@ a.v-list-item.v-theme--light {
   display: none;
 }
 
+#external-tools-list a.v-list-item {
+  padding-right: 4px;
+}
+
 [data-aid^="relative_time_input_"] .v-input__append {
   padding-top: 0px !important;
 }


### PR DESCRIPTION
Shrink the padding on external tools links on the right side from 16px down to 4px to prevent "Osquery Manager" from truncating with an ellipsis.