### PR TITLE
Fix Always Passing Date Parameters to Backend

### DIFF
--- a/html/js/routes/jobs.js
+++ b/html/js/routes/jobs.js
@@ -150,26 +150,31 @@ routes.push({ path: '/jobs', name: 'jobs', component: {
             protocol = protocol.toLowerCase();
           }
 
-          let beginDate = ''
-          let endDate = '';
+          let filter = {
+            importId: importId,
+            protocol: protocol,
+            srcIp: srcIp,
+            srcPort: parseInt(srcPort),
+            dstIp: dstIp,
+            dstPort: parseInt(dstPort),
+          };
+
+          let beginDate;
+          let endDate;
           if (timeframe) {
             const [beginTime, endTime] = timeframe.split(' - ', 2);
             beginDate = moment(beginTime, this.i18n.timePickerFormat).format(this.i18n.timestampFormat);
             endDate = moment(endTime, this.i18n.timePickerFormat).format(this.i18n.timestampFormat);
           }
 
+          if (beginDate && endDate) {
+            filter.beginTime = beginDate;
+            filter.endTime = endDate;
+          }
+
           const response = await this.$root.papi.post('job/', {
             nodeId: sensorId,
-            filter: {
-              importId: importId,
-              protocol: protocol,
-              srcIp: srcIp,
-              srcPort: parseInt(srcPort),
-              dstIp: dstIp,
-              dstPort: parseInt(dstPort),
-              beginTime: beginDate,
-              endTime: endDate
-            }
+            filter: filter,
           });
           this.$root.populateUserDetails(response.data, "userId", "owner");
           this.jobs.push(response.data);

--- a/html/js/routes/jobs.test.js
+++ b/html/js/routes/jobs.test.js
@@ -45,3 +45,26 @@ test('addJob', async () => {
 
 	expect(comp.jobs).toEqual(['addJobResponse']);
 });
+
+test('addJob - minimal', async () => {
+	resetPapi();
+	const mock = mockPapi('post', { data: 'addJobResponse' });
+	comp.jobs = [];
+
+	await comp.addJob('manager');
+
+	expect(mock).toHaveBeenCalledTimes(1);
+	expect(mock).toHaveBeenCalledWith('job/', {
+		nodeId: 'manager',
+		filter: {
+			importId: undefined,
+			protocol: undefined,
+			srcIp: undefined,
+			srcPort: NaN,
+			dstIp: undefined,
+			dstPort: NaN,
+		}
+	});
+
+	expect(comp.jobs).toEqual(['addJobResponse']);
+});


### PR DESCRIPTION
The old approach took advantage of the fact that undefined properties, when converted to JSON, are left out. The updated approach always specified the `beginDate` and `endDate` fields, if no value was entered by the user an empty string was used and this threw a 400 from the backend because they don't parse as a valid date. The new approach conditionally adds them if the user set their values.

Added a regression test.