### PR TITLE
Cogburn/detection override updated

### DIFF
--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1167,8 +1167,6 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
-			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 
 			if hasChanged {
 				logger.WithFields(log.Fields{

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1085,6 +1085,8 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 	for _, det := range community {
 		toDelete[det.PublicID] = struct{}{}
 
+		e.ExtractDetails(det)
+
 		path, ok := existing[det.PublicID]
 		if ok {
 			index[det.PublicID] = path
@@ -1165,7 +1167,6 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			// hasChanged = hasChanged || len(detect.Overrides) != 0
 			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
 			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 
@@ -1662,6 +1663,7 @@ func (e *ElastAlertEngine) DuplicateDetection(ctx context.Context, detection *mo
 		return nil, err
 	}
 
+	rule.OriginalSource = ""
 	rule.Title += " (copy)"
 	rule.ID = &id
 

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1165,7 +1165,7 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			hasChanged = hasChanged || len(detect.Overrides) != 0
+			// hasChanged = hasChanged || len(detect.Overrides) != 0
 			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
 			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1000,18 +1000,20 @@ level: high
 	}
 
 	expected := &model.Detection{
-		Author:      "Corey Ogburn",
-		PublicID:    "00000000-0000-0000-0000-00000000",
-		Title:       "Always Alert",
-		Severity:    model.SeverityHigh,
-		Content:     data,
-		Description: "Always Alerts",
-		Product:     "windows",
-		IsCommunity: true,
-		Engine:      model.EngineNameElastAlert,
-		Language:    model.SigLangSigma,
-		Ruleset:     "all_rules",
-		License:     model.LicenseDRL,
+		Author:        "Corey Ogburn",
+		PublicID:      "00000000-0000-0000-0000-00000000",
+		Title:         "Always Alert",
+		Severity:      model.SeverityHigh,
+		Content:       data,
+		Description:   "Always Alerts",
+		Product:       "windows",
+		IsCommunity:   true,
+		Engine:        model.EngineNameElastAlert,
+		Language:      model.SigLangSigma,
+		Ruleset:       "all_rules",
+		License:       model.LicenseDRL,
+		SourceCreated: util.Ptr(time.Date(2023, 11, 3, 0, 0, 0, 0, time.UTC)),
+		SourceUpdated: util.Ptr(time.Date(2023, 11, 3, 0, 0, 0, 0, time.UTC)),
 	}
 
 	dets, errMap := engine.parseZipRules(pkgZips)
@@ -1068,19 +1070,20 @@ license: Elastic-2.0
 	}
 
 	expected := &model.Detection{
-		Author:      "Security Onion Solutions",
-		PublicID:    "bf86ef21-41e6-417b-9a05-b9ea6bf28a38",
-		Title:       "Security Onion - SOC Login Failure",
-		Severity:    model.SeverityHigh,
-		Content:     data,
-		Description: "Detects when a user fails to login to the Security Onion Console (Web UI). Review associated logs for target username and source IP.",
-		IsCommunity: true,
-		Product:     "kratos",
-		Service:     "audit",
-		Engine:      model.EngineNameElastAlert,
-		Language:    model.SigLangSigma,
-		Ruleset:     "repo-path",
-		License:     model.LicenseDRL,
+		Author:        "Security Onion Solutions",
+		PublicID:      "bf86ef21-41e6-417b-9a05-b9ea6bf28a38",
+		Title:         "Security Onion - SOC Login Failure",
+		Severity:      model.SeverityHigh,
+		Content:       data,
+		Description:   "Detects when a user fails to login to the Security Onion Console (Web UI). Review associated logs for target username and source IP.",
+		IsCommunity:   true,
+		Product:       "kratos",
+		Service:       "audit",
+		Engine:        model.EngineNameElastAlert,
+		Language:      model.SigLangSigma,
+		Ruleset:       "repo-path",
+		License:       model.LicenseDRL,
+		SourceCreated: util.Ptr(time.Date(2024, 3, 6, 0, 0, 0, 0, time.UTC)),
 	}
 
 	dets, errMap := engine.parseRepoRules(repos)
@@ -1178,24 +1181,24 @@ id: bcc6f179-11cd-4111-a9a6-0fab68515cf7
 status: experimental
 description: Detects process execution patterns related to Griffon malware as reported by Kaspersky
 references:
-  - https://securelist.com/fin7-5-the-infamous-cybercrime-rig-fin7-continues-its-activities/90703/
+    - https://securelist.com/fin7-5-the-infamous-cybercrime-rig-fin7-continues-its-activities/90703/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/03/09
 tags:
-  - attack.execution
-  - detection.emerging_threats
+    - attack.execution
+    - detection.emerging_threats
 logsource:
-  category: process_creation
-  product: windows
+    category: process_creation
+    product: windows
 detection:
-  selection:
-    CommandLine|contains|all:
-      - '\local\temp\'
-      - '//b /e:jscript'
-      - '.txt'
-  condition: selection
+    selection:
+        CommandLine|contains|all:
+            - '\local\temp\'
+            - '//b /e:jscript'
+            - '.txt'
+    condition: selection
 falsepositives:
-  - Unlikely
+    - Unlikely
 level: critical`
 	SimpleRuleNoId = `title: Griffon Malware Attack Pattern
 status: experimental
@@ -1578,7 +1581,7 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 	}, nil)
 	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
 	// check for changes before sync
-	iom.EXPECT().ReadFile("rulesFingerprintFile").Return([]byte(`{"core+": "c6OTI9nTQxGEeeNkSZZB9+OESMNvfMXrb+XLtMiVhf0="}`), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return([]byte(`{"core+": "GwJvQmt07Ma9kvq2D8bpbQfXW+IRe0nN4fITj9Ghxis="}`), nil)
 	// WriteStateFile
 	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
 	// IntegrityCheck
@@ -1839,6 +1842,153 @@ func TestSyncChanges(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"abc", "", "deleteme"}, workDocIds) // update has an id, create does not, delete does
+}
+
+func TestSyncUnchangedOverrides(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	buf := bytes.NewBuffer([]byte{})
+
+	writer := zip.NewWriter(buf)
+	sr, err := writer.Create("rules/simple_rule.yml")
+	assert.NoError(t, err)
+
+	_, err = sr.Write([]byte(SimpleRule))
+	assert.NoError(t, err)
+
+	assert.NoError(t, writer.Close())
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+	bim := servermock.NewMockBulkIndexer(ctrl)
+
+	eng := &ElastAlertEngine{
+		srv: &server.Server{
+			Context:        context.Background(),
+			Detectionstore: detStore,
+		},
+		isRunning:                     true,
+		sigmaPipelineFinal:            "sigmaPipelineFinal",
+		sigmaPipelineSO:               "sigmaPipelineSO",
+		sigmaPipelinesFingerprintFile: "sigmaPipelinesFingerprintFile",
+		sigmaRulePackages:             []string{"core+"},
+		sigmaPackageDownloadTemplate:  "https://github.com/SigmaHQ/sigma/releases/latest/download/sigma_%s.zip",
+		reposFolder:                   "repos",
+		rulesFingerprintFile:          "rulesFingerprintFile",
+		elastAlertRulesFolder:         "elastAlertRulesFolder",
+		rulesRepos: []*model.RuleRepo{
+			{
+				Repo:      "https://github.com/user/repo",
+				Community: true,
+			},
+		},
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager:       iom,
+		showAiSummaries: false,
+	}
+
+	logger := log.WithField("detectionEngine", "test-elastalert")
+
+	workItems := []esutil.BulkIndexerItem{}
+
+	// checkSigmaPipelines
+	iom.EXPECT().ReadFile("sigmaPipelineFinal").Return([]byte("data"), nil)
+	iom.EXPECT().ReadFile("sigmaPipelineSO").Return([]byte("data"), nil)
+	iom.EXPECT().ReadFile("sigmaPipelinesFingerprintFile").Return([]byte("a different hash"), nil)
+	// downloadSigmaPackages
+	iom.EXPECT().MakeRequest(gomock.Any()).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(buf),
+	}, nil)
+	// UpdateRepos
+	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: "repo",
+			Dir:      true,
+		},
+	}, nil)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
+	// parseRepoRules
+	iom.EXPECT().WalkDir("repos/repo", gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
+		files := []fs.DirEntry{
+			&handmock.MockDirEntry{
+				Filename: "rules/123.yml",
+			},
+		}
+
+		for _, file := range files {
+			err := fn(file.Name(), file, nil)
+			assert.NoError(t, err)
+		}
+
+		return nil
+	})
+	iom.EXPECT().ReadFile("rules/123.yml").Return([]byte(SimpleRule), nil)
+	// syncCommunityDetections
+	iom.EXPECT().ReadDir("elastAlertRulesFolder").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: SimpleRuleSID + ".yml",
+		},
+	}, nil) // IndexExistingRules
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		SimpleRuleSID: {
+			Auditable: model.Auditable{
+				Id:         "abc",
+				CreateTime: util.Ptr(time.Now()),
+			},
+			PublicID:  SimpleRuleSID,
+			IsEnabled: true,
+			Content:   SimpleRule,
+			Ruleset:   "core+",
+			Overrides: []*model.Override{
+				{
+					Type:      model.OverrideTypeCustomFilter,
+					IsEnabled: true,
+					OverrideParameters: model.OverrideParameters{
+						CustomFilter: util.Ptr(`x: y`),
+					},
+				},
+			},
+		},
+	}, nil)
+	detStore.EXPECT().BuildBulkIndexer(gomock.Any(), gomock.Any()).Return(bim, nil)
+	detStore.EXPECT().ConvertObjectToDocument(gomock.Any(), "detection", gomock.Any(), gomock.Any(), gomock.Any(), nil, nil).Return([]byte("document"), "index", nil)
+	bim.EXPECT().Close(gomock.Any()).Return(nil)
+	bim.EXPECT().Stats().Return(esutil.BulkIndexerStats{})
+	iom.EXPECT().ExecCommand(gomock.Any()).Return([]byte("\n[query]"), 0, time.Duration(time.Second), nil) // sigmaToElastAlert
+	iom.EXPECT().WriteFile("elastAlertRulesFolder/bcc6f179-11cd-4111-a9a6-0fab68515cf7.yml", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	// SyncLocalDetections
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(nil, nil)
+	iom.EXPECT().ReadDir("elastAlertRulesFolder").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: SimpleRuleSID + ".yml",
+		},
+	}, nil) // IndexExistingRules
+	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)        // WriteStateFile
+	iom.EXPECT().WriteFile("rulesFingerprintFile", gomock.Any(), fs.FileMode(0644)).Return(nil) // WriteFingerprintFile
+	// regenNeeded
+	iom.EXPECT().WriteFile("sigmaPipelinesFingerprintFile", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	// IntegrityCheck
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		SimpleRuleSID: nil,
+	}, nil)
+
+	err = eng.Sync(logger, true)
+	assert.NoError(t, err)
+
+	assert.False(t, eng.EngineState.IntegrityFailure)
+	assert.False(t, eng.EngineState.Migrating)
+	assert.False(t, eng.EngineState.MigrationFailure)
+	assert.False(t, eng.EngineState.Importing)
+	assert.False(t, eng.EngineState.SyncFailure)
+
+	assert.Len(t, workItems, 0)
 }
 
 func TestLoadAndMergeAuxiliaryData(t *testing.T) {

--- a/server/modules/elastalert/validate.go
+++ b/server/modules/elastalert/validate.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
 	"gopkg.in/yaml.v3"
 )
 
