### PR TITLE
Bidirectional Binding

### DIFF
--- a/html/pages/jobs.html
+++ b/html/pages/jobs.html
@@ -15,7 +15,7 @@
 					<v-icon>fa-sync</v-icon>
 				</v-btn>		  
 			</v-toolbar>
-			<v-data-table :sort-by="sortBy" @update:sort-by="val => sortBy = val" :items-per-page-options="itemsPerPageOptions" :items-per-page="itemsPerPage"
+			<v-data-table :sort-by="sortBy" @update:sort-by="val => sortBy = val" :items-per-page-options="itemsPerPageOptions" v-model:items-per-page="itemsPerPage"
 				must-sort :headers="headers" :items="jobs">
 				<template #headers="{ columns, isSorted, getSortIcon, toggleSort }">
 					<tr>


### PR DESCRIPTION
Forgot to include bidirectional binding. The dropdown would default to 10 items per page. If the user changed it, the table would change behavior but we wouldn't notice the new page size to save it. Then when you refresh the page, it defaults of 10 again. We were already watching for the variable change to save it, but without bidirectional binding only the table saw the new value and not our component.