### PR TITLE
Light Theme Fixes

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -76,14 +76,6 @@
   padding-top: 0;
 }
 
-a.v-list-item.v-theme--dark {
-  color: white;
-}
-
-a.v-list-item.v-theme--light {
-  color: black;
-}
-
 .v-list-item > .v-list-item__prepend > i.fa {
   margin-right: 16px !important;
 }
@@ -162,7 +154,7 @@ td.expansion:last-child {
   font-size: 14px !important;
 }
 
-.theme-text, .deep-theme-text, .deep-theme-text * {
+.theme-text, .theme-links a, .theme-links a:active {
   color: rgb(var(--v-theme-text)) !important;
 }
 
@@ -246,11 +238,11 @@ th:hover, th.is-sorted, .solid {
   background-color: rgba(45, 45, 45, 0.25);
  }
 
- .theme--light.v-data-table tr:nth-of-type(even) {
+ .v-theme--light.v-data-table tr:nth-of-type(even) {
   background-color: rgba(230, 230, 230, 0.25);
  }
 
-.v-list-item__icon.v-list-group__header__append-icon .theme--light{
+.v-list-item__icon.v-list-group__header__append-icon .v-theme--light{
   color: white !important;
 }
 
@@ -339,11 +331,11 @@ a#title, a#title:visited, a#title:active, a#title:hover {
   min-width: auto !important;
 }
 
-.theme--light.v-application .case.tabular-row {
+.v-theme--light .case.tabular-row {
   border-bottom: 1px dotted rgba(0,0,0,.05);
 }
 
-.v-theme--dark.v-application .case.tabular-row {
+.v-theme--dark .case.tabular-row {
   border-bottom: 1px dotted hsla(0,0%,100%,.05);
 }
 
@@ -465,21 +457,21 @@ td {
   margin: 8px 0 8px 0;
 }
 
-.v-theme--dark.v-application .markdown-body td,
-.v-theme--dark.v-application  .markdown-body th {
+.v-theme--dark .markdown-body td,
+.v-theme--dark .markdown-body th {
   border: 1px solid hsla(0,0%,100%,.1);
 }
 
-.theme--light.v-application .markdown-body td,
-.theme--light.v-application  .markdown-body th {
+.v-theme--light .markdown-body td,
+.v-theme--light .markdown-body th {
   border: 1px solid rgba(0,0,0,.2);
 }
 
-.v-theme--dark.v-application .markdown-body tr:nth-child(even) {
+.v-theme--dark .markdown-body tr:nth-child(even) {
   background-color: hsla(0,0%,100%,.05);
 }
 
-.theme--light.v-application .markdown-body tr:nth-child(even) {
+.v-theme--light .markdown-body tr:nth-child(even) {
   background-color: rgba(0,0,0,.05);
 }
 
@@ -509,18 +501,18 @@ td {
   padding: 0.5em 0.7em !important;
 }
 
-.v-application .markdown-body pre code {
+.markdown-body pre code {
   display: block;
   background-color: revert !important;
   padding: 0 !important;
 }
 
-.theme--light.v-application .markdown-body pre {
+.v-theme--light .markdown-body pre {
   background-color: rgba(0,0,0,.05);
   border-radius: 0.25em;
 }
 
-.v-theme--dark.v-application .markdown-body pre {
+.v-theme--dark .markdown-body pre {
   background-color: hsla(0,0%,100%,.1);
   border-radius: 0.25em;
 }
@@ -570,7 +562,7 @@ td {
   background-color: rgb(var(--v-theme-drawer_background));
 }
 
-.theme--light.v-card.config-setting {
+.v-theme--light.v-card.config-setting {
   background-color: rgb(var(--v-theme-drawer_background));
 }
 
@@ -578,7 +570,7 @@ td {
   background-color: rgb(var(--v-theme-drawer_background-lighten-1));
 }
 
-.theme--light.editing .v-input__slot {
+.v-theme--light.editing .v-input__slot {
   background-color: rgb(var(--v-theme-drawer_background-lighten-1));
 }
 
@@ -631,7 +623,7 @@ td {
   color: rgba(255, 255, 255, 0.5);
 }
 
-.theme--light .resolved-host {
+.v-theme--light .resolved-host {
   color: rgba(0, 0, 0, 0.5);
 }
 
@@ -832,7 +824,7 @@ tbody tr:hover {
   background-color: rgba(45, 45, 45, 0.25) !important;
 }
 
-.theme--light tbody tr:hover:nth-of-type(even) {
+.v-theme--light tbody tr:hover:nth-of-type(even) {
   background-color: rgba(230, 230, 230, 0.25) !important;
 }
 

--- a/html/index.html
+++ b/html/index.html
@@ -33,7 +33,7 @@
           </v-app-bar-nav-icon>
           <v-toolbar-title>
             <a href="/" id="title" data-aid="nav_overview">
-              <img class="pt-1" :title="i18n.product" :alt="i18n.product" height="45" src="images/so-logo.svg"></v-img>
+              <img class="pt-1" :title="i18n.product" :alt="i18n.product" height="45" src="images/so-logo.svg"></img>
             </a>
           </v-toolbar-title>
           <v-spacer></v-spacer>
@@ -197,7 +197,7 @@
             </router-link>
           </span>
         </v-footer>
-        <v-navigation-drawer v-model="toolbar" width="200" clipped overflow app>
+        <v-navigation-drawer v-model="toolbar" width="200" clipped overflow app class="theme-links">
           <v-list density="compact" :disabled="forceUserOtp">
             <v-list-item data-aid="nav_overview" @click="" to="/">
               <template #prepend>
@@ -893,7 +893,7 @@
         </v-row>
         <v-menu v-model="quickActionVisible" :target="quickActionTarget" :data-aid="'context_menu_' + category">
           <div class="d-flex">
-            <v-list id="hunt-quick-action" v-model:opened="quickActionsOpen">
+            <v-list id="hunt-quick-action" v-model:opened="quickActionsOpen" class="v-theme--dark">
               <v-list-item density="compact" id="actionFilterInclude" :to="filterRouteInclude" v-bind:title.attr="i18n.filterIncludeHelp" :data-aid="'context_menu_filter_include_' + category" active-class="">
                 <template #prepend>
                   <v-icon :alt="i18n.filterInclude" class="theme-icon">fa-search-plus</v-icon>
@@ -958,7 +958,7 @@
                   {{ i18n.groupNew }}
                 </v-list-item-title>
               </v-list-item>
-              <v-list-group density="compact" :value="'numeric'" @click.stop v-if="quickActionVisible && quickActionIsNumeric" :data-aid="'context_menu_compare_' + category" class="deep-theme-text">
+              <v-list-group density="compact" :value="'numeric'" @click.stop v-if="quickActionVisible && quickActionIsNumeric" :data-aid="'context_menu_compare_' + category">
                 <template #activator="{ props, isOpen }">
                   <v-list-item v-bind="props" class="v-list-item--active">
                     <template #prepend>
@@ -997,7 +997,7 @@
                   </v-list-item-title>
                 </v-list-item>
               </v-list-group>
-              <v-list-group density="compact" :value="'clipboard'" @click.stop class="deep-theme-text" :data-aid="'context_menu_clipboard_' + category">
+              <v-list-group density="compact" :value="'clipboard'" @click.stop :data-aid="'context_menu_clipboard_' + category">
                 <template #activator="{ props, isOpen }">
                   <v-list-item v-bind="props" class="v-list-item--active">
                     <template #prepend>
@@ -1044,7 +1044,7 @@
                   </v-list-item-title>
                 </v-list-item>
               </v-list-group>
-              <v-list-group v-if="!!actions && actions.length" :value="'actions'" density="compact" @click.stop class="deep-theme-text" :data-aid="'context_menu_quickaction_' + category">
+              <v-list-group v-if="!!actions && actions.length" :value="'actions'" density="compact" @click.stop :data-aid="'context_menu_quickaction_' + category">
                 <template #activator="{ props, isOpen }">
                   <v-list-item v-bind="props" class="v-list-item--active">
                     <template #prepend>
@@ -1066,7 +1066,7 @@
                     <template #prepend>
                       <v-icon :alt="action.name" class="solid" class="theme-icon">{{ action.icon }}</v-icon>
                     </template>
-                    <v-list-item-title class="theme-text">
+                    <v-list-item-title>
                       {{ $root.localizeMessage(action.name) }}
                     </v-list-item-title>
                   </v-list-item>
@@ -1080,19 +1080,19 @@
           <v-list id="hunt-escalate-menu" color="secondary">
             <v-list-item id="escalateNewMenuItem" density="compact" @click="ack(escalationItem, true, true, null, escalationGroupIdx, escalatingDetectionEvents)" v-bind:title.attr="i18n.escalateNewCaseHelp" :data-aid="'escalate_menu_new_' + category">
               <template #prepend>
-                <v-icon :alt="i18n.escalateNewCase" color="white">fa-plus</v-icon>
+                <v-icon :alt="i18n.escalateNewCase">fa-plus</v-icon>
               </template>
-              <v-list-item-title class="text-white">
+              <v-list-item-title class="theme-text">
                 {{ i18n.escalateNewCase }}
               </v-list-item-title>
             </v-list-item>
             <v-divider></v-divider>
-            <v-list-subheader class="text-white">{{ i18n.escalateExistingCase }}</v-list-subheader>
+            <v-list-subheader class="theme-text">{{ i18n.escalateExistingCase }}</v-list-subheader>
             <v-list-item v-for="socCase in mruCases" density="compact" v-bind:title.attr="i18n.escalateExistingCaseHelp" @click="ack(escalationItem, true, true, socCase.id, escalationGroupIdx, escalatingDetectionEvents)" :data-aid="'escalate_menu_existing_' + category">
               <template #prepend>
-                <v-icon :alt="i18n.escalateExistingCase" color="white">fa-link</v-icon>
+                <v-icon :alt="i18n.escalateExistingCase">fa-link</v-icon>
               </template>
-              <v-list-item-title class="text-white">
+              <v-list-item-title class="theme-text">
                 {{ formatCaseSummary(socCase) }}
               </v-list-item-title>
             </v-list-item>
@@ -3042,7 +3042,7 @@
             </v-alert>
           </v-col>
         </v-row>
-        <v-menu v-model="quickActionVisible" :position-x="quickActionX" :position-y="quickActionY" absolute data-aid="job_details_context_menu">
+        <v-menu v-model="quickActionVisible" :position-x="quickActionX" :position-y="quickActionY" absolute data-aid="job_details_context_menu" class="text-white">
           <v-list id="job-common-action" color="secondary">
             <v-list-item id="actionCopyValue" density="compact" @click="$root.copyToClipboard(quickActionValue)" data-aid="job_details_context_menu_copy">
               <template #prepend>


### PR DESCRIPTION
Nearly a dozen fixes by properly renaming .theme--light to .v-theme--light and removing .v-application from a few selectors. This brings back separator lines in cases history tab, multiple mark down fixes, resolved DNS names, and alternate row highlighting.

Ensure QuickAction menu is always in dark mode.