### PR TITLE
Don't add Escalate/Acknowledge Queries When Id is Present

### DIFF
--- a/server/casehandler.go
+++ b/server/casehandler.go
@@ -173,18 +173,17 @@ func (h *CaseHandler) CreateEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-	}
+		if body.Acknowledge {
+			queryParts = append(queryParts, `event.acknowledged:true`)
+		} else {
+			queryParts = append(queryParts, `NOT event.acknowledged:true`)
+		}
 
-	if body.Acknowledge {
-		queryParts = append(queryParts, `event.acknowledged:true`)
-	} else {
-		queryParts = append(queryParts, `NOT event.acknowledged:true`)
-	}
-
-	if body.Escalate {
-		queryParts = append(queryParts, `event.escalated:true`)
-	} else {
-		queryParts = append(queryParts, `NOT event.escalated:true`)
+		if body.Escalate {
+			queryParts = append(queryParts, `event.escalated:true`)
+		} else {
+			queryParts = append(queryParts, `NOT event.escalated:true`)
+		}
 	}
 
 	query := strings.Join(queryParts, " AND ")

--- a/server/casehandler_test.go
+++ b/server/casehandler_test.go
@@ -99,6 +99,8 @@ func TestHandlerCreateEvents(t *testing.T) {
 				assert.Contains(t, searchCriteria.RawQuery, `event.severity_label:"low"`)
 				assert.Contains(t, searchCriteria.RawQuery, `rule.uuid:"2102466"`)
 				assert.Contains(t, searchCriteria.RawQuery, ` AND `)
+				assert.Contains(t, searchCriteria.RawQuery, `NOT event.acknowledged:true`)
+				assert.Contains(t, searchCriteria.RawQuery, `NOT event.escalated:true`)
 				assert.NotContains(t, searchCriteria.RawQuery, ` OR `)
 				assert.NotContains(t, searchCriteria.RawQuery, `count:"30"`)
 
@@ -192,9 +194,10 @@ func TestHandlerCreateEvents(t *testing.T) {
 
 				searchCriteria := fakeEventStore.InputSearchCriterias[0]
 				assert.Contains(t, searchCriteria.RawQuery, `_id:"456"`)
-				assert.Contains(t, searchCriteria.RawQuery, `event.acknowledged:true`)
-				assert.Contains(t, searchCriteria.RawQuery, `event.escalated:true`)
 				assert.NotContains(t, searchCriteria.RawQuery, ` OR `)
+				// searching for a single event doesn't care what state that event is in
+				assert.NotContains(t, searchCriteria.RawQuery, `event.acknowledged:true`)
+				assert.NotContains(t, searchCriteria.RawQuery, `event.escalated:true`)
 
 				assert.Equal(t, "2024-12-03T14:31:35Z", searchCriteria.BeginTime.Format("2006-01-02T15:04:05Z"))
 				assert.Equal(t, "2024-12-04T14:31:35Z", searchCriteria.EndTime.Format("2006-01-02T15:04:05Z"))


### PR DESCRIPTION
When an Id is present, just search for the one event. Acknowledged, escalated, doesn't matter. Only apply those search queries when doing a search expecting multiple results.