### PR TITLE
Prevent Second Popup When Disabling Detection

### DIFF
--- a/html/js/components/detection-panel.js
+++ b/html/js/components/detection-panel.js
@@ -126,7 +126,7 @@ components.push({
 				this.showUnreviewedAiSummaries = !!params?.['showUnreviewedAiSummaries'];
 			},
 			ack() {
-				this.emit('ack', [this.alertInfo.item, null, false, null, this.alertInfo.groupIndex, true]);
+				this.emit('ack', [this.alertInfo.item, null, false, null, this.alertInfo.groupIndex, true, true]);
 			},
 			escalate(e) {
 				this.emit('chooseCase', [e, this.alertInfo.item, this.alertInfo.groupIndex, true]);

--- a/html/js/components/detection-panel.test.js
+++ b/html/js/components/detection-panel.test.js
@@ -481,6 +481,7 @@ test('ack emits event', () => {
     false,
     null,
     comp.alertInfo.groupIndex,
+    true,
     true
   ]);
 });


### PR DESCRIPTION
When disabling a detection, we want to offer a popup to the user asking "Do you also want to acknowledge all alerts for this detection?" This popup is controlled by the Detection Panel and is desired. However if the user clicks Yes, the panel calls out to the alerts page to do the actual acknowledging. At the page level, a new optional parameter was added to the ack function to help with a soon-to-be-implemented feature where every event can be escalated and this too will have a dialog. The detection panel was failing to provide the new optional parameter that would hide this second page-level popup and thus 2 confirmation popups were being displayed. Having the detection panel pass `true` for this optional parameter prevents the second popup and provides the user with a cleaner experience as we originally intended.

Updated test.