### PR TITLE
Replace Virtual Table

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -799,7 +799,7 @@
                       <template #expanded-row="{ columns, item }">
                         <tr>
                           <td :colspan="columns.length" class="px-0" :data-aid="'events_fields_' + category">
-                            <v-data-table-virtual density="compact" hide-default-header hide-default-footer :headers="expandedHeaders" :items="getExpandedData(item)">
+                            <v-data-table density="compact" hide-default-header hide-default-footer :headers="expandedHeaders" :items="getExpandedData(item)" items-per-page="-1">
                               <template #item="{ item: kvp }">
                                 <tr :data-aid="'events_field_' + category + '_' + kvp.key" class="pt-3">
                                   <td class="expansion">
@@ -818,7 +818,7 @@
                                   </td>
                                 </tr>
                               </template>
-                            </v-data-table-virtual>
+                            </v-data-table>
                           </td>
                         </tr>
                       </template>


### PR DESCRIPTION
v-data-table-virtual says on the tin that it "relies on all data being available locally but unlike the standard data-table it uses virtualization to only render a small portion of the rows." This makes it not a good fit for use showing alert detail rows in the ungrouped Alerts table. We're only rendering a small portion of rows (a little over half) upon expanding a row. The behavior appears glitchy rather than intended when you expand a second row and the first row fills out it's missing rows.

Now the table is the non-virtual variant with items-per-page set to -1 so we see every row as expected.