### PR TITLE
Local Storage and Objects

### DIFF
--- a/html/js/routes/jobs.js
+++ b/html/js/routes/jobs.js
@@ -75,12 +75,14 @@ routes.push({ path: '/jobs', name: 'jobs', component: {
       }
     },
     saveLocalSettings() {
-      localStorage['settings.jobs.sortBy'] = this.sortBy;
+      localStorage['settings.jobs.sortBy'] = JSON.stringify(this.sortBy);
       localStorage['settings.jobs.itemsPerPage'] = this.itemsPerPage;
     },
     loadLocalSettings() {
       if (localStorage['settings.jobs.sortBy']) {
-        this.sortBy = localStorage['settings.jobs.sortBy'];
+        try {
+          this.sortBy = JSON.parse(localStorage['settings.jobs.sortBy']);
+        } catch {}
         this.itemsPerPage = parseInt(localStorage['settings.jobs.itemsPerPage']);
       }
       this.form.sensorId = localStorage['settings.jobs.addJobForm.sensorId'];


### PR DESCRIPTION
sortBy is an array. When we save to localStorage, we need to save it as a string otherwise the value becomes `[object Object]` which breaks the headers of the table when the value is used onLoad. When storing, stringify. When reading from storage, parse. This does not effect other components as they break up how sort is stored by having "sortby" and "sortDesc" and not attempting to store objects.

Anybody currently affected by this bug can clear their cache or more specifically open DevTools > Application > Storage > Local storage > [soc url] and find the key "settings.jobs.sortBy" and delete it. Then refresh the page.