### PR TITLE
Fix Refresh on Arrow Click

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1000,3 +1000,7 @@ ul ul ul {
 .vert-divider {
   margin-left: -4px;
 }
+
+.closer-prepend .v-input__prepend {
+  margin-right: unset !important;
+}

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -146,16 +146,19 @@
 							</span>
 						</template>
 					</v-text-field>
-					<v-text-field variant="underlined" :disabled="loading()" v-if="!relativeTimeEnabled && !isCategory('detections')" id="huntdaterange" @change="notifyInputsChanged" class="mx-2"
+					<v-text-field variant="underlined" :disabled="loading()" v-if="!relativeTimeEnabled && !isCategory('detections')" id="huntdaterange" @change="notifyInputsChanged" class="mx-2 closer-prepend"
 						v-model="dateRange" :hint="i18n.timePickerHelp" persistent-hint
-						prepend-inner-icon="fa-angle-down" @click:prepend-inner="showDateRangePicker" :data-aid="'absolute_time_' + category">
+						:data-aid="'absolute_time_' + category">
 						<template #prepend>
 							<v-btn v-if="!relativeTimeEnabled" icon variant="text" size="x-small" @click="showRelativeTime" id="show-relative-time" :data-aid="'relative_time_toggle_' + category">
 								<v-icon class="theme-icon">fa-calendar-alt</v-icon>
 							</v-btn>
+							<v-btn @click="showDateRangePicker()" icon variant="text" size="x-small">
+								<v-icon class="theme-icon">fa-angle-down</v-icon>
+							</v-btn>
 						</template>
 					</v-text-field>
-					<v-btn id="hunt" class="align-self-start" :disabled="loading()" :color="huntPending ? 'light-green accent-4' : (autoRefreshInterval ? 'secondary' : 'primary')" @click.stop="hunt" :data-aid="'run_query_' + category">
+					<v-btn id="hunt" class="align-self-start" :class="{'mt-4': !relativeTimeEnabled}" :disabled="loading()" :color="huntPending ? 'light-green accent-4' : (autoRefreshInterval ? 'secondary' : 'primary')" @click.stop="hunt" :data-aid="'run_query_' + category">
 						<span v-if="isCategory('hunt')" class="d-sm-none d-lg-inline pr-2" v-text="i18n.hunt"></span>
 						<span v-if="!isCategory('hunt')" class="d-sm-none d-lg-inline pr-2" v-text="i18n.refresh"></span>
 						<v-icon v-if="isCategory('hunt') && !autoRefreshInterval">fa-crosshairs</v-icon>


### PR DESCRIPTION
Move dropdown icon to outside of the daterange input. Clicking the arrow should no longer refresh the page.