### PR TITLE
Detection Panel Fixes

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -992,3 +992,7 @@ ul ul ul {
   overflow-wrap: break-word;
   hyphens: none;
 }
+
+.pos-rel {
+  position: relative;
+}

--- a/html/js/components/detection-panel.js
+++ b/html/js/components/detection-panel.js
@@ -36,6 +36,7 @@ components.push({
 				loading: false,
 				extractedSummary: '',
 				newOverride: null,
+				newOverrideValid: false,
 				overrideHeaders: {
 					'elastalert': [
 						{},
@@ -58,6 +59,7 @@ components.push({
 				rules: {
 					required: value => (value && value.length > 0) || this.$root.i18n.required,
 					number: value => (!isNaN(+value) && Number.isInteger(parseFloat(value))) || this.$root.i18n.required,
+					noteLengthLimit: value => (value.length <= MAX_OVERRIDE_NOTE_LENGTH) || this.$root.i18n.ruleMaxLen,
 					cidrFormat: value => (!value ||
 						/^!?\$[a-z_][a-z0-9_]*$/i.test(value) || // Suricata variable
 						/^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\/(3[0-2]|[12]\d|\d)$/.test(value) || // IPv4 CIDR
@@ -546,7 +548,7 @@ components.push({
 			},
 			closeDetectionPanel() {
 				this.emit('close');
-			}
+			},
 		},
 	}
 });

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -1147,12 +1147,6 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 
 			return out;
 		},
-		createOverrideTypeChange() {
-			// reset the form, but we want the selected type to persist
-			const t = this.newOverride.type;
-			this.$refs.OverrideCreate.reset();
-			this.newOverride.type = t;
-		},
 		cancelNewOverride() {
 			this.$refs.OverrideCreate.reset();
 			this.newOverride = null;

--- a/html/pages/detection-panel.html
+++ b/html/pages/detection-panel.html
@@ -1,409 +1,411 @@
 <div v-if="detection" id="detection-col" class="theme-background theme-text pa-0">
-	<v-expansion-panels multiple focusable v-model="panels" class="mt-2">
-		<v-expansion-panel>
-			<v-expansion-panel-title expand-icon="fa-chevron-down" collapse-icon="fa-chevron-up" data-aid="detection_panel_overview_header">
-				<h3>
-					{{ i18n.overview }}
-				</h3>
-			</v-expansion-panel-title>
-			<v-expansion-panel-text>
-				<h3 class="my-2 hard-wrap" data-aid="detection_panel_title">
-					<v-icon class="va-baseline" color="success" data-aid="detection_panel_title_thumbtack">fa-thumbtack</v-icon>
-					{{detection.title}}
-				</h3>
-				<div class="contrast-bg pa-4">
-					<div class="header">{{i18n.summary}} <v-icon v-if="showAiSummary()" :title="i18n.aiGenSummary" class="unset-vertical-align" data-aid="detection_summary_ai_indicator">fa-flask</v-icon></div>
-					<div class="summary hard-wrap" data-aid="detection_panel_ai_summary_display" v-if="showAiSummary()">
-						{{ detection.aiSummary }}
-						<div class="font-weight-thin mt-2" v-if="detection.isAiSummaryStale" data-aid="detection_panel_summary_stale">
-							({{ i18n.aiSummaryStale }})
-						</div>
-					</div>
-					<div class="summary" v-else data-aid="detection_panel_summary_display">
-						{{ extractedSummary }}
-					</div>
-				</div>
-				<div class="quicklinks pt-2">
-					<v-btn id="detection-panel-ack" icon variant="text" size="small" @click="ack(false)" data-aid="detection_panel_ack" :title="i18n.alertAcknowledge">
-						<v-icon :color="ackColor">
-							<span>
-								<i class="fas fa-bell fa-stack-1x"></i>
-								<i class="fas fa-plus fa-stack-1x icon-overlay-top-right"></i>
-							</span>
-						</v-icon>
-					</v-btn>
-					<v-btn id="detection-panel-escalate" icon variant="text" size="small" @click="escalate($event)" data-aid="detection_panel_escalate" :title="i18n.escalate">
-						<v-icon color="primary">
-							<span>
-								<i class="fas fa-triangle-exclamation fa-stack-1x"></i>
-								<i class="fas fa-plus fa-stack-1x icon-overlay-top-right"></i>
-							</span>
-						</v-icon>
-					</v-btn>
-					<v-btn id="detection-panel-open" icon variant="text" size="small" class="no-link" :to="{name:'detection',params: {id:detection.id}}" target="_blank" data-aid="detection_panel_open_detection" :title="i18n.viewDetection">
-						<v-icon color="primary">fa-magnifying-glass</v-icon>
-					</v-btn>
-				</div>
-				<div class="pa-4">
-					<span>
-						<div class="ops-header mt-0">
-							{{ i18n.status }}: {{ detection.isEnabled ? i18n.enabled : i18n.disabled }}
-						</div>
-						<div data-aid="detection_panel_enabled_toggle">
-							<v-switch id="detection-enabled-edit" inset v-model="detection.isEnabled" class="no-details" @change="toggleStatus()"></v-switch>
-						</div>
-					</span>
-				</div>
-			</v-expansion-panel-text>
-		</v-expansion-panel>
-		<v-expansion-panel>
-			<v-expansion-panel-title expand-icon="fa-chevron-down" collapse-icon="fa-chevron-up" data-aid="detection_panel_tuning_header">
-				<h3>
-					{{ i18n.tuning }}
-				</h3>
-			</v-expansion-panel-title>
-			<v-expansion-panel-text>
-				<v-row v-if="canAddOverride()">
-					<v-col>
-						<v-toolbar class="elevation-0 theme-background-lighten-1" fixed>
-							<v-btn variant="flat" class="ml-3" color="primary" id="add-override-button" style="text-decoration: none; cursor: 'pointer'" @click="createNewOverride()" data-aid="detection_panel_new_override">
-								<v-icon :title="i18n.create">fa-plus</v-icon>
-							</v-btn>
-						</v-toolbar>
-					</v-col>
-				</v-row>
-				<div v-if="newOverride != null" class="ma-3">
-					<v-form ref="OverrideCreate" v-model="newOverrideValid">
-						<span data-aid="detection_panel_new_override_type_select">
-							<v-select variant="underlined" id="new-override-type" v-model="newOverride.type" :items="overrideTypes[this.detection.engine]" persistent-hint :hint="i18n.type" @change="createOverrideTypeChange()"></v-select>
-						</span>
-						<div v-if="!!newOverride.type && detection.engine === 'suricata'">
-							<v-text-field variant="underlined" v-if="newOverride.type === 'modify'" id="new-override-regex-edit" v-model="newOverride.regex" :rules="[rules.required]" persistent-hint :hint="i18n.regex" data-aid="detection_panel_new_override_regex_input"></v-text-field>
-							<v-text-field variant="underlined" v-if="newOverride.type === 'modify'" id="new-override-value-edit" v-model="newOverride.value" :rules="[rules.required]" persistent-hint :hint="i18n.value" data-aid="detection_panel_new_override_value_input"></v-text-field>
-							<span data-aid="detection_panel_new_override_threshold_type_select">
-								<v-select variant="underlined" v-if="newOverride.type === 'threshold'" id="new-override-threshold-type-edit" v-model="newOverride.thresholdType" :items="thresholdTypes" :rules="[rules.required]" persistent-hint :hint="i18n.thresholdType"></v-select>
-							</span>
-							<span data-aid="detection_panel_new_override_track_type_select">
-								<v-select variant="underlined" v-if="['threshold', 'suppress'].includes(newOverride.type)" id="new-override-track-edit" v-model="newOverride.track" :items="trackOptions[newOverride.type]" :rules="[rules.required]" persistent-hint :hint="i18n.track"></v-select>
-							</span>
-							<v-text-field variant="underlined" v-if="newOverride.type === 'suppress'" id="new-override-ip-edit" v-model="newOverride.ip" :rules="[rules.required, rules.cidrFormat]" persistent-hint :hint="i18n.ipCidr" data-aid="detection_panel_new_override_suppress_ip_input">
-								<template #append>
-									<router-link class="theme-icon" :to="{ name: 'config', query: { s: 'suricata.config.vars', a: '1', e: '1' }}" target="_blank" data-aid="detection_panel_new_override_ip_edit_config_shortcut">
-										<v-icon>fa fa-gear</v-icon>
-									</router-link>
-								</template>
-							</v-text-field>
-							<v-text-field variant="underlined" v-if="newOverride.type === 'threshold'" id="new-override-count-edit" v-model="newOverride.count" :rules="[rules.required, rules.number]" persistent-hint :hint="i18n.count" data-aid="detection_panel_new_override_threshold_count_input"></v-text-field>
-							<v-text-field variant="underlined" v-if="newOverride.type === 'threshold'" id="new-override-seconds-edit" v-model="newOverride.seconds" :rules="[rules.required, rules.number]" persistent-hint :hint="i18n.secondsLabel" data-aid="detection_panel_new_override_threshold_seconds_input"></v-text-field>
-						</div>
-						<div v-if="!!newOverride.type && detection.engine === 'elastalert'">
-							<v-textarea variant="underlined" v-if="newOverride.type === 'customFilter'" id="new-override-custom-filter-edit" v-model="newOverride.customFilter" :rules="[rules.required]" auto-grow rows="2" persistent-hint :hint="i18n.customFilter" data-aid="detection_panel_new_override_filter_input"></v-textarea>
-						</div>
-						<div v-if="!!newOverride.type">
-							<v-text-field variant="underlined" id="new-override-note-edit" v-model="newOverride.note" :rules="[rules.noteLengthLimit]" persistent-hint :hint="i18n.note" data-aid="detection_panel_new_override_note_input"></v-text-field>
-						</div>
-						<div v-if="newOverride" class="d-flex align-center align-self-end text-body-2 mt-2">
-							<div class="justify-end">
-								<v-btn id="detection-create-cancel" variant="text" size="small" color="primary" class="align-self-end" @click="newOverride = null" data-aid="detection_panel_new_override_cancel">
-									{{ i18n.cancel }}
-								</v-btn>
-								<v-btn v-if="newOverride.type" id="detection-create-create" :disabled="!newOverrideValid" variant="text" size="small" color="primary" class="align-self-end" @click="addNewOverride()" data-aid="detection_panel_new_override_save">
-									{{ i18n.create }}
-								</v-btn>
-								<v-btn variant="text" size="small" icon class="theme-text" :target="$root.target('so-help')" :href="$root.parameters.docsUrl + 'detections.html#managing-detections'" :title="i18n.overrideDocumentationHelp" data-aid="detection_panel_override_help_new">
-									<v-icon class="mb-1">fa-regular fa-circle-question</v-icon>
-								</v-btn>
+	<div class="pos-rel">
+		<v-expansion-panels multiple focusable v-model="panels" class="mt-2">
+			<v-expansion-panel>
+				<v-expansion-panel-title expand-icon="fa-chevron-down" collapse-icon="fa-chevron-up" data-aid="detection_panel_overview_header">
+					<h3>
+						{{ i18n.overview }}
+					</h3>
+				</v-expansion-panel-title>
+				<v-expansion-panel-text>
+					<h3 class="my-2 hard-wrap" data-aid="detection_panel_title">
+						<v-icon class="va-baseline" color="success" data-aid="detection_panel_title_thumbtack">fa-thumbtack</v-icon>
+						{{detection.title}}
+					</h3>
+					<div class="contrast-bg pa-4">
+						<div class="header">{{i18n.summary}} <v-icon v-if="showAiSummary()" :title="i18n.aiGenSummary" class="unset-vertical-align" data-aid="detection_summary_ai_indicator">fa-flask</v-icon></div>
+						<div class="summary hard-wrap" data-aid="detection_panel_ai_summary_display" v-if="showAiSummary()">
+							{{ detection.aiSummary }}
+							<div class="font-weight-thin mt-2" v-if="detection.isAiSummaryStale" data-aid="detection_panel_summary_stale">
+								({{ i18n.aiSummaryStale }})
 							</div>
 						</div>
-					</v-form>
-				</div>
-				<v-data-table :sort-by="sortBy" @update:sort-by="val => sortBy = val" must-sort :headers="overrideHeaders[detection.engine]"
-					:items="detection.overrides || []" item-value="index" show-expand :custom-sort="sortOverrides" hide-default-footer items-per-page="-1">
-					<template #headers="{ columns, isSorted, getSortIcon, toggleSort }">
-						<tr>
-							<template v-for="header in columns" :key="header.key">
-								<th :class="{'is-sorted': isSorted(header)}" :data-aid="'detections_panel_overrides_' + header?.value?.toLowerCase()">
-									<template v-if="header.key">
-										<span @click="toggleSort(header)">
-											{{ header.title }}
-										</span>
-										<template v-if="isSorted(header)">
-											<v-icon>
-												{{ getSortIcon(header) === '$sortAsc' ? 'fa-caret-up' : 'fa-caret-down'}}
-											</v-icon>
-										</template>
-									</template>
-								</th>
-							</template>
-						</tr>
-					</template>
-					<template #item="{ item, index, isExpanded, toggleExpand, internalItem }">
-						<tr>
-							<td>
-								<v-btn id="expandOverrideArrow" icon variant="text" size="small" @click="toggleExpand(internalItem)">
-									<v-icon v-if="isExpanded(internalItem)" :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_panel_overrides_collapse">fa-angle-down</v-icon>
-									<v-icon v-else :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_panel_overrides_expand">fa-angle-right</v-icon>
+						<div class="summary" v-else data-aid="detection_panel_summary_display">
+							{{ extractedSummary }}
+						</div>
+					</div>
+					<div class="quicklinks pt-2">
+						<v-btn id="detection-panel-ack" icon variant="text" size="small" @click="ack(false)" data-aid="detection_panel_ack" :title="i18n.alertAcknowledge">
+							<v-icon :color="ackColor">
+								<span>
+									<i class="fas fa-bell fa-stack-1x"></i>
+									<i class="fas fa-plus fa-stack-1x icon-overlay-top-right"></i>
+								</span>
+							</v-icon>
+						</v-btn>
+						<v-btn id="detection-panel-escalate" icon variant="text" size="small" @click="escalate($event)" data-aid="detection_panel_escalate" :title="i18n.escalate">
+							<v-icon color="primary">
+								<span>
+									<i class="fas fa-triangle-exclamation fa-stack-1x"></i>
+									<i class="fas fa-plus fa-stack-1x icon-overlay-top-right"></i>
+								</span>
+							</v-icon>
+						</v-btn>
+						<v-btn id="detection-panel-open" icon variant="text" size="small" class="no-link" :to="{name:'detection',params: {id:detection.id}}" target="_blank" data-aid="detection_panel_open_detection" :title="i18n.viewDetection">
+							<v-icon color="primary">fa-magnifying-glass</v-icon>
+						</v-btn>
+					</div>
+					<div class="pa-4">
+						<span>
+							<div class="ops-header mt-0">
+								{{ i18n.status }}: {{ detection.isEnabled ? i18n.enabled : i18n.disabled }}
+							</div>
+							<div data-aid="detection_panel_enabled_toggle">
+								<v-switch id="detection-enabled-edit" inset v-model="detection.isEnabled" class="no-details" @change="toggleStatus()"></v-switch>
+							</div>
+						</span>
+					</div>
+				</v-expansion-panel-text>
+			</v-expansion-panel>
+			<v-expansion-panel>
+				<v-expansion-panel-title expand-icon="fa-chevron-down" collapse-icon="fa-chevron-up" data-aid="detection_panel_tuning_header">
+					<h3>
+						{{ i18n.tuning }}
+					</h3>
+				</v-expansion-panel-title>
+				<v-expansion-panel-text>
+					<v-row v-if="canAddOverride()">
+						<v-col>
+							<v-toolbar class="elevation-0 theme-background-lighten-1" fixed>
+								<v-btn variant="flat" class="ml-3" color="primary" id="add-override-button" style="text-decoration: none; cursor: 'pointer'" @click="createNewOverride()" data-aid="detection_panel_new_override">
+									<v-icon :title="i18n.create">fa-plus</v-icon>
 								</v-btn>
-							</td>
-							<template v-for="field in overrideHeaders[detection.engine]" :key="field.value">
-								<td v-if="field.value" data-aid="detection_panel_overrides_headers_display">
-									<div class="d-inline-block">
-										<span v-if="field.format" v-text="$root.formatLocalTimestamp(item[field.value], zone)"></span>
-										<span v-else-if="field.localize">{{ $root.tryLocalize(item[field.value]) }}</span>
-										<span v-else>{{ pickValue(item, field) }}</span>
+							</v-toolbar>
+						</v-col>
+					</v-row>
+					<div v-if="newOverride != null" class="ma-3">
+						<v-form ref="OverrideCreate" v-model="newOverrideValid">
+							<span data-aid="detection_panel_new_override_type_select">
+								<v-select variant="underlined" id="new-override-type" v-model="newOverride.type" :items="overrideTypes[this.detection.engine]" persistent-hint :hint="i18n.type"></v-select>
+							</span>
+							<div v-if="!!newOverride.type && detection.engine === 'suricata'">
+								<v-text-field variant="underlined" v-if="newOverride.type === 'modify'" id="new-override-regex-edit" v-model="newOverride.regex" :rules="[rules.required]" persistent-hint :hint="i18n.regex" data-aid="detection_panel_new_override_regex_input"></v-text-field>
+								<v-text-field variant="underlined" v-if="newOverride.type === 'modify'" id="new-override-value-edit" v-model="newOverride.value" :rules="[rules.required]" persistent-hint :hint="i18n.value" data-aid="detection_panel_new_override_value_input"></v-text-field>
+								<span data-aid="detection_panel_new_override_threshold_type_select">
+									<v-select variant="underlined" v-if="newOverride.type === 'threshold'" id="new-override-threshold-type-edit" v-model="newOverride.thresholdType" :items="thresholdTypes" :rules="[rules.required]" persistent-hint :hint="i18n.thresholdType"></v-select>
+								</span>
+								<span data-aid="detection_panel_new_override_track_type_select">
+									<v-select variant="underlined" v-if="['threshold', 'suppress'].includes(newOverride.type)" id="new-override-track-edit" v-model="newOverride.track" :items="trackOptions[newOverride.type]" :rules="[rules.required]" persistent-hint :hint="i18n.track"></v-select>
+								</span>
+								<v-text-field variant="underlined" v-if="newOverride.type === 'suppress'" id="new-override-ip-edit" v-model="newOverride.ip" :rules="[rules.required, rules.cidrFormat]" persistent-hint :hint="i18n.ipCidr" data-aid="detection_panel_new_override_suppress_ip_input">
+									<template #append>
+										<router-link class="theme-icon" :to="{ name: 'config', query: { s: 'suricata.config.vars', a: '1', e: '1' }}" target="_blank" data-aid="detection_panel_new_override_ip_edit_config_shortcut">
+											<v-icon>fa fa-gear</v-icon>
+										</router-link>
+									</template>
+								</v-text-field>
+								<v-text-field variant="underlined" v-if="newOverride.type === 'threshold'" id="new-override-count-edit" v-model="newOverride.count" :rules="[rules.required, rules.number]" persistent-hint :hint="i18n.count" data-aid="detection_panel_new_override_threshold_count_input"></v-text-field>
+								<v-text-field variant="underlined" v-if="newOverride.type === 'threshold'" id="new-override-seconds-edit" v-model="newOverride.seconds" :rules="[rules.required, rules.number]" persistent-hint :hint="i18n.secondsLabel" data-aid="detection_panel_new_override_threshold_seconds_input"></v-text-field>
+							</div>
+							<div v-if="!!newOverride.type && detection.engine === 'elastalert'">
+								<v-textarea variant="underlined" v-if="newOverride.type === 'customFilter'" id="new-override-custom-filter-edit" v-model="newOverride.customFilter" :rules="[rules.required]" auto-grow rows="2" persistent-hint :hint="i18n.customFilter" data-aid="detection_panel_new_override_filter_input"></v-textarea>
+							</div>
+							<div v-if="!!newOverride.type">
+								<v-text-field variant="underlined" id="new-override-note-edit" v-model="newOverride.note" :rules="[rules.noteLengthLimit]" persistent-hint :hint="i18n.note" data-aid="detection_panel_new_override_note_input"></v-text-field>
+							</div>
+							<div v-if="newOverride" class="d-flex align-center align-self-end text-body-2 mt-2">
+								<div class="justify-end">
+									<v-btn id="detection-create-cancel" variant="text" size="small" color="primary" class="align-self-end" @click="newOverride = null" data-aid="detection_panel_new_override_cancel">
+										{{ i18n.cancel }}
+									</v-btn>
+									<v-btn v-if="newOverride.type" id="detection-create-create" :disabled="!newOverrideValid" variant="text" size="small" color="primary" class="align-self-end" @click="addNewOverride()" data-aid="detection_panel_new_override_save">
+										{{ i18n.create }}
+									</v-btn>
+									<v-btn variant="text" size="small" icon class="theme-text" :target="$root.target('so-help')" :href="$root.parameters.docsUrl + 'detections.html#managing-detections'" :title="i18n.overrideDocumentationHelp" data-aid="detection_panel_override_help_new">
+										<v-icon class="mb-1">fa-regular fa-circle-question</v-icon>
+									</v-btn>
+								</div>
+							</div>
+						</v-form>
+					</div>
+					<v-data-table :sort-by="sortBy" @update:sort-by="val => sortBy = val" must-sort :headers="overrideHeaders[detection.engine]"
+						:items="detection.overrides || []" item-value="index" show-expand :custom-sort="sortOverrides" hide-default-footer items-per-page="-1">
+						<template #headers="{ columns, isSorted, getSortIcon, toggleSort }">
+							<tr>
+								<template v-for="header in columns" :key="header.key">
+									<th :class="{'is-sorted': isSorted(header)}" :data-aid="'detections_panel_overrides_' + header?.value?.toLowerCase()">
+										<template v-if="header.key">
+											<span @click="toggleSort(header)">
+												{{ header.title }}
+											</span>
+											<template v-if="isSorted(header)">
+												<v-icon>
+													{{ getSortIcon(header) === '$sortAsc' ? 'fa-caret-up' : 'fa-caret-down'}}
+												</v-icon>
+											</template>
+										</template>
+									</th>
+								</template>
+							</tr>
+						</template>
+						<template #item="{ item, index, isExpanded, toggleExpand, internalItem }">
+							<tr>
+								<td>
+									<v-btn id="expandOverrideArrow" icon variant="text" size="small" @click="toggleExpand(internalItem)">
+										<v-icon v-if="isExpanded(internalItem)" :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_panel_overrides_collapse">fa-angle-down</v-icon>
+										<v-icon v-else :alt="i18n.overrideExpand" :title="i18n.eventExpandHelp" data-aid="detection_panel_overrides_expand">fa-angle-right</v-icon>
+									</v-btn>
+								</td>
+								<template v-for="field in overrideHeaders[detection.engine]" :key="field.value">
+									<td v-if="field.value" data-aid="detection_panel_overrides_headers_display">
+										<div class="d-inline-block">
+											<span v-if="field.format" v-text="$root.formatLocalTimestamp(item[field.value], zone)"></span>
+											<span v-else-if="field.localize">{{ $root.tryLocalize(item[field.value]) }}</span>
+											<span v-else>{{ pickValue(item, field) }}</span>
+										</div>
+									</td>
+								</template>
+							</tr>
+						</template>
+						<template #expanded-row="{ columns, item }">
+							<tr>
+								<td :colspan="columns.length" class="pa-4" v-if="detection.engine === 'suricata'">
+									<div data-aid="detection_panel_override_enabled_toggle">
+										<div class="font-weight-bold mt-4">
+											{{i18n.enabled}}: {{item.isEnabled}}
+										</div>
+										<v-switch id="override-enabled-edit" ref="override-enabled" hide-details="auto" v-model="item.isEnabled"
+											inset @change="saveDetection(false)"></v-switch>
+									</div>
+									<div v-if="item.type === 'modify'" @click="startOverrideEdit('override-regex', item, 'regex')" :class="{ clicktoedit: !isOverrideEdit('override-regex') }">
+										<div class="font-weight-bold mt-4">
+											{{i18n.regex}}:
+										</div>
+										<span id="override-regex" v-if="!isOverrideEdit('override-regex')">
+											{{item.regex}}
+										</span>
+										<span v-else>
+											<v-text-field variant="underlined" id="override-regex-edit" ref="override-regex" hide-details="auto" outlined v-model="item.regex" :rules="[rules.required]"
+												persistent-hint :hint="i18n.regex" @keyup.enter="isFieldValid('override-regex') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_regex_input"></v-text-field>
+											<div id="override-count-regex-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_regex_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-regex')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_regex_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div v-if="item.type === 'modify'" @click="startOverrideEdit('override-value', item, 'value')" :class="{ clicktoedit: !isOverrideEdit('override-value') }">
+										<div class="font-weight-bold mt-4">
+											{{i18n.value}}:
+										</div>
+										<span id="override-value" v-if="!isOverrideEdit('override-value')">
+											{{item.value}}
+										</span>
+										<span v-else>
+											<v-text-field variant="outlined" id="override-value-edit" ref="override-value" hide-details="auto" v-model="item.value" :rules="[rules.required]"
+												persistent-hint :hint="i18n.value" @keyup.enter="isFieldValid('override-value') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_value_input"></v-text-field>
+											<div id="override-value-edit-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_value_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-value')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_value_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div v-if="item.type === 'threshold'" @click="startOverrideEdit('override-threshold-type', item, 'thresholdType')" :class="{ clicktoedit: !isOverrideEdit('override-threshold-type') }" data-aid="detection_panel_override_threshold_type_select">
+										<div class="font-weight-bold mt-4">
+											{{i18n.type}}:
+										</div>
+										<span id="override-threshold-type" v-if="!isOverrideEdit('override-threshold-type')">
+											{{item.thresholdType}}
+										</span>
+										<v-select variant="underlined" v-else id="override-threshold-type-edit" ref="override-threshold-type" v-model="item.thresholdType" :items="thresholdTypes" :rules="[rules.required]" persistent-hint :hint="i18n.type" @update:model-value="stopOverrideEdit(true)"></v-select>
+									</div>
+									<div v-if="['suppress', 'threshold'].includes(item.type)" @click="startOverrideEdit('override-track', item, 'track')" :class="{ clicktoedit: !isOverrideEdit('override-track') }" data-aid="detection_panel_override_threshold_track_select">
+										<div class="font-weight-bold mt-4">
+											{{i18n.track}}:
+										</div>
+										<span id="override-track" v-if="!isOverrideEdit('override-track')">
+											{{item.track}}
+										</span>
+										<v-select variant="underlined" v-else id="override-track-edit" ref="override-track" v-model="item.track" :items="trackOptions[item.type]" :rules="[rules.required]" persistent-hint :hint="i18n.type" @update:model-value="stopOverrideEdit(true)"></v-select>
+									</div>
+									<div v-if="item.type === 'suppress'" @click="startOverrideEdit('override-ip', item, 'ip')" :class="{ clicktoedit: !isOverrideEdit('override-ip') }">
+										<div class="font-weight-bold mt-4">
+											{{i18n.ip}}:
+										</div>
+										<span id="override-ip" v-if="!isOverrideEdit('override-ip')">
+											{{item.ip}}
+										</span>
+										<span v-else>
+											<v-text-field id="override-ip-edit" ref="override-ip" hide-details="auto" variant="outlined" v-model="item.ip" :rules="[rules.required, rules.cidrFormat]"
+												persistent-hint :hint="i18n.ipCidr" @keyup.enter="isFieldValid('override-ip') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_suppress_ip_input">
+											<template #append>
+												<router-link class="theme-icon" :to="{ name: 'config', query: { s: 'suricata.config.vars', a: '1', e: '1' }}" target="_blank" data-aid="detection_panel_override_ip_edit_config_shortcut">
+													<v-icon>fa fa-gear</v-icon>
+												</router-link>
+											</template>
+											</v-text-field>
+											<div id="override-ip-edit-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_ip_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-ip')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_ip_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div v-if="item.type === 'threshold'" @click="startOverrideEdit('override-count', item, 'count')" :class="{ clicktoedit: !isOverrideEdit('override-count') }">
+										<div class="font-weight-bold mt-4">
+											{{i18n.count}}:
+										</div>
+										<span id="override-count" v-if="!isOverrideEdit('override-count')">
+											{{item.count}}
+										</span>
+										<span v-else>
+											<v-text-field id="override-count-edit" ref="override-count" hide-details="auto" variant="outlined" v-model="item.count" :rules="[rules.required, rules.number]"
+												persistent-hint :hint="i18n.count" @keyup.enter="isFieldValid('override-count') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_threshold_count_input"></v-text-field>
+											<div id="override-count-edit-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_count_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-count')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_count_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div v-if="item.type === 'threshold'" @click="startOverrideEdit('override-seconds', item, 'seconds')" :class="{ clicktoedit: !isOverrideEdit('override-seconds') }">
+										<div class="font-weight-bold mt-4">
+											{{i18n.secondsLabel}}:
+										</div>
+										<span id="override-seconds" v-if="!isOverrideEdit('override-seconds')">
+											{{item.seconds}}
+										</span>
+										<span v-else>
+											<v-text-field id="override-seconds-edit" ref="override-seconds" hide-details="auto" variant="outlined" v-model="item.seconds" :rules="[rules.required, rules.number]"
+												persistent-hint :hint="i18n.secondsLabel" @keyup.enter="isFieldValid('override-seconds') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_threshold_seconds_input"></v-text-field>
+											<div id="override-seconds-edit-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_seconds_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-seconds')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_seconds_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div @click="startOverrideEdit('override-note', item, 'note')" :class="{ clicktoedit: !isOverrideEdit('override-note') }">
+										<div class="font-weight-bold mt-4">
+											{{i18n.note}}:
+										</div>
+										<span id="override-note" v-if="!isOverrideEdit('override-note')">
+											{{item.note}}
+										</span>
+										<span v-else>
+											<v-text-field variant="outlined" id="override-note-edit" ref="override-note" hide-details="auto" v-model="item.note" :rules="[rules.noteLengthLimit]"
+												persistent-hint :hint="i18n.note" @keyup.enter="isFieldValid('override-note') && stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_note_input"></v-text-field>
+											<div id="override-note-edit-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" :disabled="!isFieldValid('override-note')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div class="d-flex justify-end text-body-2 mt-4">
+										<div class="d-inline-flex">
+											<v-btn variant="text" size="small" icon :target="$root.target('so-help')" :href="$root.parameters.docsUrl + 'nids.html#managing-nids-rules'" :title="i18n.overrideDocumentationHelp" data-aid="detection_override_help_suricata">
+												<v-icon>fa-regular fa-circle-question</v-icon>
+											</v-btn>
+											<v-btn color="red" @click="deleteOverride(item)" variant="text" size="small" icon :title="i18n.overrideDeleteHelp" data-aid="detection_panel_override_edit_delete_suricata">
+												<v-icon>fa-circle-xmark</v-icon>
+											</v-btn>
+										</div>
 									</div>
 								</td>
-							</template>
-						</tr>
-					</template>
-					<template #expanded-row="{ columns, item }">
-						<tr>
-							<td :colspan="columns.length" class="pa-4" v-if="detection.engine === 'suricata'">
-								<div data-aid="detection_panel_override_enabled_toggle">
-									<div class="font-weight-bold mt-4">
-										{{i18n.enabled}}: {{item.isEnabled}}
-									</div>
-									<v-switch id="override-enabled-edit" ref="override-enabled" hide-details="auto" v-model="item.isEnabled"
-										inset @change="saveDetection(false)"></v-switch>
-								</div>
-								<div v-if="item.type === 'modify'" @click="startOverrideEdit('override-regex', item, 'regex')" :class="{ clicktoedit: !isOverrideEdit('override-regex') }">
-									<div class="font-weight-bold mt-4">
-										{{i18n.regex}}:
-									</div>
-									<span id="override-regex" v-if="!isOverrideEdit('override-regex')">
-										{{item.regex}}
-									</span>
-									<span v-else>
-										<v-text-field variant="underlined" id="override-regex-edit" ref="override-regex" hide-details="auto" outlined v-model="item.regex" :rules="[rules.required]"
-											persistent-hint :hint="i18n.regex" @keyup.enter="isFieldValid('override-regex') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_regex_input"></v-text-field>
-										<div id="override-count-regex-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_regex_cancel">
-												{{ i18n.cancel }}
-											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-regex')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_regex_save">
-												{{ i18n.save }}
-											</v-btn>
+								<td :colspan="overrideHeaders[detection.engine].length" class="pa-4" v-else-if="detection.engine === 'elastalert'">
+									<div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }" data-aid="detection_panel_override_enabled_toggle">
+										<div class="font-weight-bold mt-2">
+											{{i18n.enabled}}: {{item.isEnabled}}
 										</div>
-									</span>
-								</div>
-								<div v-if="item.type === 'modify'" @click="startOverrideEdit('override-value', item, 'value')" :class="{ clicktoedit: !isOverrideEdit('override-value') }">
-									<div class="font-weight-bold mt-4">
-										{{i18n.value}}:
+										<v-switch id="override-enabled-edit" ref="override-enabled" hide-details="auto" v-model="item.isEnabled"
+											inset @change="saveDetection(false)"></v-switch>
 									</div>
-									<span id="override-value" v-if="!isOverrideEdit('override-value')">
-										{{item.value}}
-									</span>
-									<span v-else>
-										<v-text-field variant="outlined" id="override-value-edit" ref="override-value" hide-details="auto" v-model="item.value" :rules="[rules.required]"
-											persistent-hint :hint="i18n.value" @keyup.enter="isFieldValid('override-value') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_value_input"></v-text-field>
-										<div id="override-value-edit-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_value_cancel">
-												{{ i18n.cancel }}
-											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-value')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_value_save">
-												{{ i18n.save }}
-											</v-btn>
+									<div @click="startOverrideEdit('override-custom-filter', item, 'customFilter')" :class="{ clicktoedit: !isOverrideEdit('override-custom-filter') }">
+										<div class="font-weight-bold mt-2">
+											{{i18n.customFilter}}:
 										</div>
-									</span>
-								</div>
-								<div v-if="item.type === 'threshold'" @click="startOverrideEdit('override-threshold-type', item, 'thresholdType')" :class="{ clicktoedit: !isOverrideEdit('override-threshold-type') }" data-aid="detection_panel_override_threshold_type_select">
-									<div class="font-weight-bold mt-4">
-										{{i18n.type}}:
-									</div>
-									<span id="override-threshold-type" v-if="!isOverrideEdit('override-threshold-type')">
-										{{item.thresholdType}}
-									</span>
-									<v-select variant="underlined" v-else id="override-threshold-type-edit" ref="override-threshold-type" v-model="item.thresholdType" :items="thresholdTypes" :rules="[rules.required]" persistent-hint :hint="i18n.type" @update:model-value="stopOverrideEdit(true)"></v-select>
-								</div>
-								<div v-if="['suppress', 'threshold'].includes(item.type)" @click="startOverrideEdit('override-track', item, 'track')" :class="{ clicktoedit: !isOverrideEdit('override-track') }" data-aid="detection_panel_override_threshold_track_select">
-									<div class="font-weight-bold mt-4">
-										{{i18n.track}}:
-									</div>
-									<span id="override-track" v-if="!isOverrideEdit('override-track')">
-										{{item.track}}
-									</span>
-									<v-select variant="underlined" v-else id="override-track-edit" ref="override-track" v-model="item.track" :items="trackOptions[item.type]" :rules="[rules.required]" persistent-hint :hint="i18n.type" @update:model-value="stopOverrideEdit(true)"></v-select>
-								</div>
-								<div v-if="item.type === 'suppress'" @click="startOverrideEdit('override-ip', item, 'ip')" :class="{ clicktoedit: !isOverrideEdit('override-ip') }">
-									<div class="font-weight-bold mt-4">
-										{{i18n.ip}}:
-									</div>
-									<span id="override-ip" v-if="!isOverrideEdit('override-ip')">
-										{{item.ip}}
-									</span>
-									<span v-else>
-										<v-text-field id="override-ip-edit" ref="override-ip" hide-details="auto" variant="outlined" v-model="item.ip" :rules="[rules.required, rules.cidrFormat]"
-											persistent-hint :hint="i18n.ipCidr" @keyup.enter="isFieldValid('override-ip') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_suppress_ip_input">
-										<template #append>
-											<router-link class="theme-icon" :to="{ name: 'config', query: { s: 'suricata.config.vars', a: '1', e: '1' }}" target="_blank" data-aid="detection_panel_override_ip_edit_config_shortcut">
-												<v-icon>fa fa-gear</v-icon>
-											</router-link>
-										</template>
-										</v-text-field>
-										<div id="override-ip-edit-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_ip_cancel">
-												{{ i18n.cancel }}
-											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-ip')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_ip_save">
-												{{ i18n.save }}
-											</v-btn>
-										</div>
-									</span>
-								</div>
-								<div v-if="item.type === 'threshold'" @click="startOverrideEdit('override-count', item, 'count')" :class="{ clicktoedit: !isOverrideEdit('override-count') }">
-									<div class="font-weight-bold mt-4">
-										{{i18n.count}}:
-									</div>
-									<span id="override-count" v-if="!isOverrideEdit('override-count')">
-										{{item.count}}
-									</span>
-									<span v-else>
-										<v-text-field id="override-count-edit" ref="override-count" hide-details="auto" variant="outlined" v-model="item.count" :rules="[rules.required, rules.number]"
-											persistent-hint :hint="i18n.count" @keyup.enter="isFieldValid('override-count') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_threshold_count_input"></v-text-field>
-										<div id="override-count-edit-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_count_cancel">
-												{{ i18n.cancel }}
-											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-count')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_count_save">
-												{{ i18n.save }}
-											</v-btn>
-										</div>
-									</span>
-								</div>
-								<div v-if="item.type === 'threshold'" @click="startOverrideEdit('override-seconds', item, 'seconds')" :class="{ clicktoedit: !isOverrideEdit('override-seconds') }">
-									<div class="font-weight-bold mt-4">
-										{{i18n.secondsLabel}}:
-									</div>
-									<span id="override-seconds" v-if="!isOverrideEdit('override-seconds')">
-										{{item.seconds}}
-									</span>
-									<span v-else>
-										<v-text-field id="override-seconds-edit" ref="override-seconds" hide-details="auto" variant="outlined" v-model="item.seconds" :rules="[rules.required, rules.number]"
-											persistent-hint :hint="i18n.secondsLabel" @keyup.enter="isFieldValid('override-seconds') && stopOverrideEdit(true)" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_threshold_seconds_input"></v-text-field>
-										<div id="override-seconds-edit-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_seconds_cancel">
-												{{ i18n.cancel }}
-											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-seconds')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_seconds_save">
-												{{ i18n.save }}
-											</v-btn>
-										</div>
-									</span>
-								</div>
-								<div @click="startOverrideEdit('override-note', item, 'note')" :class="{ clicktoedit: !isOverrideEdit('override-note') }">
-									<div class="font-weight-bold mt-4">
-										{{i18n.note}}:
-									</div>
-									<span id="override-note" v-if="!isOverrideEdit('override-note')">
-										{{item.note}}
-									</span>
-									<span v-else>
-										<v-text-field variant="outlined" id="override-note-edit" ref="override-note" hide-details="auto" v-model="item.note" :rules="[rules.noteLengthLimit]"
-											persistent-hint :hint="i18n.note" @keyup.enter="isFieldValid('override-note') && stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_note_input"></v-text-field>
-										<div id="override-note-edit-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_cancel">
-												{{ i18n.cancel }}
-											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" :disabled="!isFieldValid('override-note')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_save">
-												{{ i18n.save }}
-											</v-btn>
-										</div>
-									</span>
-								</div>
-								<div class="d-flex justify-end text-body-2 mt-4">
-									<div class="d-inline-flex">
-										<v-btn variant="text" size="small" icon :target="$root.target('so-help')" :href="$root.parameters.docsUrl + 'nids.html#managing-nids-rules'" :title="i18n.overrideDocumentationHelp" data-aid="detection_override_help_suricata">
-											<v-icon>fa-regular fa-circle-question</v-icon>
-										</v-btn>
-										<v-btn color="red" @click="deleteOverride(item)" variant="text" size="small" icon :title="i18n.overrideDeleteHelp" data-aid="detection_panel_override_edit_delete_suricata">
-											<v-icon>fa-circle-xmark</v-icon>
-										</v-btn>
-									</div>
-								</div>
-							</td>
-							<td :colspan="overrideHeaders[detection.engine].length" class="pa-4" v-else-if="detection.engine === 'elastalert'">
-								<div @click="startOverrideEdit('override-enabled', item, 'isEnabled')" :class="{ clicktoedit: !isOverrideEdit('override-enabled') }" data-aid="detection_panel_override_enabled_toggle">
-									<div class="font-weight-bold mt-2">
-										{{i18n.enabled}}: {{item.isEnabled}}
-									</div>
-									<v-switch id="override-enabled-edit" ref="override-enabled" hide-details="auto" v-model="item.isEnabled"
-										inset @change="saveDetection(false)"></v-switch>
-								</div>
-								<div @click="startOverrideEdit('override-custom-filter', item, 'customFilter')" :class="{ clicktoedit: !isOverrideEdit('override-custom-filter') }">
-									<div class="font-weight-bold mt-2">
-										{{i18n.customFilter}}:
-									</div>
-									<span id="override-custom-filter" v-if="!isOverrideEdit('override-custom-filter')">
-										<pre>{{item.customFilter}}</pre>
-									</span>
-									<span v-else>
-										<span data-aid="detection_panel_override_filter_input">
-											<v-textarea variant="underlined" id="override-custom-filter-edit" ref="override-custom-filter" hide-details="auto" rows="2" auto-grow v-model="item.customFilter" :rules="[rules.required]"
-											persistent-hint :hint="i18n.customFilter" @keyup.esc="stopOverrideEdit(false)"></v-textarea>
+										<span id="override-custom-filter" v-if="!isOverrideEdit('override-custom-filter')">
+											<pre>{{item.customFilter}}</pre>
 										</span>
-										<div id="override-filter-edit-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_filter_cancel">
-												{{ i18n.cancel }}
+										<span v-else>
+											<span data-aid="detection_panel_override_filter_input">
+												<v-textarea variant="underlined" id="override-custom-filter-edit" ref="override-custom-filter" hide-details="auto" rows="2" auto-grow v-model="item.customFilter" :rules="[rules.required]"
+												persistent-hint :hint="i18n.customFilter" @keyup.esc="stopOverrideEdit(false)"></v-textarea>
+											</span>
+											<div id="override-filter-edit-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_filter_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-custom-filter')" variant="text" size="small" color="primary" class="align-self-end" data-aid="detection_panel_override_filter_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div @click="startOverrideEdit('override-note', item, 'note')" :class="{ clicktoedit: !isOverrideEdit('override-note') }">
+										<div class="font-weight-bold mt-4">
+											{{i18n.note}}:
+										</div>
+										<span id="override-note" v-if="!isOverrideEdit('override-note')">
+											{{item.note}}
+										</span>
+										<span v-else>
+											<v-text-field variant="outlined" id="override-note-edit" ref="override-note" hide-details="auto" v-model="item.note" :rules="[rules.noteLengthLimit]"
+												persistent-hint :hint="i18n.note" @keyup.enter="isFieldValid('override-note') && stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_note_input" :maxlength="MAX_OVERRIDE_NOTE_LENGTH"></v-text-field>
+											<div id="override-note-edit-buttons">
+												<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_cancel">
+													{{ i18n.cancel }}
+												</v-btn>
+												<v-btn @click.stop="stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" :disabled="!isFieldValid('override-note')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_save">
+													{{ i18n.save }}
+												</v-btn>
+											</div>
+										</span>
+									</div>
+									<div class="d-flex justify-end text-body-2 mt-2">
+										<div class="d-inline-flex">
+											<v-btn variant="text" size="small" icon :target="$root.target('so-help')" :href="$root.parameters.docsUrl + 'sigma.html#managing-sigma-rules'" :title="i18n.overrideDocumentationHelp" data-aid="detection_panel_override_help_elastalert">
+												<v-icon>fa-regular fa-circle-question</v-icon>
 											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true)" :disabled="!isFieldValid('override-custom-filter')" variant="text" size="small" color="primary" class="align-self-end" data-aid="detection_panel_override_filter_save">
-												{{ i18n.save }}
+											<v-btn color="red" @click="deleteOverride(item)" variant="text" size="small" icon :title="i18n.overrideDeleteHelp" data-aid="detection_panel_override_edit_delete_elastalert">
+												<v-icon>fa-circle-xmark</v-icon>
 											</v-btn>
 										</div>
-									</span>
-								</div>
-								<div @click="startOverrideEdit('override-note', item, 'note')" :class="{ clicktoedit: !isOverrideEdit('override-note') }">
-									<div class="font-weight-bold mt-4">
-										{{i18n.note}}:
 									</div>
-									<span id="override-note" v-if="!isOverrideEdit('override-note')">
-										{{item.note}}
-									</span>
-									<span v-else>
-										<v-text-field variant="outlined" id="override-note-edit" ref="override-note" hide-details="auto" v-model="item.note" :rules="[rules.noteLengthLimit]"
-											persistent-hint :hint="i18n.note" @keyup.enter="isFieldValid('override-note') && stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" @keyup.esc="stopOverrideEdit(false)" data-aid="detection_panel_override_note_input" :maxlength="MAX_OVERRIDE_NOTE_LENGTH"></v-text-field>
-										<div id="override-note-edit-buttons">
-											<v-btn @click.stop="stopOverrideEdit(false)" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_cancel">
-												{{ i18n.cancel }}
-											</v-btn>
-											<v-btn @click.stop="stopOverrideEdit(true, () => { this.saveOverrideNote(item) })" :disabled="!isFieldValid('override-note')" color="primary" variant="text" size="small" class="align-self-end" data-aid="detection_panel_override_note_save">
-												{{ i18n.save }}
-											</v-btn>
-										</div>
-									</span>
-								</div>
-								<div class="d-flex justify-end text-body-2 mt-2">
-									<div class="d-inline-flex">
-										<v-btn variant="text" size="small" icon :target="$root.target('so-help')" :href="$root.parameters.docsUrl + 'sigma.html#managing-sigma-rules'" :title="i18n.overrideDocumentationHelp" data-aid="detection_panel_override_help_elastalert">
-											<v-icon>fa-regular fa-circle-question</v-icon>
-										</v-btn>
-										<v-btn color="red" @click="deleteOverride(item)" variant="text" size="small" icon :title="i18n.overrideDeleteHelp" data-aid="detection_panel_override_edit_delete_elastalert">
-											<v-icon>fa-circle-xmark</v-icon>
-										</v-btn>
-									</div>
-								</div>
-							</td>
-							<td :colspan="headers.length" class="pa-4" v-else-if="detection.engine === 'yara'"></td>
-						</tr>
-					</template>
-				</v-data-table>
-			</v-expansion-panel-text>
-		</v-expansion-panel>
-	</v-expansion-panels>
-	<div id="panel-loading-overlay" class="component-overlay bring-to-front" v-if="loading" data-aid="detection_panel_overlay_loading">
-		<v-container class="d-flex justify-center">
-			<v-progress-circular indeterminate :size="50" color="primary"></v-progress-circular>
-		</v-container>
+								</td>
+								<td :colspan="headers.length" class="pa-4" v-else-if="detection.engine === 'yara'"></td>
+							</tr>
+						</template>
+					</v-data-table>
+				</v-expansion-panel-text>
+			</v-expansion-panel>
+		</v-expansion-panels>
+		<div id="panel-loading-overlay" class="component-overlay" v-if="loading" data-aid="detection_panel_overlay_loading">
+			<v-container class="d-flex justify-center">
+				<v-progress-circular indeterminate :size="50" color="primary"></v-progress-circular>
+			</v-container>
+		</div>
+		<v-dialog v-model="ackExistingDialog" persistent max-width="450">
+			<v-card>
+				<v-card-title class="text-h5" v-text="i18n.acknowledgeExistingAlertsTitle"></v-card-title>
+				<v-card-text v-html="i18n.acknowledgeExistingAlertsText"></v-card-text>
+				<v-card-actions>
+					<v-spacer></v-spacer>
+					<v-btn text id="ack-existing-confirm-yes-button" @click="saveDetection(); ack(true);" v-text="i18n.yes" data-aid="detection_panel_ack_existing_yes"></v-btn>
+					<v-btn text id="ack-existing-confirm-no-button" @click="saveDetection();" v-text="i18n.no" data-aid="detection_panel_ack_existing_no"></v-btn>
+					<v-btn text id="ack-existing-confirm-cancel-button" @click="detection.isEnabled = true; ackExistingDialog = false;" v-text="i18n.cancel" data-aid="detection_panel_ack_existing_cancel"></v-btn>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
 	</div>
-	<v-dialog v-model="ackExistingDialog" persistent max-width="450">
-		<v-card>
-			<v-card-title class="text-h5" v-text="i18n.acknowledgeExistingAlertsTitle"></v-card-title>
-			<v-card-text v-html="i18n.acknowledgeExistingAlertsText"></v-card-text>
-			<v-card-actions>
-				<v-spacer></v-spacer>
-				<v-btn text id="ack-existing-confirm-yes-button" @click="saveDetection(); ack(true);" v-text="i18n.yes" data-aid="detection_panel_ack_existing_yes"></v-btn>
-				<v-btn text id="ack-existing-confirm-no-button" @click="saveDetection();" v-text="i18n.no" data-aid="detection_panel_ack_existing_no"></v-btn>
-				<v-btn text id="ack-existing-confirm-cancel-button" @click="detection.isEnabled = true; ackExistingDialog = false;" v-text="i18n.cancel" data-aid="detection_panel_ack_existing_cancel"></v-btn>
-			</v-card-actions>
-		</v-card>
-	</v-dialog>
 </div>

--- a/html/pages/detection-panel.html
+++ b/html/pages/detection-panel.html
@@ -7,7 +7,7 @@
 				</h3>
 			</v-expansion-panel-title>
 			<v-expansion-panel-text>
-				<h3 class="my-2" data-aid="detection_panel_title">
+				<h3 class="my-2 hard-wrap" data-aid="detection_panel_title">
 					<v-icon class="va-baseline" color="success" data-aid="detection_panel_title_thumbtack">fa-thumbtack</v-icon>
 					{{detection.title}}
 				</h3>

--- a/html/pages/detection.html
+++ b/html/pages/detection.html
@@ -253,7 +253,7 @@
 					<div v-if="newOverride != null">
 						<v-form ref="OverrideCreate" v-model="newOverrideValid">
 							<span data-aid="detection_new_override_type_select">
-								<v-select variant="underlined" id="new-override-type" v-model="newOverride.type" :items="getOverrideTypes()" persistent-hint :hint="i18n.type" @change="createOverrideTypeChange()"></v-select>
+								<v-select variant="underlined" id="new-override-type" v-model="newOverride.type" :items="getOverrideTypes()" persistent-hint :hint="i18n.type"></v-select>
 							</span>
 							<div v-if="!!newOverride.type && detect.engine === 'suricata'">
 								<v-text-field variant="underlined" v-if="newOverride.type === 'modify'" id="new-override-regex-edit" v-model="newOverride.regex" :rules="[rules.required]" persistent-hint :hint="i18n.regex" data-aid="detection_new_override_regex_input"></v-text-field>


### PR DESCRIPTION
Titles of Detections in the detection panel are now broken up if they are too long.

The loading overlay for the panel now covers the entire panel regardless of scroll position.

Multiple overrides can be created now that form validation is properly bound.