### PR TITLE
Update PCAP Quick Action Menu

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -970,3 +970,15 @@ ul ul ul {
 #external-tools-list a.v-list-item {
   padding-right: 4px;
 }
+
+#job-common-action {
+  padding-bottom: 0px;
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+#job-quick-action {
+  padding-top: 0px;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -2246,7 +2246,7 @@
                           {{ $root.mgmtMac }}
                           <v-btn icon variant="text" class="mx-2" density="compact" size="small" @click="$root.copyToClipboard($root.mgmtMac)" data-aid="terms_license_copy_mac">
                             <v-icon>fa-copy</v-icon>
-                          </v-btn>      
+                          </v-btn>
                         </v-col>
                       </v-row>
                       <span v-if="$root.licenseKey && ($root.licenseStatus != LICENSE_STATUS_UNPROVISIONED && $root.licenseStatus != LICENSE_STATUS_INVALID)">
@@ -3060,8 +3060,8 @@
             </v-alert>
           </v-col>
         </v-row>
-        <v-menu v-model="quickActionVisible" :position-x="quickActionX" :position-y="quickActionY" absolute data-aid="job_details_context_menu" class="text-white">
-          <v-list id="job-common-action" color="secondary">
+        <v-menu v-model="quickActionVisible" :target="quickActionTarget" data-aid="job_details_context_menu" class="text-white remove-spacer">
+          <v-list id="job-common-action" class="v-theme--dark" color="secondary">
             <v-list-item id="actionCopyValue" density="compact" @click="$root.copyToClipboard(quickActionValue)" data-aid="job_details_context_menu_copy">
               <template #prepend>
                 <v-icon color="white">fa-copy</v-icon>
@@ -3071,7 +3071,7 @@
               </v-list-item-title>
             </v-list-item>
           </v-list>
-          <v-list id="job-quick-action" color="secondary">
+          <v-list id="job-quick-action" class="v-theme--dark" color="secondary">
             <template #activator>
               <v-icon color="white">fa-external-link-alt</v-icon>
               <v-list-item-title class="text-white">
@@ -3080,11 +3080,11 @@
             </template>
             <template v-for="action in actions" :key="action.link">
               <v-list-item density="compact" class="custom-quick-action-button" v-if="action.enabled" :href="action.background ? '' : action.linkFormatted"
-                :title="$root.localizeMessage(action.description)" :target="$root.target(action.target)" @click="$root.performAction($event, action)" :data-aid="'job_details_context_menu_action' + action.name">
+                :target="$root.target(action.target)" @click="$root.performAction($event, action)" :data-aid="'job_details_context_menu_action' + action.name">
                 <template #prepend>
                   <v-icon :alt="action.name" color="white">{{ action.icon }}</v-icon>
                 </template>
-                <v-list-item-title class="text-white">
+                <v-list-item-title class="text-white" :title="$root.localizeMessage(action.description)">
                   {{ $root.localizeMessage(action.name) }}
                 </v-list-item-title>
               </v-list-item>

--- a/html/js/routes/job.js
+++ b/html/js/routes/job.js
@@ -31,8 +31,7 @@ routes.push({ path: '/job/:jobId', name: 'job', component: {
     footerProps: { 'items-per-page-options': [10,50,250,1000] },
     count: 500,
     quickActionVisible: false,
-    quickActionX: 0,
-    quickActionY: 0,
+    quickActionTarget: [],
     quickActionEvent: null,
     quickActionField: "",
     quickActionValue: "",
@@ -103,8 +102,7 @@ routes.push({ path: '/job/:jobId', name: 'job', component: {
         this.quickActionEvent = event;
         this.quickActionField = field;
         this.quickActionValue = value;
-        this.quickActionX = domEvent.clientX;
-        this.quickActionY = domEvent.clientY;
+        this.quickActionTarget = [domEvent.clientX, domEvent.clientY];
         this.$nextTick(() => {
           this.quickActionVisible = true;
         });


### PR DESCRIPTION
Instead of specifying X and Y separately, combine them into an array and use `target` for positioning the menu. The `absolute` directive is no longer needed.

Fix a few styles so the 2x v-lists in the menu look like 1 cohesive list.

Ensure description appears as hover text.

Ensure the quick action menu looks dark in light mode.