### PR TITLE
Max Height on Input Messages

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1004,3 +1004,7 @@ ul ul ul {
 .closer-prepend .v-input__prepend {
   margin-right: unset !important;
 }
+
+.v-messages__message {
+  max-height: 36px;
+}


### PR DESCRIPTION
Persistent hints appear below an input and in some narrow window sizes would stack each letter of the text on top of the next displacing the rest of the page vertically. By limiting the max-height, we can control that behavior. The text will wrap until it's 3 lines tall and then it will start truncating text.