### PR TITLE
Fix For Zoom Levels between %25 and %150

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -992,3 +992,11 @@ ul ul ul {
   overflow-wrap: break-word;
   hyphens: none;
 }
+
+.pos-rel {
+  position: relative;
+}
+
+.vert-divider {
+  margin-left: -4px;
+}

--- a/html/pages/config.html
+++ b/html/pages/config.html
@@ -78,7 +78,7 @@
 					:item-title="getSettingName" :setting-modified="isSettingModified" :setting-modified-per-node="isSettingModifiedPerNode" :i18n="i18n" data-aid="config_tree"></tree-view>
 			</v-container>
 		</v-col>
-		<v-divider vertical></v-divider>
+		<v-divider vertical class="vert-divider"></v-divider>
 		<v-col cols="12" :lg="treeVisible ? 8 : 12">
 			<v-fade-transition mode="out-in" duration="100">
 				<div v-if="!selected" id="config-quick-links">


### PR DESCRIPTION
The page is 12 columns wide split into 4 and 8 with a divider in the middle. As zoom levels shrink, the divider's negative width isn't adjusted properly and this pushes the 8 columns to a new row. By decreasing the margin-left from -1px to -4px, zoom levels down to 25% will continue to show the 2 columns side by side without having a large impact on the un-zoomed appearance of the page. Zoom levels up to 150% look good and after that the view is no longer considered "Large" and the columns rearrange properly.