@@ -62,6 +63,7 @@ type SigmaRule struct {
 	Level          *SigmaLevel            `yaml:"level"`
 	License        *string                `yaml:"license,omitempty"`
 	Rest           map[string]interface{} `yaml:",inline"`
+	OriginalSource string                 `yaml:"-"`
 }
 
 type LogSource struct {
@@ -128,6 +130,8 @@ func ParseElastAlertRule(data []byte) (*SigmaRule, error) {
 		return nil, err
 	}
 
+	rule.OriginalSource = string(data)
+
 	return rule, nil
 }
 
@@ -182,7 +186,13 @@ func (r *SigmaRule) ToDetection(ruleset string, license string, isCommunity bool
 		}
 	}
 
-	content, _ := yaml.Marshal(r)
+	var content []byte
+
+	if len(r.OriginalSource) > 0 {
+		content = []byte(r.OriginalSource)
+	} else {
+		content, _ = yaml.Marshal(r)
+	}
 
 	author := "unknown"
 	if r.Author != nil {
@@ -200,6 +210,22 @@ func (r *SigmaRule) ToDetection(ruleset string, license string, isCommunity bool
 		Language:    model.SigLangSigma,
 		Ruleset:     ruleset,
 		License:     license,
+	}
+
+	formats := []string{"2006-01-02", "2006/01/02", "2006_01_02"}
+
+	if r.Date != nil {
+		t, err := detections.ParseDate(*r.Date, formats)
+		if err == nil {
+			det.SourceCreated = &t
+		}
+	}
+
+	if r.Modified != nil {
+		t, err := detections.ParseDate(*r.Modified, formats)
+		if err == nil {
+			det.SourceUpdated = &t
+		}
 	}
 
 	if r.Description != nil {

--- a/server/modules/elastalert/validate_test.go
+++ b/server/modules/elastalert/validate_test.go
@@ -8,6 +8,7 @@ package elastalert
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
@@ -274,24 +275,28 @@ func TestToDetection(t *testing.T) {
 					Service:  util.Ptr("test-service"),
 				},
 				Detection: SigmaDetection{},
+				Date:      util.Ptr("2023-10-01"),
+				Modified:  util.Ptr("2023-10-02"),
 			},
 			ruleset:   "test-ruleset",
 			license:   "test-license",
 			community: true,
 			expected: &model.Detection{
-				Title:       "Test Rule",
-				PublicID:    "custom-id",
-				Author:      "test author",
-				Engine:      model.EngineNameElastAlert,
-				Severity:    model.SeverityHigh,
-				Description: "test description",
-				Category:    "test-category",
-				Product:     "test-product",
-				Service:     "test-service",
-				IsCommunity: true,
-				Language:    model.SigLangSigma,
-				Ruleset:     "test-ruleset",
-				License:     "test-license",
+				Title:         "Test Rule",
+				PublicID:      "custom-id",
+				Author:        "test author",
+				Engine:        model.EngineNameElastAlert,
+				Severity:      model.SeverityHigh,
+				Description:   "test description",
+				Category:      "test-category",
+				Product:       "test-product",
+				Service:       "test-service",
+				IsCommunity:   true,
+				Language:      model.SigLangSigma,
+				Ruleset:       "test-ruleset",
+				License:       "test-license",
+				SourceCreated: util.Ptr(time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)),
+				SourceUpdated: util.Ptr(time.Date(2023, 10, 2, 0, 0, 0, 0, time.UTC)),
 			},
 		},
 		{

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -533,7 +533,6 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			// hasChanged = hasChanged || len(detect.Overrides) != 0
 			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
 			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -533,8 +533,6 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
-			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 
 			if hasChanged {
 				logger.WithFields(log.Fields{

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -533,7 +533,7 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			hasChanged = hasChanged || len(detect.Overrides) != 0
+			// hasChanged = hasChanged || len(detect.Overrides) != 0
 			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
 			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -86,6 +86,7 @@ private rule MetadataExample {
 	meta:
 		author = "John Doe"
 		date = "2023-12-27"
+		date_modified = "2024-05-06"
 		version = "1.0"
 		reference = "http://somewhere.invalid"
 		description = "Example Rule"
@@ -400,6 +401,7 @@ func TestParseRule(t *testing.T) {
 						Reference:   util.Ptr("http://somewhere.invalid"),
 						Description: util.Ptr("Example Rule"),
 						Rest: map[string]string{
+							"date_modified":   "2024-05-06",
 							"my_identifier_1": "Some string data",
 							"my_identifier_2": "24",
 							"my_identifier_3": "true",
@@ -633,17 +635,19 @@ func TestToDetection(t *testing.T) {
 	e := &StrelkaEngine{}
 
 	expected := &model.Detection{
-		Engine:      model.EngineNameStrelka,
-		Language:    model.SigLangYara,
-		PublicID:    "MetadataExample",
-		Author:      "John Doe",
-		Title:       "MetadataExample",
-		Description: "Example Rule",
-		Content:     BasicRuleWMeta,
-		Severity:    model.SeverityUnknown,
-		IsCommunity: true,
-		Ruleset:     "ruleset",
-		License:     "license",
+		Engine:        model.EngineNameStrelka,
+		Language:      model.SigLangYara,
+		PublicID:      "MetadataExample",
+		Author:        "John Doe",
+		Title:         "MetadataExample",
+		Description:   "Example Rule",
+		Content:       BasicRuleWMeta,
+		Severity:      model.SeverityUnknown,
+		IsCommunity:   true,
+		Ruleset:       "ruleset",
+		License:       "license",
+		SourceCreated: util.Ptr(time.Date(2023, 12, 27, 0, 0, 0, 0, time.UTC)),
+		SourceUpdated: util.Ptr(time.Date(2024, 5, 6, 0, 0, 0, 0, time.UTC)),
 	}
 
 	rules, err := e.parseYaraRules([]byte(BasicRuleWMeta))

--- a/server/modules/strelka/validate.go
+++ b/server/modules/strelka/validate.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 )
 
@@ -126,6 +127,23 @@ func (r *YaraRule) ToDetection(license string, ruleset string, isCommunity bool)
 		Language:    model.SigLangYara,
 		Ruleset:     ruleset,
 		License:     lic,
+	}
+
+	formats := []string{"2006-01-02", "2006/01/02", "2006_01_02"}
+
+	if r.Meta.Date != nil {
+		t, err := detections.ParseDate(*r.Meta.Date, formats)
+		if err != nil {
+			det.SourceCreated = &t
+		}
+	}
+
+	modified, ok := r.Meta.Rest["date_modified"]
+	if ok && modified != "" {
+		t, err := detections.ParseDate(modified, formats)
+		if err == nil {
+			det.SourceUpdated = &t
+		}
 	}
 
 	if r.Meta.Author != nil {

--- a/server/modules/strelka/validate.go
+++ b/server/modules/strelka/validate.go
@@ -133,7 +133,7 @@ func (r *YaraRule) ToDetection(license string, ruleset string, isCommunity bool)
 
 	if r.Meta.Date != nil {
 		t, err := detections.ParseDate(*r.Meta.Date, formats)
-		if err != nil {
+		if err == nil {
 			det.SourceCreated = &t
 		}
 	}

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1327,8 +1327,6 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *lo
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
-			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 			hasChanged = hasChanged || modifiedByFilter
 
 			if hasChanged {

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1302,7 +1302,7 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *lo
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			hasChanged = hasChanged || len(detect.Overrides) != 0
+			// hasChanged = hasChanged || len(detect.Overrides) != 0
 			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
 			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 			hasChanged = hasChanged || modifiedByFilter

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -759,6 +759,7 @@ func (e *SuricataEngine) ParseRules(content string, ruleset string) ([]*model.De
 
 		category := checkAndExtractCategory(title)
 
+		var srcCreated, srcUpdated *time.Time
 		severity := model.SeverityUnknown // TODO: Default severity?
 
 		md := parsed.ParseMetaData()
@@ -778,20 +779,44 @@ func (e *SuricataEngine) ParseRules(content string, ruleset string) ([]*model.De
 					severity = model.SeverityCritical
 				}
 			}
+
+			formats := []string{"2006-01-02", "2006/01/02", "2006_01_02"}
+
+			sourceCreated, ok := lo.Find(md, func(m *MetaData) bool {
+				return strings.EqualFold(m.Key, "created_at")
+			})
+			if ok {
+				t, err := detections.ParseDate(sourceCreated.Value, formats)
+				if err == nil {
+					srcCreated = &t
+				}
+			}
+
+			sourceUpdated, ok := lo.Find(md, func(m *MetaData) bool {
+				return strings.EqualFold(m.Key, "updated_at")
+			})
+			if ok {
+				t, err := detections.ParseDate(sourceUpdated.Value, formats)
+				if err == nil {
+					srcUpdated = &t
+				}
+			}
 		}
 
 		d := &model.Detection{
-			IsEnabled: !wasCommented,
-			Author:    ruleset,
-			Category:  category,
-			PublicID:  sid,
-			Title:     title,
-			Severity:  severity,
-			Content:   line,
-			Engine:    model.EngineNameSuricata,
-			Language:  model.SigLangSuricata,
-			Ruleset:   ruleset,
-			License:   lookupLicense(ruleset),
+			IsEnabled:     !wasCommented,
+			Author:        ruleset,
+			Category:      category,
+			PublicID:      sid,
+			Title:         title,
+			Severity:      severity,
+			Content:       line,
+			Engine:        model.EngineNameSuricata,
+			Language:      model.SigLangSuricata,
+			Ruleset:       ruleset,
+			License:       lookupLicense(ruleset),
+			SourceCreated: srcCreated,
+			SourceUpdated: srcUpdated,
 		}
 
 		dets = append(dets, d)
@@ -1302,7 +1327,6 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *lo
 		if exists {
 			hasChanged := orig.Content != detect.Content
 			hasChanged = hasChanged || orig.Ruleset != detect.Ruleset
-			// hasChanged = hasChanged || len(detect.Overrides) != 0
 			hasChanged = hasChanged || !util.Equal(orig.SourceCreated, detect.SourceCreated)
 			hasChanged = hasChanged || !util.Equal(orig.SourceUpdated, detect.SourceUpdated)
 			hasChanged = hasChanged || modifiedByFilter

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -495,17 +495,19 @@ func TestParse(t *testing.T) {
 			},
 			ExpectedDetections: []*model.Detection{
 				{
-					Author:    ruleset,
-					PublicID:  SimpleRuleSID,
-					Title:     `GPL ATTACK_RESPONSE id check returned root`,
-					Category:  `GPL ATTACK_RESPONSE`,
-					Severity:  model.SeverityUnknown,
-					Content:   SimpleRule,
-					IsEnabled: true,
-					Engine:    model.EngineNameSuricata,
-					Language:  model.SigLangSuricata,
-					Ruleset:   ruleset,
-					License:   "Unknown",
+					Author:        ruleset,
+					PublicID:      SimpleRuleSID,
+					Title:         `GPL ATTACK_RESPONSE id check returned root`,
+					Category:      `GPL ATTACK_RESPONSE`,
+					Severity:      model.SeverityUnknown,
+					Content:       SimpleRule,
+					IsEnabled:     true,
+					Engine:        model.EngineNameSuricata,
+					Language:      model.SigLangSuricata,
+					Ruleset:       ruleset,
+					License:       "Unknown",
+					SourceCreated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
+					SourceUpdated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
 				},
 				{
 					Author:   ruleset,
@@ -1811,17 +1813,19 @@ func TestReadCustomRulesets(t *testing.T) {
 				{
 					PublicID: SimpleRuleSID,
 
-					Title:       "GPL ATTACK_RESPONSE id check returned root",
-					Severity:    model.SeverityUnknown,
-					Author:      "ruleset",
-					Category:    "GPL ATTACK_RESPONSE",
-					Content:     "alert http any any -> any any (msg:\"GPL ATTACK_RESPONSE id check returned root\"; content:\"uid=0|28|root|29|\"; classtype:bad-unknown; sid:10000; rev:7; metadata:created_at 2010_09_23, updated_at 2010_09_23;)",
-					IsEnabled:   true,
-					IsCommunity: true,
-					Engine:      model.EngineNameSuricata,
-					Language:    model.SigLangSuricata,
-					Ruleset:     "ruleset",
-					License:     "DRL",
+					Title:         "GPL ATTACK_RESPONSE id check returned root",
+					Severity:      model.SeverityUnknown,
+					Author:        "ruleset",
+					Category:      "GPL ATTACK_RESPONSE",
+					Content:       "alert http any any -> any any (msg:\"GPL ATTACK_RESPONSE id check returned root\"; content:\"uid=0|28|root|29|\"; classtype:bad-unknown; sid:10000; rev:7; metadata:created_at 2010_09_23, updated_at 2010_09_23;)",
+					IsEnabled:     true,
+					IsCommunity:   true,
+					Engine:        model.EngineNameSuricata,
+					Language:      model.SigLangSuricata,
+					Ruleset:       "ruleset",
+					License:       "DRL",
+					SourceCreated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
+					SourceUpdated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
 				},
 			},
 		},
@@ -1843,17 +1847,19 @@ func TestReadCustomRulesets(t *testing.T) {
 				{
 					PublicID: SimpleRuleSID,
 
-					Title:       "GPL ATTACK_RESPONSE id check returned root",
-					Severity:    model.SeverityUnknown,
-					Author:      "ruleset",
-					Category:    "GPL ATTACK_RESPONSE",
-					Content:     "alert http any any -> any any (msg:\"GPL ATTACK_RESPONSE id check returned root\"; content:\"uid=0|28|root|29|\"; classtype:bad-unknown; sid:10000; rev:7; metadata:created_at 2010_09_23, updated_at 2010_09_23;)",
-					IsEnabled:   true,
-					IsCommunity: true,
-					Engine:      model.EngineNameSuricata,
-					Language:    model.SigLangSuricata,
-					Ruleset:     "ruleset",
-					License:     "DRL",
+					Title:         "GPL ATTACK_RESPONSE id check returned root",
+					Severity:      model.SeverityUnknown,
+					Author:        "ruleset",
+					Category:      "GPL ATTACK_RESPONSE",
+					Content:       "alert http any any -> any any (msg:\"GPL ATTACK_RESPONSE id check returned root\"; content:\"uid=0|28|root|29|\"; classtype:bad-unknown; sid:10000; rev:7; metadata:created_at 2010_09_23, updated_at 2010_09_23;)",
+					IsEnabled:     true,
+					IsCommunity:   true,
+					Engine:        model.EngineNameSuricata,
+					Language:      model.SigLangSuricata,
+					Ruleset:       "ruleset",
+					License:       "DRL",
+					SourceCreated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
+					SourceUpdated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
 				},
 			},
 		},
@@ -2586,6 +2592,128 @@ func TestSyncModifiedByFilter(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"abc"}, workDocIds) // update has an id, create does not, delete does
+}
+
+func TestSyncUnchangedOverrides(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+	bim := servermock.NewMockBulkIndexer(ctrl)
+	cfgStore := server.NewMemConfigStore([]*model.Setting{
+		{Id: "idstools.rules.local__rules", Value: SimpleRule},
+		{Id: "idstools.sids.enabled", Value: SimpleRuleSID},
+		{Id: "idstools.sids.disabled"},
+		{Id: "idstools.sids.modify", Value: SimpleRuleSID + ` "rev:1" "rev:2"`},
+		{Id: "suricata.thresholding.sids__yaml"},
+		{Id: "idstools.config.ruleset", Value: "repo"},
+		{Id: "soc.config.server.modules.suricataengine.ignoredSidRanges"},
+	})
+
+	migrationChecked := false
+	checkMigration := func() {
+		migrationChecked = true
+	}
+
+	eng := &SuricataEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+			Configstore:    cfgStore,
+			Context:        ctx,
+		},
+		isRunning:            true,
+		communityRulesFile:   "communityRulesFile",
+		rulesFingerprintFile: "rulesFingerprintFile",
+		checkMigrationsOnce:  sync.OnceFunc(checkMigration),
+		allRulesFile:         "allRulesFile",
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager:       iom,
+		showAiSummaries: false,
+	}
+
+	logger := log.WithField("detectionEngine", "test-suricata")
+
+	workItems := []esutil.BulkIndexerItem{}
+
+	// readAndHash
+	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule), nil)
+	// syncCommunityDetections
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		SimpleRuleSID: {
+			Auditable: model.Auditable{
+				Id:         "abc",
+				CreateTime: util.Ptr(time.Now()),
+			},
+			IsEnabled:     true,
+			Content:       SimpleRule,
+			Ruleset:       "repo",
+			SourceCreated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
+			SourceUpdated: util.Ptr(time.Date(2010, 9, 23, 0, 0, 0, 0, time.UTC)),
+			Overrides: []*model.Override{
+				{
+					IsEnabled: true,
+					Type:      "modify",
+					OverrideParameters: model.OverrideParameters{
+						Regex: util.Ptr("rev:1"),
+						Value: util.Ptr("rev:2"),
+					},
+				},
+			},
+		},
+	}, nil)
+	detStore.EXPECT().BuildBulkIndexer(gomock.Any(), gomock.Any()).Return(bim, nil)
+	detStore.EXPECT().ConvertObjectToDocument(gomock.Any(), "detection", gomock.Any(), gomock.Any(), gomock.Any(), nil, nil).Return([]byte("document"), "index", nil)
+	bim.EXPECT().Close(gomock.Any()).Return(nil)
+	bim.EXPECT().Stats().Return(esutil.BulkIndexerStats{})
+
+	// WriteStateFile
+	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	iom.EXPECT().WriteFile("rulesFingerprintFile", gomock.Any(), fs.FileMode(0644)).Return(nil)
+	// IntegrityCheck
+	iom.EXPECT().ReadFile("allRulesFile").Return([]byte(SimpleRule), nil)
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
+		SimpleRuleSID: nil,
+	}, nil)
+
+	err := eng.Sync(logger, true)
+	assert.NoError(t, err)
+
+	assert.True(t, eng.EngineState.Syncing) // stays true until the SyncScheduler resets it
+	assert.False(t, eng.EngineState.IntegrityFailure)
+	assert.False(t, eng.EngineState.Migrating)
+	assert.False(t, eng.EngineState.MigrationFailure)
+	assert.False(t, eng.EngineState.Importing)
+	assert.False(t, eng.EngineState.SyncFailure)
+	assert.True(t, migrationChecked)
+
+	allSettings, err := cfgStore.GetSettings(ctx, true)
+	assert.NoError(t, err)
+
+	enabled := settingByID(allSettings, "idstools.sids.enabled")
+	assert.NotNil(t, enabled)
+	assert.Equal(t, SimpleRuleSID, enabled.Value)
+
+	disabled := settingByID(allSettings, "idstools.sids.disabled")
+	assert.NotNil(t, disabled)
+	assert.Equal(t, "", disabled.Value)
+
+	modify := settingByID(allSettings, "idstools.sids.modify")
+	assert.NotNil(t, modify)
+	assert.Equal(t, `10000 "rev:1" "rev:2"`, modify.Value)
+
+	threshold := settingByID(allSettings, "suricata.thresholding.sids__yaml")
+	assert.NotNil(t, threshold)
+	assert.Equal(t, "{}\n", threshold.Value)
+
+	assert.Len(t, workItems, 0)
 }
 
 func TestApplyFilters(t *testing.T) {

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -37,6 +37,7 @@ import (
 const (
 	SimpleRuleSID    = "10000"
 	SimpleRule       = `alert http any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000; rev:7; metadata:created_at 2010_09_23, updated_at 2010_09_23;)`
+	SimpleRule2      = `alert http any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000; rev:7; metadata:created_at 2010_09_23, updated_at 2025_05_03;)`
 	FlowbitsRuleASID = "50000"
 	FlowbitsRuleA    = `alert http any any -> any any ( msg:"RULE A"; flow: established,to_server; http.method; content:"POST"; http.content_type; content:"x-www-form-urlencoded"; flowbits: set, test; sid:50000;)`
 	FlowbitsRuleBSID = "60000"
@@ -1028,7 +1029,7 @@ func TestSyncCommunitySuricata(t *testing.T) {
 				{
 					Auditable:   model.Auditable{Id: "1"},
 					PublicID:    SimpleRuleSID,
-					Content:     SimpleRule,
+					Content:     SimpleRule2,
 					IsEnabled:   false,
 					IsCommunity: true,
 				},


### PR DESCRIPTION
Removed overrides as cause for a detection to be updated in elasticsearch during a sync. This was erroneously marking a detection as updated and expanding it's history even though no worthwhile changes were actually made for any detection that has an override on every sync. While developing regression tests, it was observed that SourceUpdated and SourceCreated weren't always properly filled and thus might also cause a detection to be updated when nothing changed, this was fixed as well.