### PR TITLE
Faster/More Accurate Escalate

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -699,6 +699,8 @@ const huntComponent = {
             let payload = {
               fields: item,
               caseId: caseId,
+              acknowledge: acknowledge,
+              escalate: escalate,
             };
 
             if (detectionRelated) {

--- a/model/case.go
+++ b/model/case.go
@@ -127,6 +127,10 @@ type AttachEventCriteria struct {
 	DateRangeFormat string `json:"dateRangeFormat,omitempty" example:"2006/01/02 3:04:05 PM"`
 	// The timezone to use with the date range
 	Timezone string `json:"timezone,omitempty" example:"America/New_York"`
+	// Whether to attach events that are already escalated to a case: true = act on escalated events, false = act on unescalated events
+	Escalate bool `json:"escalate" example:"false"`
+	// Whether to attach events that are already acknowledged: true = act on acknowledged events, false = act on unacknowledged events
+	Acknowledge bool `json:"acknowledge" example:"true"`
 }
 
 func NewAttachEventCriteria() *AttachEventCriteria {

--- a/server/casehandler.go
+++ b/server/casehandler.go
@@ -172,6 +172,19 @@ func (h *CaseHandler) CreateEvents(w http.ResponseWriter, r *http.Request) {
 				queryParts = append(queryParts, fmt.Sprintf(`%s:"%v"`, k, v))
 			}
 		}
+
+	}
+
+	if body.Acknowledge {
+		queryParts = append(queryParts, `event.acknowledged:true`)
+	} else {
+		queryParts = append(queryParts, `NOT event.acknowledged:true`)
+	}
+
+	if body.Escalate {
+		queryParts = append(queryParts, `event.escalated:true`)
+	} else {
+		queryParts = append(queryParts, `NOT event.escalated:true`)
 	}
 
 	query := strings.Join(queryParts, " AND ")

--- a/server/casehandler_test.go
+++ b/server/casehandler_test.go
@@ -143,7 +143,7 @@ func TestHandlerCreateEvents(t *testing.T) {
 		},
 		{
 			Name:        "Escalate Single Event",
-			RequestBody: []byte(`{"caseId": "123", "dateRange": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "dateRangeFormat": "2006/01/02 3:04:05 PM", "fields": {"soc_id": "456", "event.severity_label": "low", "rule.uuid": "2102466"}}`),
+			RequestBody: []byte(`{"caseId": "123", "dateRange": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "dateRangeFormat": "2006/01/02 3:04:05 PM", "fields": {"soc_id": "456", "event.severity_label": "low", "rule.uuid": "2102466"}, "acknowledge": true, "escalate": true}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller, nonAsyncWG *sync.WaitGroup) (*sync.WaitGroup, *MockBroadcaster) {
 				fakeEventStore := srv.Eventstore.(*FakeEventstore)
 				mHostAuth := srv.Host.Authorizer.(*rbac.FakeAuthorizer)
@@ -192,7 +192,8 @@ func TestHandlerCreateEvents(t *testing.T) {
 
 				searchCriteria := fakeEventStore.InputSearchCriterias[0]
 				assert.Contains(t, searchCriteria.RawQuery, `_id:"456"`)
-				assert.NotContains(t, searchCriteria.RawQuery, ` AND `)
+				assert.Contains(t, searchCriteria.RawQuery, `event.acknowledged:true`)
+				assert.Contains(t, searchCriteria.RawQuery, `event.escalated:true`)
 				assert.NotContains(t, searchCriteria.RawQuery, ` OR `)
 
 				assert.Equal(t, "2024-12-03T14:31:35Z", searchCriteria.BeginTime.Format("2006-01-02T15:04:05Z"))

--- a/server/modules/elastic/elasticcasestore.go
+++ b/server/modules/elastic/elasticcasestore.go
@@ -681,30 +681,29 @@ func (store *ElasticCasestore) CreateRelatedEvents(ctx context.Context, events [
 		}
 
 		for _, event := range events {
-			for key, value := range event.Fields {
-				valueStr := fmt.Sprintf("%v", value)
-				if len(valueStr) == 0 || existingValueMap[valueStr] {
-					continue
-				}
+			for _, obs := range store.commonObservables {
+				value, exists := event.Fields[obs]
+				if exists {
+					valueStr := fmt.Sprintf("%v", value)
+					if len(valueStr) == 0 || existingValueMap[valueStr] {
+						continue
+					}
 
-				for _, obs := range store.commonObservables {
-					if key == obs {
-						artifact := model.NewArtifact()
-						artifact.CaseId = event.CaseId
-						artifact.Value = valueStr
-						artifact.ArtifactType = string(store.observables.GetType(artifact.Value))
-						artifact.GroupType = "evidence"
+					artifact := model.NewArtifact()
+					artifact.CaseId = event.CaseId
+					artifact.Value = valueStr
+					artifact.ArtifactType = string(store.observables.GetType(artifact.Value))
+					artifact.GroupType = "evidence"
 
-						existingValueMap[valueStr] = true
+					existingValueMap[valueStr] = true
 
-						_, err := store.CreateArtifact(ctx, artifact)
-						if err != nil {
-							logger.WithFields(log.Fields{
-								"key":          key,
-								"caseId":       event.CaseId,
-								"artifactType": artifact.ArtifactType,
-							}).WithError(err).Warn("automated observable extraction failed")
-						}
+					_, err := store.CreateArtifact(ctx, artifact)
+					if err != nil {
+						logger.WithFields(log.Fields{
+							"key":          obs,
+							"caseId":       event.CaseId,
+							"artifactType": artifact.ArtifactType,
+						}).WithError(err).Warn("automated observable extraction failed")
 					}
 				}
 			}


### PR DESCRIPTION
Pass Escalate and Acknowledge parameters to the endpoint so the backend search better aligns with the filters the user has set on the frontend.

Optimize how we process extracting Observables when attaching events to a case. Instead of iterating over every field, iterate only over the fields we're looking for.