### PR TITLE
Cogburn/rules repo rename

### DIFF
--- a/server/modules/detections/ai_summary.go
+++ b/server/modules/detections/ai_summary.go
@@ -1,10 +1,10 @@
 package detections
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/url"
-	"path"
 	"path/filepath"
 	"sync"
 	"time"
@@ -44,23 +44,19 @@ func RefreshAiSummaries(eng AiLoader, lang model.SigLanguage, isRunning *bool, a
 		logger.Debug("skipping AI summary update because airgap is enabled")
 	}
 
-	parser, err := url.Parse(aiRepoUrl)
-	if err != nil {
-		log.WithError(err).WithField("aiRepoUrl", aiRepoUrl).Error("failed to parse repo URL, doing nothing with it")
-	} else {
-		_, lastFolder := path.Split(parser.Path)
-		repoPath := filepath.Join(aiRepoPath, lastFolder)
+	h := sha256.Sum256([]byte(aiRepoUrl))
+	lastFolder := hex.EncodeToString(h[:])
+	repoPath := filepath.Join(aiRepoPath, lastFolder)
 
-		sums, err := readAiSummary(isRunning, repoPath, lang, logger, iom)
+	sums, err := readAiSummary(isRunning, repoPath, lang, logger, iom)
+	if err != nil {
+		logger.WithError(err).WithField("repoPath", repoPath).Error("unable to read AI summaries")
+	} else {
+		err = eng.LoadAuxiliaryData(sums)
 		if err != nil {
-			logger.WithError(err).WithField("repoPath", repoPath).Error("unable to read AI summaries")
+			logger.WithError(err).Error("unable to load AI summaries")
 		} else {
-			err = eng.LoadAuxiliaryData(sums)
-			if err != nil {
-				logger.WithError(err).Error("unable to load AI summaries")
-			} else {
-				logger.Info("successfully loaded AI summaries")
-			}
+			logger.Info("successfully loaded AI summaries")
 		}
 	}
 

--- a/server/modules/detections/ai_summary_test.go
+++ b/server/modules/detections/ai_summary_test.go
@@ -35,7 +35,7 @@ func TestRefreshAiSummaries(t *testing.T) {
 
 	// No calls to iom.PullRepo/iom.CloneRepo should be made
 	loader.EXPECT().IsAirgapped().Return(true)
-	iom.EXPECT().ReadFile("baseRepoFolder/repo1/detections-ai/sigma_summaries.yaml").Return([]byte(summaries), nil)
+	iom.EXPECT().ReadFile("baseRepoFolder/873c64018dc10d5a0658a4b3905e1cf4f31c8349418abc6bf40b1bc8c019df41/detections-ai/sigma_summaries.yaml").Return([]byte(summaries), nil)
 	loader.EXPECT().LoadAuxiliaryData(gomock.Any()).DoAndReturn(func(sums []*model.AiSummary) error {
 		expected := []*model.AiSummary{
 			{
@@ -89,8 +89,8 @@ func TestRefreshAiSummaries(t *testing.T) {
 	// non-Airgapped test
 	loader.EXPECT().IsAirgapped().Return(false)
 	iom.EXPECT().ReadDir("baseRepoFolder").Return([]fs.DirEntry{}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo2", repo, &branch).Return(nil)
-	iom.EXPECT().ReadFile("baseRepoFolder/repo2/detections-ai/sigma_summaries.yaml").Return([]byte(summaries), nil)
+	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/bf8fb6b1214693731c049b7b1b2822c7831a4bcfd5530e24ddb5e7153ca54c4e", repo, &branch).Return(nil)
+	iom.EXPECT().ReadFile("baseRepoFolder/bf8fb6b1214693731c049b7b1b2822c7831a4bcfd5530e24ddb5e7153ca54c4e/detections-ai/sigma_summaries.yaml").Return([]byte(summaries), nil)
 	loader.EXPECT().LoadAuxiliaryData(gomock.Any()).DoAndReturn(func(sums []*model.AiSummary) error {
 		expected := []*model.AiSummary{
 			{

--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -7,11 +7,12 @@ package detections
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -126,14 +127,10 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 			return nil, false, ErrModuleStopped
 		}
 
-		parser, err := url.Parse(repo.Repo)
-		if err != nil {
-			log.WithError(err).WithField("repoUrl", repo.Repo).Error("Failed to parse repo URL, doing nothing with it")
-			continue
-		}
+		h := sha256.Sum256([]byte(repo.Repo))
 
-		_, lastFolder := path.Split(parser.Path)
-		repoPath := filepath.Join(baseRepoFolder, lastFolder)
+		folderName := hex.EncodeToString(h[:])
+		repoPath := filepath.Join(baseRepoFolder, folderName)
 
 		dirty := &RepoOnDisk{
 			Repo: repo,
@@ -143,7 +140,7 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 		reclone := false
 		skipRepo := false
 
-		_, ok := existingRepos[lastFolder]
+		_, ok := existingRepos[folderName]
 		if ok {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
@@ -161,7 +158,7 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 				anythingNew = true
 			}
 
-			delete(existingRepos, lastFolder)
+			delete(existingRepos, folderName)
 		}
 
 		if reclone {

--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -347,17 +347,17 @@ func TestUpdateRepos(t *testing.T) {
 	iom := mock.NewMockIOManager(ctrl)
 	iom.EXPECT().ReadDir("baseRepoFolder").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo1",
+			Filename: "9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07",
 			Dir:      true,
 		},
 		&handmock.MockDirEntry{
-			Filename: "repo3",
+			Filename: "8adef80777f0755badbefb8313d1cdd93fc3c3fd50a4bebf0de289b5a3a93bac",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/repo1", nil).Return(false, false, false)
-	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo2", "http://github.com/user/repo2", &branch).Return(nil)
-	iom.EXPECT().RemoveAll("baseRepoFolder/repo3").Return(nil)
+	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07", nil).Return(false, false, false)
+	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/bf8fb6b1214693731c049b7b1b2822c7831a4bcfd5530e24ddb5e7153ca54c4e", "http://github.com/user/repo2", &branch).Return(nil)
+	iom.EXPECT().RemoveAll("baseRepoFolder/8adef80777f0755badbefb8313d1cdd93fc3c3fd50a4bebf0de289b5a3a93bac").Return(nil)
 
 	isRunning := true
 
@@ -376,11 +376,11 @@ func TestUpdateRepos(t *testing.T) {
 	assert.Len(t, allRepos, len(repos))
 	assert.Equal(t, &RepoOnDisk{
 		Repo: repos[0],
-		Path: "baseRepoFolder/repo1",
+		Path: "baseRepoFolder/9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07",
 	}, allRepos[0])
 	assert.Equal(t, &RepoOnDisk{
 		Repo:        repos[1],
-		Path:        "baseRepoFolder/repo2",
+		Path:        "baseRepoFolder/bf8fb6b1214693731c049b7b1b2822c7831a4bcfd5530e24ddb5e7153ca54c4e",
 		WasModified: true,
 	}, allRepos[1])
 	assert.True(t, anythingNew)
@@ -395,15 +395,15 @@ func TestUpdateReposFailToClone(t *testing.T) {
 	iom := mock.NewMockIOManager(ctrl)
 	iom.EXPECT().ReadDir("baseRepoFolder").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo1",
+			Filename: "9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07",
 			Dir:      true,
 		},
 		&handmock.MockDirEntry{
-			Filename: "repo3",
+			Filename: "8adef80777f0755badbefb8313d1cdd93fc3c3fd50a4bebf0de289b5a3a93bac",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo2", "http://github.com/user/repo2", &branch).Return(errors.New("unexpected error"))
+	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/bf8fb6b1214693731c049b7b1b2822c7831a4bcfd5530e24ddb5e7153ca54c4e", "http://github.com/user/repo2", &branch).Return(errors.New("unexpected error"))
 
 	isRunning := true
 
@@ -432,13 +432,13 @@ func TestUpdateReposAllowedRepoErrors(t *testing.T) {
 	iom := mock.NewMockIOManager(ctrl)
 	iom.EXPECT().ReadDir("baseRepoFolder").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo1",
+			Filename: "9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/repo1", &branch).Return(true, false, false)
-	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo2", "http://github.com/user/repo2", nil).Return(transport.ErrEmptyRemoteRepository)
-	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo3", "file:///nsm/rules/repo3", nil).Return(transport.ErrRepositoryNotFound)
+	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07", &branch).Return(true, false, false)
+	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/bf8fb6b1214693731c049b7b1b2822c7831a4bcfd5530e24ddb5e7153ca54c4e", "http://github.com/user/repo2", nil).Return(transport.ErrEmptyRemoteRepository)
+	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/accd1a60dae04a7debe8cb75b0744a0cc62a10a280e8bf1badfa0eaa803d0955", "file:///nsm/rules/repo3", nil).Return(transport.ErrRepositoryNotFound)
 
 	isRunning := true
 
@@ -460,7 +460,7 @@ func TestUpdateReposAllowedRepoErrors(t *testing.T) {
 	assert.Len(t, allRepos, 1)
 	assert.Equal(t, &RepoOnDisk{
 		Repo:        repos[0],
-		Path:        "baseRepoFolder/repo1",
+		Path:        "baseRepoFolder/9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07",
 		WasModified: true,
 	}, allRepos[0])
 	assert.True(t, anythingNew)
@@ -476,12 +476,12 @@ func TestUpdateReposRepoRemoteGoneError(t *testing.T) {
 	// 1. repo has been cloned before and exists on disk
 	iom.EXPECT().ReadDir("baseRepoFolder").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo1",
+			Filename: "9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07",
 			Dir:      true,
 		},
 	}, nil)
 	// 2. the remote repository no longer exists
-	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/repo1", &branch).Return(false, false, true)
+	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/9f9f0b566520a18e7754f06a0e5359cfa390726dbc0cf8383aad2d88b9f5db07", &branch).Return(false, false, true)
 	// 3. We DO NOT delete the repo for recloning, we do not process other repos in the config's list
 
 	isRunning := true

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1584,11 +1584,11 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 	// UpdateRepos
 	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo",
+			Filename: "b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", nil).Return(false, false, false)
 	// check for changes before sync
 	iom.EXPECT().ReadFile("rulesFingerprintFile").Return([]byte(`{"core+": "GwJvQmt07Ma9kvq2D8bpbQfXW+IRe0nN4fITj9Ghxis="}`), nil)
 	// WriteStateFile
@@ -1712,13 +1712,13 @@ func TestSyncChanges(t *testing.T) {
 	// UpdateRepos
 	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo",
+			Filename: "b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", nil).Return(false, false, false)
 	// parseRepoRules
-	iom.EXPECT().WalkDir("repos/repo", gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
+	iom.EXPECT().WalkDir("repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
 		files := []fs.DirEntry{
 			&handmock.MockDirEntry{
 				Filename: "rules/123.yml",
@@ -1918,13 +1918,13 @@ func TestSyncUnchangedOverrides(t *testing.T) {
 	// UpdateRepos
 	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo",
+			Filename: "b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", nil).Return(false, false, false)
 	// parseRepoRules
-	iom.EXPECT().WalkDir("repos/repo", gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
+	iom.EXPECT().WalkDir("repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
 		files := []fs.DirEntry{
 			&handmock.MockDirEntry{
 				Filename: "rules/123.yml",

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -7,10 +7,11 @@ package playbook
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"net/url"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -239,18 +240,14 @@ func (pdm *PlaybookDiskManager) LoadPlaybooks(logger log.Interface) error {
 }
 
 func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Playbook, error) {
-	repo, err := url.Parse(pdm.playbookRepoUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	repoFolderName := path.Base(repo.Path)
+	h := sha256.Sum256([]byte(pdm.playbookRepoUrl))
+	repoFolderName := hex.EncodeToString(h[:])
 
 	targetDir := path.Join(pdm.playbookRepoPath, repoFolderName, pdm.playbookPathInRepo)
 	files := 0
 	playbooks := []*model.Playbook{}
 
-	err = pdm.IOManager.WalkDir(targetDir, func(p string, dir fs.DirEntry, err error) error {
+	err := pdm.IOManager.WalkDir(targetDir, func(p string, dir fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -509,20 +509,20 @@ func TestScheduler(t *testing.T) {
 	}
 
 	iom.EXPECT().ReadDir(pdm.playbookRepoPath).Return(nil, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "/tmp/playbooks/repo", pdm.playbookRepoUrl, util.Ptr(pdm.playbookRepoBranch)).Return(nil)
+	iom.EXPECT().CloneRepo(gomock.Any(), "/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e", pdm.playbookRepoUrl, util.Ptr(pdm.playbookRepoBranch)).Return(nil)
 
-	iom.EXPECT().WalkDir("/tmp/playbooks/repo", gomock.Any()).DoAndReturn(func(path string, fn func(p string, dir fs.DirEntry, err error) error) error {
-		err := fn("/tmp/playbooks/repo/playbook1.yaml", &handmock.MockDirEntry{
+	iom.EXPECT().WalkDir("/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e", gomock.Any()).DoAndReturn(func(path string, fn func(p string, dir fs.DirEntry, err error) error) error {
+		err := fn("/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e/playbook1.yaml", &handmock.MockDirEntry{
 			Filename: "playbook1.yaml",
 		}, nil)
 		assert.NoError(t, err)
 
-		err = fn("/tmp/playbooks/repo/playbook2.yaml", &handmock.MockDirEntry{
+		err = fn("/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e/playbook2.yaml", &handmock.MockDirEntry{
 			Filename: "playbook2.yaml",
 		}, nil)
 		assert.NoError(t, err)
 
-		err = fn("/tmp/playbooks/repo/playbook3.yaml", &handmock.MockDirEntry{
+		err = fn("/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e/playbook3.yaml", &handmock.MockDirEntry{
 			Filename: "playbook3.yaml",
 		}, nil)
 		assert.NoError(t, err)
@@ -530,9 +530,9 @@ func TestScheduler(t *testing.T) {
 		return nil
 	})
 
-	iom.EXPECT().ReadFile("/tmp/playbooks/repo/playbook1.yaml").Return([]byte(SuricataPlaybook), nil)
-	iom.EXPECT().ReadFile("/tmp/playbooks/repo/playbook2.yaml").Return([]byte(HistoryFileDeletionPlaybook), nil)
-	iom.EXPECT().ReadFile("/tmp/playbooks/repo/playbook3.yaml").Return([]byte(ProcessCreationPlaybook), nil)
+	iom.EXPECT().ReadFile("/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e/playbook1.yaml").Return([]byte(SuricataPlaybook), nil)
+	iom.EXPECT().ReadFile("/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e/playbook2.yaml").Return([]byte(HistoryFileDeletionPlaybook), nil)
+	iom.EXPECT().ReadFile("/tmp/playbooks/213223d988fe94c66416393b51671aa9f3b96eb06bc771e5d9435b29edf9e47e/playbook3.yaml").Return([]byte(ProcessCreationPlaybook), nil)
 
 	iom.EXPECT().ReadDir(pdm.playbookRepoPath).DoAndReturn(func(path string) ([]fs.DirEntry, error) {
 		pdm.isRunning = false

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1040,11 +1040,11 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 	// UpdateRepos
 	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo",
+			Filename: "b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", nil).Return(false, false, false)
 	// WriteStateFile
 	iom.EXPECT().WriteFile("stateFilePath", gomock.Any(), fs.FileMode(0644)).Return(nil)
 	// IntegrityCheck
@@ -1141,11 +1141,11 @@ func TestSyncChanges(t *testing.T) {
 	// UpdateRepos
 	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo",
+			Filename: "b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c",
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(true, false, false)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", nil).Return(true, false, false)
 	// Sync
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		"dummy": {
@@ -1163,7 +1163,7 @@ func TestSyncChanges(t *testing.T) {
 			PublicID: "delete",
 		},
 	}, nil)
-	iom.EXPECT().WalkDir("repos/repo", gomock.Any()).DoAndReturn(func(path string, walkFn fs.WalkDirFunc) error {
+	iom.EXPECT().WalkDir("repos/b719fba9ee6de8ff3c66a089489f99c1bc6d18d009240dc02218b826ee04db4c", gomock.Any()).DoAndReturn(func(path string, walkFn fs.WalkDirFunc) error {
 		files := []fs.DirEntry{
 			&handmock.MockDirEntry{
 				Filename: "rule1.yar",


### PR DESCRIPTION
We're running into collisions when people are adding sigma rules from repos with the same name. To fix this, we hash the entire repo URL and that becomes the folder name we clone into. On next sync, each engine will re-clone all the repos and delete the old non-hashed folders.