### PR TITLE
Advanced Still Toggled After Reload

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -74,7 +74,7 @@ const i18n = {
       addObservable: 'Add as new observable...',
       addSuccessful: 'Added successfully!',
       address: 'Address',
-      advanced: 'Temporarily enable advanced interface features',
+      advanced: 'Enable advanced interface features',
       ago: 'ago',
       aiGenSummary: 'AI-Generated Summary',
       aiSummaryStale: 'This AI summary was generated for a previous version of the detection and may not be accurate.',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -235,6 +235,7 @@ const huntComponent = {
     'autohunt': 'saveLocalSettings',
     'autoRefreshInterval': 'resetRefreshTimer',
     'showDetailsPanel': 'saveLocalSettings',
+    'advanced': 'saveLocalSettings',
   },
   methods: {
     moment: moment,
@@ -2204,6 +2205,7 @@ const huntComponent = {
       this.saveSetting('relativeTimeUnit', this.relativeTimeUnit, this.params['relativeTimeUnit']);
       this.saveSetting('autohunt', this.autohunt, true);
       this.saveSetting('showDetailsPanel', this.showDetailsPanel, this.isCategory('alerts'));
+      this.saveSetting('advanced', this.advanced, false);
     },
     loadLocalSettings() {
       // Global settings
@@ -2224,6 +2226,7 @@ const huntComponent = {
       if (localStorage[prefix + '.relativeTimeUnit']) this.relativeTimeUnit = parseInt(localStorage[prefix + '.relativeTimeUnit']);
       if (localStorage[prefix + '.autohunt']) this.autohunt = localStorage[prefix + '.autohunt'] == 'true';
       if (localStorage[prefix + '.showDetailsPanel']) this.showDetailsPanel = localStorage[prefix + '.showDetailsPanel'] == 'true';
+      if (localStorage[prefix + '.advanced']) this.advanced = localStorage[prefix + '.advanced'] == 'true';
 
       if (localStorage['settings.case.mruCases']) this.mruCases = JSON.parse(localStorage['settings.case.mruCases']);
     },


### PR DESCRIPTION
When toggled, save advanced setting state to local settings and restore on page load. Affects Alerts and Cases.

Changed the advanced toggle's label to remove the word "Temporarily" as it sticks until toggled off.