### PR TITLE
DetectionEngines sync.Map

### DIFF
--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -121,13 +121,15 @@ func (h *DetectionHandler) GetDetection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	eng, ok := h.server.DetectionEngines[detect.Engine]
+	engInt, ok := h.server.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		logger.WithFields(log.Fields{
 			"detectionEngine":   detect.Engine,
 			"detectionPublicId": detectId,
 		}).Error("retrieved detection with unsupported engine")
 	} else {
+		eng := engInt.(DetectionEngine)
+
 		err = eng.MergeAuxiliaryData(detect)
 		if err != nil {
 			logger.WithError(err).WithFields(log.Fields{
@@ -173,13 +175,15 @@ func (h *DetectionHandler) GetByPublicId(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	eng, ok := h.server.DetectionEngines[detect.Engine]
+	engInt, ok := h.server.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		logger.WithFields(log.Fields{
 			"detectionEngine":   detect.Engine,
 			"detectionPublicId": publicId,
 		}).Error("retrieved detection with unsupported engine")
 	} else {
+		eng := engInt.(DetectionEngine)
+
 		err = eng.MergeAuxiliaryData(detect)
 		if err != nil {
 			logger.WithError(err).WithFields(log.Fields{
@@ -245,11 +249,13 @@ func (h *DetectionHandler) CreateDetection(w http.ResponseWriter, r *http.Reques
 		detect.Engine = model.EngineNameSuricata
 	}
 
-	engine, ok := h.server.DetectionEngines[detect.Engine]
+	engInt, ok := h.server.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		web.Respond(w, r, http.StatusBadRequest, errors.New("unsupported engine"))
 		return
 	}
+
+	engine := engInt.(DetectionEngine)
 
 	_, err = engine.ValidateRule(detect.Content)
 	if err != nil {
@@ -368,11 +374,13 @@ func (h *DetectionHandler) DuplicateDetection(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	eng, ok := h.server.DetectionEngines[detect.Engine]
+	engInt, ok := h.server.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		web.Respond(w, r, http.StatusBadRequest, errors.New("unsupported engine"))
 		return
 	}
+
+	eng := engInt.(DetectionEngine)
 
 	dupe, err := eng.DuplicateDetection(ctx, detect)
 	if err != nil {
@@ -422,11 +430,13 @@ func (h *DetectionHandler) UpdateDetection(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	eng, ok := h.server.DetectionEngines[detect.Engine]
+	engInt, ok := h.server.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		web.Respond(w, r, http.StatusBadRequest, errors.New("unsupported engine"))
 		return
 	}
+
+	eng := engInt.(DetectionEngine)
 
 	_, err = eng.ValidateRule(detect.Content)
 	if err != nil {
@@ -808,7 +818,7 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 		detect := detects[i]
 		id := detect.Id
 
-		engine, ok := h.server.DetectionEngines[detect.Engine]
+		engineInt, ok := h.server.DetectionEngines.Load(detect.Engine)
 		if !ok {
 			logger.WithFields(log.Fields{
 				"publicId": detect.PublicID,
@@ -818,6 +828,8 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 
 			continue
 		}
+
+		engine := engineInt.(DetectionEngine)
 
 		if !body.Delete {
 			detect.IsEnabled = body.NewStatus
@@ -1004,19 +1016,26 @@ func syncLocalDetections(ctx context.Context, srv *Server, detections []*model.D
 		byEngine[detect.Engine] = append(byEngine[detect.Engine], detect)
 	}
 
-	for name, engine := range srv.DetectionEngines {
+	srv.DetectionEngines.Range(func(n, engineInt interface{}) bool {
+		name := n.(model.EngineName)
+		engine := engineInt.(DetectionEngine)
+
 		if len(byEngine[name]) != 0 {
-			eMap, err := engine.SyncLocalDetections(ctx, byEngine[name])
+			var eMap map[string]string
+
+			eMap, err = engine.SyncLocalDetections(ctx, byEngine[name])
 			for sid, e := range eMap {
 				errMap[sid] = e
 			}
 			if err != nil {
-				return errMap, err
+				return false
 			}
 		}
-	}
 
-	return errMap, nil
+		return true
+	})
+
+	return errMap, err
 }
 
 // @Summary      Create Detection Comment
@@ -1211,7 +1230,10 @@ func (h *DetectionHandler) ConvertContent(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	eaQuery, err := h.server.DetectionEngines[model.EngineNameElastAlert].ConvertRule(ctx, det)
+	engInt, _ := h.server.DetectionEngines.Load(model.EngineNameElastAlert)
+	eng := engInt.(DetectionEngine)
+
+	eaQuery, err := eng.ConvertRule(ctx, det)
 	if err != nil {
 		web.Respond(w, r, http.StatusInternalServerError, err)
 		return
@@ -1247,15 +1269,20 @@ func (h *DetectionHandler) SyncEngineDetections(w http.ResponseWriter, r *http.R
 	fullUpgrade := typ == "full"
 
 	if engine == "all" {
-		for _, engine := range h.server.DetectionEngines {
-			engine.InterruptSync(fullUpgrade, true)
-		}
+		h.server.DetectionEngines.Range(func(_, engineInt interface{}) bool {
+			eng := engineInt.(DetectionEngine)
+			eng.InterruptSync(fullUpgrade, true)
+
+			return true
+		})
 	} else {
-		engine, ok := h.server.DetectionEngines[model.EngineName(engine)]
+		engInt, ok := h.server.DetectionEngines.Load(model.EngineName(engine))
 		if !ok {
 			web.Respond(w, r, http.StatusBadRequest, errors.New("unknown engine"))
 			return
 		}
+
+		engine := engInt.(DetectionEngine)
 
 		engine.InterruptSync(fullUpgrade, true)
 	}
@@ -1280,11 +1307,13 @@ func (h *DetectionHandler) GenPublicId(w http.ResponseWriter, r *http.Request) {
 
 	engine := chi.URLParam(r, "engine")
 
-	eng, ok := h.server.DetectionEngines[model.EngineName(engine)]
+	engInt, ok := h.server.DetectionEngines.Load(model.EngineName(engine))
 	if !ok {
 		web.Respond(w, r, http.StatusBadRequest, errors.New("unsupported engine"))
 		return
 	}
+
+	eng := engInt.(DetectionEngine)
 
 	id, err := eng.GenerateUnusedPublicId(ctx)
 	if err != nil {

--- a/server/detectionshandler_test.go
+++ b/server/detectionshandler_test.go
@@ -398,7 +398,7 @@ func TestHandlerGetDetection(t *testing.T) {
 				mDetStore.EXPECT().GetDetection(gomock.Any(), "12345").Return(det, nil)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = eng
+				srv.DetectionEngines.Store(model.EngineNameSuricata, eng)
 
 				eng.EXPECT().MergeAuxiliaryData(det).Return(nil)
 			},
@@ -463,7 +463,7 @@ func TestHandlerGetDetection(t *testing.T) {
 				mDetStore.EXPECT().GetDetection(gomock.Any(), "12345").Return(det, nil)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = eng
+				srv.DetectionEngines.Store(model.EngineNameSuricata, eng)
 
 				eng.EXPECT().MergeAuxiliaryData(det).Return(errors.New("failed to merge"))
 			},
@@ -558,7 +558,7 @@ func TestHandlerGetByPublicId(t *testing.T) {
 				mDetStore.EXPECT().GetDetectionByPublicId(gomock.Any(), "12345").Return(det, nil)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = eng
+				srv.DetectionEngines.Store(model.EngineNameSuricata, eng)
 
 				eng.EXPECT().MergeAuxiliaryData(det).Return(nil)
 			},
@@ -634,7 +634,7 @@ func TestHandlerGetByPublicId(t *testing.T) {
 				mDetStore.EXPECT().GetDetectionByPublicId(gomock.Any(), "12345").Return(det, nil)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = eng
+				srv.DetectionEngines.Store(model.EngineNameSuricata, eng)
 
 				eng.EXPECT().MergeAuxiliaryData(det).Return(errors.New("failed to merge"))
 			},
@@ -726,7 +726,7 @@ func TestHandlerCreateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
@@ -809,7 +809,7 @@ func TestHandlerCreateDetection(t *testing.T) {
 			ReqBody: []byte(`{"language":"suricata","content":"test"}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = eng
+				srv.DetectionEngines.Store(model.EngineNameSuricata, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", errors.New("something went wrong"))
 			},
@@ -829,7 +829,7 @@ func TestHandlerCreateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
@@ -877,7 +877,7 @@ func TestHandlerCreateDetection(t *testing.T) {
 			ReqBody: []byte(`{"language":"sigma","content":"test"}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ExtractDetails(gomock.Any()).Return(errors.New("rule does not contain a public Id"))
@@ -891,7 +891,7 @@ func TestHandlerCreateDetection(t *testing.T) {
 			ReqBody: []byte(`{"language":"sigma","content":"test"}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ExtractDetails(gomock.Any()).Return(errors.New("something went wrong"))
@@ -911,7 +911,7 @@ func TestHandlerCreateDetection(t *testing.T) {
 				mUserStore := srv.Userstore.(*servermock.MockUserstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
@@ -1108,7 +1108,7 @@ func TestHandlerDuplicateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				orig := &model.Detection{
 					PublicID: "Original",
@@ -1170,7 +1170,7 @@ func TestHandlerDuplicateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				orig := &model.Detection{
 					PublicID: "Original",
@@ -1194,7 +1194,7 @@ func TestHandlerDuplicateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				orig := &model.Detection{
 					PublicID: "Original",
@@ -1295,7 +1295,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1353,7 +1353,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1433,7 +1433,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 			ReqBody: []byte(`{"engine":"suricata","content":"test"}`),
 			InitMock: func(t *testing.T, srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = eng
+				srv.DetectionEngines.Store(model.EngineNameSuricata, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", errors.New("something went wrong"))
 			},
@@ -1451,7 +1451,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1472,7 +1472,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1497,7 +1497,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 			ReqBody: []byte(`{"engine":"strelka","content":"test"}`),
 			InitMock: func(t *testing.T, srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1515,7 +1515,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 			ReqBody: []byte(`{"engine":"strelka","content":"test"}`),
 			InitMock: func(t *testing.T, srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1536,7 +1536,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1559,7 +1559,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1584,7 +1584,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1610,7 +1610,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1658,7 +1658,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
@@ -1697,7 +1697,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).DoAndReturn(func(det *model.Detection) (bool, error) {
@@ -1733,7 +1733,7 @@ func TestHandlerUpdateDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().ValidateRule(gomock.Any()).Return("", nil)
 				eng.EXPECT().ApplyFilters(gomock.Any()).DoAndReturn(func(det *model.Detection) (bool, error) {
@@ -1978,7 +1978,7 @@ func TestHandlerDeleteDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				orig := &model.Detection{
 					PublicID: "Original",
@@ -2069,7 +2069,7 @@ func TestHandlerDeleteDetection(t *testing.T) {
 				mAuth := srv.Authorizer.(*rbac.FakeAuthorizer)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				mDetStore.EXPECT().GetDetection(gomock.Any(), "12345").Return(&model.Detection{}, nil)
 
@@ -2093,7 +2093,7 @@ func TestHandlerDeleteDetection(t *testing.T) {
 				mDetStore := srv.Detectionstore.(*servermock.MockDetectionstore)
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				mDetStore.EXPECT().GetDetection(gomock.Any(), "12345").Return(&model.Detection{}, nil)
 
@@ -2188,13 +2188,13 @@ func TestHandlerBulkUpdateDetection(t *testing.T) {
 				mHostAuth := srv.Host.Authorizer.(*rbac.FakeAuthorizer)
 
 				engElastAlert := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = engElastAlert
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, engElastAlert)
 
 				engSuricata := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = engSuricata
+				srv.DetectionEngines.Store(model.EngineNameSuricata, engSuricata)
 
 				engStrelka := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = engStrelka
+				srv.DetectionEngines.Store(model.EngineNameStrelka, engStrelka)
 
 				mAuth.Authorized = true
 
@@ -2345,13 +2345,14 @@ func TestHandlerBulkUpdateDetection(t *testing.T) {
 				mHostAuth := srv.Host.Authorizer.(*rbac.FakeAuthorizer)
 
 				engElastAlert := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = engElastAlert
+				// srv.DetectionEngines[model.EngineNameElastAlert] = engElastAlert
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, engElastAlert)
 
 				engSuricata := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = engSuricata
+				srv.DetectionEngines.Store(model.EngineNameSuricata, engSuricata)
 
 				engStrelka := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = engStrelka
+				srv.DetectionEngines.Store(model.EngineNameStrelka, engStrelka)
 
 				mAuth.Authorized = true
 
@@ -3329,7 +3330,7 @@ func TestHandlerConvertContent(t *testing.T) {
 			ReqBody: []byte(`{"content": "sigma goes here", "engine": "elastalert"}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ConvertRule(gomock.Any(), &model.Detection{Content: "sigma goes here", Engine: model.EngineNameElastAlert}).Return("converted query", nil)
 			},
@@ -3369,7 +3370,7 @@ func TestHandlerConvertContent(t *testing.T) {
 			ReqBody: []byte(`{"language": "sigma", "content": "sigma goes here"}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ConvertRule(gomock.Any(), &model.Detection{Content: "sigma goes here", Language: model.SigLangSigma}).Return("converted query", nil)
 			},
@@ -3386,7 +3387,7 @@ func TestHandlerConvertContent(t *testing.T) {
 			ReqBody: []byte(`{"engine": "elastalert", "content": "sigma goes here"}`),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().ConvertRule(gomock.Any(), &model.Detection{Content: "sigma goes here", Engine: model.EngineNameElastAlert}).Return("", errors.New("something went wrong"))
 			},
@@ -3473,7 +3474,7 @@ func TestHandlerSyncEngineDetections(t *testing.T) {
 				mAuth.Authorized = true
 
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().InterruptSync(true, true)
 			},
@@ -3492,17 +3493,17 @@ func TestHandlerSyncEngineDetections(t *testing.T) {
 				mAuth.Authorized = true
 
 				engElastAlert := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = engElastAlert
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, engElastAlert)
 
 				engSuricata := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameSuricata] = engSuricata
+				srv.DetectionEngines.Store(model.EngineNameSuricata, engSuricata)
 
 				engStrelka := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = engStrelka
+				srv.DetectionEngines.Store(model.EngineNameStrelka, engStrelka)
 
 				// all means all
 				engWhatever := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines["whatever"] = engWhatever
+				srv.DetectionEngines.Store(model.EngineName("whatever"), engWhatever)
 
 				engElastAlert.EXPECT().InterruptSync(false, true)
 				engSuricata.EXPECT().InterruptSync(false, true)
@@ -3616,7 +3617,7 @@ func TestHandlerGenPublicId(t *testing.T) {
 			Engine: string(model.EngineNameElastAlert),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameElastAlert] = eng
+				srv.DetectionEngines.Store(model.EngineNameElastAlert, eng)
 
 				eng.EXPECT().GenerateUnusedPublicId(gomock.Any()).Return("unused-public-id", nil)
 			},
@@ -3644,7 +3645,7 @@ func TestHandlerGenPublicId(t *testing.T) {
 			Engine: string(model.EngineNameStrelka),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().GenerateUnusedPublicId(gomock.Any()).Return("", errors.New("not implemented"))
 			},
@@ -3658,7 +3659,7 @@ func TestHandlerGenPublicId(t *testing.T) {
 			Engine: string(model.EngineNameStrelka),
 			InitMock: func(srv *Server, ctrl *gomock.Controller) {
 				eng := servermock.NewMockDetectionEngine(ctrl)
-				srv.DetectionEngines[model.EngineNameStrelka] = eng
+				srv.DetectionEngines.Store(model.EngineNameStrelka, eng)
 
 				eng.EXPECT().GenerateUnusedPublicId(gomock.Any()).Return("", errors.New("something went wrong"))
 			},

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -314,7 +314,7 @@ func (e *ElastAlertEngine) Init(config module.ModuleConfig) (err error) {
 }
 
 func (e *ElastAlertEngine) Start() error {
-	e.srv.DetectionEngines[model.EngineNameElastAlert] = e
+	e.srv.DetectionEngines.Store(model.EngineNameElastAlert, e)
 	e.isRunning = true
 	e.IntegrityCheckerData.IsRunning = true
 

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -125,7 +126,7 @@ func TestCheckEnabledSigmaRule(t *testing.T) {
 
 func TestElastAlertModule(t *testing.T) {
 	srv := &server.Server{
-		DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+		DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 	}
 	mod := NewElastAlertEngine(srv)
 
@@ -145,8 +146,16 @@ func TestElastAlertModule(t *testing.T) {
 	err = mod.Stop()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, len(srv.DetectionEngines))
-	assert.Same(t, mod, srv.DetectionEngines[model.EngineNameElastAlert])
+	count := 0
+	srv.DetectionEngines.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 1, count)
+
+	m, ok := srv.DetectionEngines.Load(model.EngineNameElastAlert)
+	assert.True(t, ok)
+	assert.Same(t, mod, m)
 }
 
 func TestParseSigmaPackages(t *testing.T) {
@@ -1379,11 +1388,11 @@ sofilter_hosts:
 			mockIO := mock.NewMockIOManager(ctrl)
 
 			mod := NewElastAlertEngine(&server.Server{
-				DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+				DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 			})
 
 			mod.IOManager = mockIO
-			mod.srv.DetectionEngines[model.EngineNameElastAlert] = mod
+			mod.srv.DetectionEngines.Store(model.EngineNameElastAlert, mod)
 
 			if test.InitMock != nil {
 				test.InitMock(mod, mockIO)

--- a/server/modules/navigator/navigator_test.go
+++ b/server/modules/navigator/navigator_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -78,7 +79,7 @@ func setupTest(t *testing.T) *testSetup {
 
 	srv := &server.Server{
 		Context:          context.Background(),
-		DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+		DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 		Detectionstore:   mockDetectionstore,
 		Eventstore:       fakeEventstore,
 	}

--- a/server/modules/sostatus/sostatus.go
+++ b/server/modules/sostatus/sostatus.go
@@ -203,20 +203,25 @@ func (status *SoStatus) refreshGrid(ctx context.Context) {
 func (status *SoStatus) refreshDetections(ctx context.Context) {
 	localGridStatus := status.statusByGridId[model.LOCAL_GRID_ID]
 
-	if _, exists := status.server.DetectionEngines[model.EngineNameElastAlert]; exists {
+	eng, exists := status.server.DetectionEngines.Load(model.EngineNameElastAlert)
+	if exists {
 		localGridStatus.Detections.ElastAlert = status.checkDetectionEngineStatus("ElastAlert2",
 			localGridStatus.Detections.ElastAlert,
-			status.server.DetectionEngines[model.EngineNameElastAlert].GetState())
+			eng.(server.DetectionEngine).GetState())
 	}
-	if _, exists := status.server.DetectionEngines[model.EngineNameSuricata]; exists {
+
+	eng, exists = status.server.DetectionEngines.Load(model.EngineNameSuricata)
+	if exists {
 		localGridStatus.Detections.Suricata = status.checkDetectionEngineStatus("Suricata",
 			localGridStatus.Detections.Suricata,
-			status.server.DetectionEngines[model.EngineNameSuricata].GetState())
+			eng.(server.DetectionEngine).GetState())
 	}
-	if _, exists := status.server.DetectionEngines[model.EngineNameStrelka]; exists {
+
+	eng, exists = status.server.DetectionEngines.Load(model.EngineNameStrelka)
+	if exists {
 		localGridStatus.Detections.Strelka = status.checkDetectionEngineStatus("Strelka",
 			localGridStatus.Detections.Strelka,
-			status.server.DetectionEngines[model.EngineNameStrelka].GetState())
+			eng.(server.DetectionEngine).GetState())
 	}
 }
 

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -148,7 +148,7 @@ func (e *StrelkaEngine) Init(config module.ModuleConfig) (err error) {
 }
 
 func (e *StrelkaEngine) Start() error {
-	e.srv.DetectionEngines[model.EngineNameStrelka] = e
+	e.srv.DetectionEngines.Store(model.EngineNameStrelka, e)
 	e.isRunning = true
 
 	// start long running processes

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -231,7 +232,7 @@ rule ExtractableRule {
 
 func TestStrelkaModule(t *testing.T) {
 	srv := &server.Server{
-		DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+		DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 	}
 	mod := NewStrelkaEngine(srv)
 
@@ -251,8 +252,16 @@ func TestStrelkaModule(t *testing.T) {
 	err = mod.Stop()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, len(srv.DetectionEngines))
-	assert.Same(t, mod, srv.DetectionEngines[model.EngineNameStrelka])
+	count := 0
+	srv.DetectionEngines.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 1, count)
+
+	m, ok := srv.DetectionEngines.Load(model.EngineNameStrelka)
+	assert.True(t, ok)
+	assert.Same(t, mod, m)
 }
 
 func TestCheckAutoEnabledYaraRule(t *testing.T) {
@@ -340,11 +349,11 @@ func TestSyncStrelka(t *testing.T) {
 			iom := mock.NewMockIOManager(ctrl)
 
 			mod := NewStrelkaEngine(&server.Server{
-				DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+				DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 				Detectionstore:   mockDetStore,
 			})
 			mod.isRunning = true
-			mod.srv.DetectionEngines[model.EngineNameSuricata] = mod
+			mod.srv.DetectionEngines.Store(model.EngineNameSuricata, mod)
 			mod.IOManager = iom
 
 			mod.compileYaraPythonScriptPath = "compileYaraPythonScriptPath"

--- a/server/modules/suricata/migration-2.4.70.go
+++ b/server/modules/suricata/migration-2.4.70.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
 
 	"github.com/apex/log"
 	"gopkg.in/yaml.v3"
@@ -117,7 +118,10 @@ func (e *SuricataEngine) Migration2470(statePath string) error {
 	}
 
 	// sync suricata
-	errMap, err := e.srv.DetectionEngines[model.EngineNameSuricata].SyncLocalDetections(ctx, dirtyDets)
+	engInt, _ := e.srv.DetectionEngines.Load(model.EngineNameSuricata)
+	eng := engInt.(server.DetectionEngine)
+
+	errMap, err := eng.SyncLocalDetections(ctx, dirtyDets)
 	if err != nil {
 		return err
 	}

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -178,7 +178,7 @@ func (e *SuricataEngine) Init(config module.ModuleConfig) (err error) {
 }
 
 func (e *SuricataEngine) Start() error {
-	e.srv.DetectionEngines[model.EngineNameSuricata] = e
+	e.srv.DetectionEngines.Store(model.EngineNameSuricata, e)
 	e.isRunning = true
 	e.IntegrityCheckerData.IsRunning = true
 

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -59,7 +59,7 @@ func emptySettings() []*model.Setting {
 
 func TestSuricataModule(t *testing.T) {
 	srv := &server.Server{
-		DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+		DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 	}
 	mod := NewSuricataEngine(srv)
 
@@ -79,8 +79,16 @@ func TestSuricataModule(t *testing.T) {
 	err = mod.Stop()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, len(srv.DetectionEngines))
-	assert.Same(t, mod, srv.DetectionEngines[model.EngineNameSuricata])
+	count := 0
+	srv.DetectionEngines.Range(func(k, v interface{}) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 1, count)
+
+	m, ok := srv.DetectionEngines.Load(model.EngineNameSuricata)
+	assert.True(t, ok)
+	assert.Same(t, mod, m)
 }
 
 func TestSettingByID(t *testing.T) {
@@ -875,9 +883,9 @@ func TestSyncLocalSuricata(t *testing.T) {
 			mCfgStore := server.NewMemConfigStore(test.InitialSettings)
 			mod := NewSuricataEngine(&server.Server{
 				Configstore:      mCfgStore,
-				DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+				DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 			})
-			mod.srv.DetectionEngines[model.EngineNameSuricata] = mod
+			mod.srv.DetectionEngines.Store(model.EngineNameSuricata, mod)
 
 			mod.isRunning = true
 
@@ -1099,10 +1107,10 @@ func TestSyncCommunitySuricata(t *testing.T) {
 			mCfgStore := server.NewMemConfigStore(test.InitialSettings)
 			mod := NewSuricataEngine(&server.Server{
 				Configstore:      mCfgStore,
-				DetectionEngines: map[model.EngineName]server.DetectionEngine{},
+				DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 				Detectionstore:   detStore,
 			})
-			mod.srv.DetectionEngines[model.EngineNameSuricata] = mod
+			mod.srv.DetectionEngines.Store(model.EngineNameSuricata, mod)
 
 			mod.isRunning = true
 

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/security-onion-solutions/securityonion-soc/config"
@@ -44,7 +45,7 @@ type Server struct {
 	Agent            *model.User
 	Context          context.Context
 	Playbookstore    Playbookstore
-	DetectionEngines map[model.EngineName]DetectionEngine
+	DetectionEngines sync.Map // map[model.EngineName]DetectionEngine
 	ApiRouter        *chi.Mux
 	Statusstore      Statusstore
 }
@@ -54,7 +55,7 @@ func NewServer(cfg *config.ServerConfig, version string) *Server {
 		Config:           cfg,
 		Host:             web.NewHost(cfg.BindAddress, cfg.HtmlDir, cfg.IdleConnectionTimeoutMs, version, cfg.SrvKeyBytes),
 		stoppedChan:      make(chan bool, 1),
-		DetectionEngines: map[model.EngineName]DetectionEngine{},
+		DetectionEngines: sync.Map{},
 	}
 	server.initContext()
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,12 +8,12 @@ package server_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/config"
 	"github.com/security-onion-solutions/securityonion-soc/licensing"
-	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/rbac"
 	. "github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/server/mock"
@@ -53,7 +53,7 @@ func NewMockServer(t *testing.T, ctrl *gomock.Controller, cfg *config.ServerConf
 		Authorizer:       &rbac.FakeAuthorizer{},
 		Agent:            nil,
 		Context:          context.Background(),
-		DetectionEngines: map[model.EngineName]DetectionEngine{},
+		DetectionEngines: sync.Map{}, // map[model.EngineName]DetectionEngine{},
 	}
 
 	return srv


### PR DESCRIPTION
All the Detection Engines load themselves up at about the same time from separate goroutines. Part of this loading is adding themselves to the server's DetectionEngines map. It's blind luck we don't hit this more often, but recently a test failed because of simultaneous writes to the map.

This commit changes the server field from map[model.EngineName]server.DetectionEngine to a sync.Map. This guarantees safe writes every time. All references were updated and all usages were refactored to work with the new type.