### PR TITLE
Fix PCAP Date Range

### DIFF
--- a/html/js/routes/jobs.js
+++ b/html/js/routes/jobs.js
@@ -93,8 +93,7 @@ routes.push({ path: '/jobs', name: 'jobs', component: {
       this.form.srcPort = localStorage['settings.jobs.addJobForm.srcPort'];
       this.form.dstIp = localStorage['settings.jobs.addJobForm.dstIp'];
       this.form.dstPort = localStorage['settings.jobs.addJobForm.dstPort'];
-      this.form.beginTime = localStorage['settings.jobs.addJobForm.beginTime'];
-      this.form.endTime = localStorage['settings.jobs.addJobForm.endTime'];
+      this.form.timeframe = localStorage['settings.jobs.addJobForm.timeframe'];
     },
     updateJob(job) {
       for (var i = 0; i < this.jobs.length; i++) {
@@ -165,8 +164,8 @@ routes.push({ path: '/jobs', name: 'jobs', component: {
           let endDate;
           if (timeframe) {
             const [beginTime, endTime] = timeframe.split(' - ', 2);
-            beginDate = moment(beginTime, this.i18n.timePickerFormat).format(this.i18n.timestampFormat);
-            endDate = moment(endTime, this.i18n.timePickerFormat).format(this.i18n.timestampFormat);
+            beginDate = moment(beginTime, this.i18n.timePickerFormat).format(/* ISO 8601 */);
+            endDate = moment(endTime, this.i18n.timePickerFormat).format(/* ISO 8601 */);
           }
 
           if (beginDate && endDate) {
@@ -246,6 +245,7 @@ routes.push({ path: '/jobs', name: 'jobs', component: {
       const route = this;
       $('#jobtimeframe').on('apply.daterangepicker', function (ev, picker) {
         const value = picker.startDate.format(route.i18n.timePickerFormat) + ' - ' + picker.endDate.format(route.i18n.timePickerFormat)
+        route.form.timeframe = value;
         $(this).val(value);
       });
     },


### PR DESCRIPTION
With autoUpdateInput set to false, the daterangepicker wasn't updating the model. Once I fixed that, I saw we were sending the dates in the wrong format for Go's JSON parsing to successfully parse it as a time.Time so now we format it into ISO 8601.

Updated loadLocalSettings to restore the timeframe and not the 2 independent dates it used to be.