### PR TITLE
Right Number of Dialogs at the Right Times, Check Language and Engine

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -5911,7 +5911,7 @@
                 </div>
               </div>
               <div class="quicklinks pt-2">
-                <v-btn id="detection-panel-ack" icon variant="text" size="small" @click="ack()" data-aid="detection_panel_ack" :title="i18n.alertAcknowledge">
+                <v-btn id="detection-panel-ack" icon variant="text" size="small" @click="ack(false)" data-aid="detection_panel_ack" :title="i18n.alertAcknowledge">
                   <v-icon :color="ackColor">
                     <span>
                       <i class="fas fa-bell fa-stack-1x"></i>
@@ -6287,7 +6287,7 @@
             <v-card-text v-html="i18n.acknowledgeExistingAlertsText" />
             <v-card-actions>
               <v-spacer></v-spacer>
-              <v-btn text id="ack-existing-confirm-yes-button" @click="saveDetection(); ack();" v-text="i18n.yes" data-aid="detection_panel_ack_existing_yes" />
+              <v-btn text id="ack-existing-confirm-yes-button" @click="saveDetection(); ack(true);" v-text="i18n.yes" data-aid="detection_panel_ack_existing_yes" />
               <v-btn text id="ack-existing-confirm-no-button" @click="saveDetection();" v-text="i18n.no" data-aid="detection_panel_ack_existing_no" />
               <v-btn text id="ack-existing-confirm-cancel-button" @click="detection.isEnabled = true; ackExistingDialog = false;" v-text="i18n.cancel" data-aid="detection_panel_ack_existing_cancel" />
             </v-card-actions>

--- a/html/js/components/detection-panel.js
+++ b/html/js/components/detection-panel.js
@@ -125,8 +125,8 @@ components.push({
 			initParams(params) {
 				this.showUnreviewedAiSummaries = !!params?.['showUnreviewedAiSummaries'];
 			},
-			ack() {
-				this.emit('ack', [this.alertInfo.item, null, false, null, this.alertInfo.groupIndex, true, true]);
+			ack(alreadyAcceptedDialog) {
+				this.emit('ack', [this.alertInfo.item, null, false, null, this.alertInfo.groupIndex, true, alreadyAcceptedDialog]);
 			},
 			escalate(e) {
 				this.emit('chooseCase', [e, this.alertInfo.item, this.alertInfo.groupIndex, true]);

--- a/html/js/components/detection-panel.test.js
+++ b/html/js/components/detection-panel.test.js
@@ -474,7 +474,18 @@ test('deleteOverride', async () => {
 });
 
 test('ack emits event', () => {
-  comp.ack();
+  comp.ack(false);
+  expect(comp.emit).toHaveBeenCalledWith('ack', [
+    comp.alertInfo.item,
+    null,
+    false,
+    null,
+    comp.alertInfo.groupIndex,
+    true,
+    false
+  ]);
+
+  comp.ack(true);
   expect(comp.emit).toHaveBeenCalledWith('ack', [
     comp.alertInfo.item,
     null,

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -1198,7 +1198,8 @@ func (h *DetectionHandler) ConvertContent(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if det.Engine != model.EngineNameElastAlert {
+	if model.EngineName(strings.ToLower(string(det.Engine))) != model.EngineNameElastAlert &&
+		model.SigLanguage(strings.ToLower(string(det.Language))) != model.SigLangSigma {
 		web.Respond(w, r, http.StatusBadRequest, errors.New("that detection's engine doesn't support conversion"))
 		return
 	}

--- a/server/detectionshandler_test.go
+++ b/server/detectionshandler_test.go
@@ -3357,6 +3357,24 @@ func TestHandlerConvertContent(t *testing.T) {
 			},
 		},
 		{
+			// when creating a new detection, the engine isn't specified yet, but language is
+			Name:    "Good Language",
+			ReqBody: []byte(`{"language": "sigma", "content": "sigma goes here"}`),
+			InitMock: func(srv *Server, ctrl *gomock.Controller) {
+				eng := servermock.NewMockDetectionEngine(ctrl)
+				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+
+				eng.EXPECT().ConvertRule(gomock.Any(), &model.Detection{Content: "sigma goes here", Language: model.SigLangSigma}).Return("converted query", nil)
+			},
+			Code: 200,
+			Response: &ConvertContentResp{
+				Query: "converted query",
+			},
+			Logs: []EntryMatcher{
+				handled,
+			},
+		},
+		{
 			Name:    "Unknown Error",
 			ReqBody: []byte(`{"engine": "elastalert", "content": "sigma goes here"}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {


### PR DESCRIPTION
Restored the ack all dialog triggered by the Detection Panel on alerts. Updated tests.

When converting a rule from the New Detection page, the detection's engine isn't specified yet. Refactored a check to now allow the engine to be "elastalert" or the language to be "sigma" so the request can continue as it should. Added a new test just for this.