### PR TITLE
Multiline Comment Fix

### DIFF
--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -852,6 +852,7 @@ func (e *StrelkaEngine) parseYaraRules(data []byte) ([]*YaraRule, error) {
 		if (curCommentType == '*' && last == '*' && r == '/') ||
 			(curCommentType == '/' && r == '\n') {
 			curCommentType = ' '
+			curQuotes = ' '
 
 			if last == '*' {
 				last = r
@@ -948,7 +949,7 @@ func (e *StrelkaEngine) parseYaraRules(data []byte) ([]*YaraRule, error) {
 				buffer.WriteRune(r)
 			}
 		case parseStateInSection:
-			if r == '\n' {
+			if r == '\n' && curQuotes != '}' {
 				buf := strings.TrimSpace(buffer.String())
 				if len(buf) != 0 && buf[len(buf)-1] == ':' && !strings.HasPrefix(buf, "for ") {
 					// found a header, new section

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -183,6 +183,9 @@ strings:
 $my_text_string = "text here"
 $my_hex_string = { E2 34 A1 C8 23 FB }
 $badslashes = "\\var\\www\\html\\"
+/*
+Multiline comment
+*/
 $multilinehex = {
 46 DC EA D3 17 FE 45 D8 09 23
 EB 97 E4 95 64 10 D4 CD B2 C2
@@ -501,10 +504,7 @@ func TestParseRule(t *testing.T) {
 						`$my_text_string = "text here"`,
 						`$my_hex_string = { E2 34 A1 C8 23 FB }`,
 						`$badslashes = "\\var\\www\\html\\"`,
-						`$multilinehex = {`,
-						`46 DC EA D3 17 FE 45 D8 09 23`,
-						`EB 97 E4 95 64 10 D4 CD B2 C2`,
-						`}`,
+						"$multilinehex = {\n46 DC EA D3 17 FE 45 D8 09 23\nEB 97 E4 95 64 10 D4 CD B2 C2\n}",
 					},
 					Condition: `$my_text_string or $my_hex_string`,
 					Src:       WeirdRule,


### PR DESCRIPTION
In some situations, a /* multiline comment */ was being interpreted as quotes and breaking the import of 13 files. By clearing quotes when we exit comments, this issue is resolved. As a sister fix, if a strings variable opens a `{}` block of bytes to define, accept the newlines as part of the string definition and treat it like a multiline string.

Refactor a test to account for a multiline comment before a multiline string of bytes that should pass but previously wasn't.