### PR TITLE
Occasionally a detection summary or AI summary contains a long unbrok…

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -986,3 +986,9 @@ ul ul ul {
 [data-aid="grid_members_screen"] .v-btn.v-theme--light {
   background-color: rgb(var(--v-theme-drawer_background)) !important;
 }
+
+.hard-wrap {
+  word-break: break-word;
+  overflow-wrap: break-word;
+  hyphens: none;
+}

--- a/html/pages/detection-panel.html
+++ b/html/pages/detection-panel.html
@@ -13,7 +13,7 @@
 				</h3>
 				<div class="contrast-bg pa-4">
 					<div class="header">{{i18n.summary}} <v-icon v-if="showAiSummary()" :title="i18n.aiGenSummary" class="unset-vertical-align" data-aid="detection_summary_ai_indicator">fa-flask</v-icon></div>
-					<div class="summary" data-aid="detection_panel_ai_summary_display" v-if="showAiSummary()">
+					<div class="summary hard-wrap" data-aid="detection_panel_ai_summary_display" v-if="showAiSummary()">
 						{{ detection.aiSummary }}
 						<div class="font-weight-thin mt-2" v-if="detection.isAiSummaryStale" data-aid="detection_panel_summary_stale">
 							({{ i18n.aiSummaryStale }})


### PR DESCRIPTION
…en string such as a registry key or a header value that doesn't quite fit in the narrow box of the Detection Panel. Added a new class to break up the string and ensure it stays technically correct by not adding a hyphen.