### PR TITLE
Fix Test

### DIFF
--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -671,7 +671,7 @@ func TestConvertQuestions(t *testing.T) {
 	}
 
 	iom.EXPECT().ExecCommand(gomock.Any()).DoAndReturn(func(cmd *exec.Cmd) ([]byte, int, time.Duration, error) {
-		assert.True(t, strings.HasSuffix(cmd.Path, "/sigma"))
+		assert.True(t, strings.HasSuffix(cmd.Path, "sigma"))
 		assert.Equal(t, []string{"sigma", "convert", "-t", "security_onion", "-p", "/opt/sensoroni/sigma_final_pipeline.yaml", "-p", "/opt/sensoroni/sigma_so_pipeline.yaml", "-p", "windows-logsources", "-p", "ecs_windows", "--disable-pipeline-check", "/dev/stdin"}, cmd.Args)
 
 		in, err := io.ReadAll(cmd.Stdin)


### PR DESCRIPTION
Locally, when I run the `TestConvertQuestions` test, the sigma cli has a full path. When run in concourse, the sigma cli is just "sigma". Updated the test to work for both situations.