### PR TITLE
Performance Profiling

### DIFF
--- a/web/performance.go
+++ b/web/performance.go
@@ -1,0 +1,81 @@
+//go:build debug
+
+package web
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"time"
+
+	"github.com/apex/log"
+)
+
+const (
+	rootDir = "/tmp"
+)
+
+func GenPerformanceMetrics(name string, mem bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nowMicro := time.Now().UnixMicro()
+
+			logger := log.WithFields(log.Fields{
+				"performanceMetrics": name,
+				"micro":              nowMicro,
+			})
+
+			profName := fmt.Sprintf("%s_%d", name, nowMicro)
+
+			prof := pprof.NewProfile(profName)
+			if mem {
+				prof.Add(runtime.MemProfileRecord{}, 0)
+			}
+
+			cpuFilename := fmt.Sprintf("%s_cpu_%d.pprof", name, nowMicro)
+			cpuFilename = filepath.Join(rootDir, cpuFilename)
+
+			// Start CPU profiling
+			f, err := os.Create(cpuFilename)
+			if err != nil {
+				logger.WithError(err).Error("failed to create CPU profile file")
+				return
+			}
+			defer f.Close()
+
+			err = pprof.StartCPUProfile(f)
+			if err != nil {
+				logger.WithError(err).Error("failed to start CPU profile, completing request anyway")
+			} else {
+				defer pprof.StopCPUProfile()
+			}
+
+			next.ServeHTTP(w, r)
+
+			if mem {
+				memFilename := fmt.Sprintf("%s_mem_%d.pprof", name, nowMicro)
+				memFilename = filepath.Join(rootDir, memFilename)
+
+				// Create memory profile
+				memProf, err := os.Create(memFilename)
+				if err != nil {
+					logger.WithError(err).Error("failed to create memory profile file")
+					return
+				}
+				defer memProf.Close()
+
+				runtime.GC() // Force garbage collection to get accurate memory profile
+
+				err = pprof.WriteHeapProfile(memProf)
+				if err != nil {
+					logger.WithError(err).Error("failed to write memory profile")
+					return
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This single file is only included in the build if the "debug" build flag is specified so by default the /debug/pprof endpoints are excluded from the build.

When included, this not only attaches the /debug/pprof endpoints, but this also provides a new middleware we can apply to endpoints in the app so that any calls to that endpoint will result in a cpu profile (and optional memory profile) being generated in your /tmp folder.

These tools are for the devs and should not make it into a production release. Although the performance impact of such an endpoint being released would be negligible, the security implications of somebody accessing the memory of a running service are too great to just add auth to the endpoint. This and it's accompanying Cypress test are designed to ensure there will not be any debug or pprof code in the binary coming out of CI/CD.