### PR TITLE
Escalating Fixes

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1160,7 +1160,7 @@
             </v-card-title>
             <v-card-text>
               {{ i18n.acknowledgeDetectionsRelatedAlertsText.replace('{ackManyVerb}', ackManyVerb) }}
-              <div v-if="ackManyArgs[0]?.count > maxEscalate" class="mt-4" v-html="i18n.acknowledgeDetectionsRelatedAlertsTextWarning.replaceAll('{maxEscalate}', maxEscalate.toLocaleString())"></div>
+              <div v-if="ackManyVerb === 'escalate' && ackManyArgs[0]?.count > maxEscalate" class="mt-4" v-html="i18n.acknowledgeDetectionsRelatedAlertsTextWarning.replaceAll('{maxEscalate}', maxEscalate.toLocaleString())"></div>
             </v-card-text>
             <v-card-actions>
               <v-spacer></v-spacer>

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -699,8 +699,8 @@ const huntComponent = {
             let payload = {
               fields: item,
               caseId: caseId,
-              acknowledge: acknowledge,
-              escalate: escalate,
+              acknowledged: this.isFilterToggleEnabled('acknowledged'),
+              escalated: this.isFilterToggleEnabled('escalated'),
             };
 
             if (detectionRelated) {

--- a/model/case.go
+++ b/model/case.go
@@ -128,9 +128,9 @@ type AttachEventCriteria struct {
 	// The timezone to use with the date range
 	Timezone string `json:"timezone,omitempty" example:"America/New_York"`
 	// Whether to attach events that are already escalated to a case: true = act on escalated events, false = act on unescalated events
-	Escalate bool `json:"escalate" example:"false"`
+	Escalated bool `json:"escalated" example:"false"`
 	// Whether to attach events that are already acknowledged: true = act on acknowledged events, false = act on unacknowledged events
-	Acknowledge bool `json:"acknowledge" example:"true"`
+	Acknowledged bool `json:"acknowledged" example:"true"`
 }
 
 func NewAttachEventCriteria() *AttachEventCriteria {

--- a/server/casehandler.go
+++ b/server/casehandler.go
@@ -173,13 +173,13 @@ func (h *CaseHandler) CreateEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		if body.Acknowledge {
+		if body.Acknowledged {
 			queryParts = append(queryParts, `event.acknowledged:true`)
 		} else {
 			queryParts = append(queryParts, `NOT event.acknowledged:true`)
 		}
 
-		if body.Escalate {
+		if body.Escalated {
 			queryParts = append(queryParts, `event.escalated:true`)
 		} else {
 			queryParts = append(queryParts, `NOT event.escalated:true`)

--- a/server/casehandler_test.go
+++ b/server/casehandler_test.go
@@ -32,7 +32,7 @@ func TestHandlerCreateEvents(t *testing.T) {
 	}{
 		{
 			Name:        "Sunny Day",
-			RequestBody: []byte(`{"caseId": "123", "dateRange": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "dateRangeFormat": "2006/01/02 3:04:05 PM", "fields": {"count": "30", "rule.name": "GPL NETBIOS SMB-DS IPC$ unicode share access", "event.module": "suricata", "event.severity_label": "low", "rule.uuid": "2102466"}}`),
+			RequestBody: []byte(`{"caseId": "123", "dateRange": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "dateRangeFormat": "2006/01/02 3:04:05 PM", "fields": {"count": "30", "rule.name": "GPL NETBIOS SMB-DS IPC$ unicode share access", "event.module": "suricata", "event.severity_label": "low", "rule.uuid": "2102466"}, "acknowledged": true, "escalated": true}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller, nonAsyncWG *sync.WaitGroup) (*sync.WaitGroup, *MockBroadcaster) {
 				fakeEventStore := srv.Eventstore.(*FakeEventstore)
 				mHostAuth := srv.Host.Authorizer.(*rbac.FakeAuthorizer)
@@ -99,8 +99,10 @@ func TestHandlerCreateEvents(t *testing.T) {
 				assert.Contains(t, searchCriteria.RawQuery, `event.severity_label:"low"`)
 				assert.Contains(t, searchCriteria.RawQuery, `rule.uuid:"2102466"`)
 				assert.Contains(t, searchCriteria.RawQuery, ` AND `)
-				assert.Contains(t, searchCriteria.RawQuery, `NOT event.acknowledged:true`)
-				assert.Contains(t, searchCriteria.RawQuery, `NOT event.escalated:true`)
+				assert.Contains(t, searchCriteria.RawQuery, `event.acknowledged:true`)
+				assert.Contains(t, searchCriteria.RawQuery, `event.escalated:true`)
+				assert.NotContains(t, searchCriteria.RawQuery, `NOT event.acknowledged:true`)
+				assert.NotContains(t, searchCriteria.RawQuery, `NOT event.escalated:true`)
 				assert.NotContains(t, searchCriteria.RawQuery, ` OR `)
 				assert.NotContains(t, searchCriteria.RawQuery, `count:"30"`)
 
@@ -145,7 +147,7 @@ func TestHandlerCreateEvents(t *testing.T) {
 		},
 		{
 			Name:        "Escalate Single Event",
-			RequestBody: []byte(`{"caseId": "123", "dateRange": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "dateRangeFormat": "2006/01/02 3:04:05 PM", "fields": {"soc_id": "456", "event.severity_label": "low", "rule.uuid": "2102466"}, "acknowledge": true, "escalate": true}`),
+			RequestBody: []byte(`{"caseId": "123", "dateRange": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "dateRangeFormat": "2006/01/02 3:04:05 PM", "fields": {"soc_id": "456", "event.severity_label": "low", "rule.uuid": "2102466"}, "acknowledged": true, "escalated": true}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller, nonAsyncWG *sync.WaitGroup) (*sync.WaitGroup, *MockBroadcaster) {
 				fakeEventStore := srv.Eventstore.(*FakeEventstore)
 				mHostAuth := srv.Host.Authorizer.(*rbac.FakeAuthorizer)
@@ -252,7 +254,15 @@ func TestHandlerCreateEvents(t *testing.T) {
 
 				return nil, nil
 			},
-			MockCheck:    func(srv *Server) {},
+			MockCheck: func(srv *Server) {
+				fakeEventStore := srv.Eventstore.(*FakeEventstore)
+
+				assert.Len(t, fakeEventStore.InputSearchCriterias, 1)
+
+				searchCriteria := fakeEventStore.InputSearchCriterias[0]
+				assert.Contains(t, searchCriteria.RawQuery, `NOT event.acknowledged:true`)
+				assert.Contains(t, searchCriteria.RawQuery, `NOT event.escalated:true`)
+			},
 			Code:         500,
 			ResponseBody: []byte(`The request could not be processed.`),
 			Logs: []EntryMatcher{


### PR DESCRIPTION
Only show the "We only escalate X number..." warning when escalating from the detections panel in alerts.

Use the filterToggle state when attaching related events rather than the ack/esc verbs that were passed in.

Tweak a few existing tests with better ack/esc query checking.