### PR TITLE
Add support for arrays

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2754,10 +2754,10 @@ const huntComponent = {
               
               if (lineWithVar !== -1) {
                 // Get the field being set (e.g., src_ip or dst_ip)
-                const match = lines[lineWithVar].match(/\s*(?:-\s*)?(\w+(?:\.\w+)*(?:\|\w+)*):(?:\s*|$)/);
+                const match = lines[lineWithVar].match(/^(\s*)(?:-\s*)?(\w+(?:\.\w+)*(?:\|\w+)*):(?:\s*|$)/);
                 if (match) {
-                  const field = match[1];
-                  const indent = lines[lineWithVar].match(/^\s*/)[0];
+                  const indent = match[1];
+                  const field = match[2];
                   const originalLine = lines[lineWithVar];
                   const hasDash = originalLine.trim().startsWith('-');
                   const prefix = hasDash ? '- ' : '';

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2729,26 +2729,57 @@ const huntComponent = {
         }
       }
     },
+
     queryVariableSubstitution(event, playbooks) {
+      // Fields that require special array handling
+      const arrayFields = ['network.private_ip', 'network.public_ip', 'related.ip'];
+
       for (let pb of playbooks) {
         for (let question of pb.questions) {
           let q = question.query;
-
-          for (let field in event) {
-            const value = event[field];
-
-            q = q.replaceAll(`{${field}}`, value);
-
-            if (field.startsWith('event_data.')) {
-              let short = field.replace('event_data.', '');
-              q = q.replaceAll(`{${short}}`, value);
+          
+          // Find all variables in the query using regex
+          const variables = q.match(/\{([^}]+)\}/g) || [];
+          
+          // Process each variable
+          for (const variable of variables) {
+            const fieldName = variable.slice(1, -1); // Remove { and }
+            let value = event[fieldName] || 'NODATA';
+            
+            // Special handling for array fields
+            if (arrayFields.includes(fieldName) && Array.isArray(value)) {
+              // Find the line containing the variable
+              const lines = q.split('\n');
+              const lineWithVar = lines.findIndex(line => line.includes(variable));
+              
+              if (lineWithVar !== -1) {
+                // Get the field being set (e.g., src_ip or dst_ip)
+                const match = lines[lineWithVar].match(/\s*(?:-\s*)?(\w+(?:\.\w+)*(?:\|\w+)*):(?:\s*|$)/);
+                if (match) {
+                  const field = match[1];
+                  const indent = lines[lineWithVar].match(/^\s*/)[0];
+                  const originalLine = lines[lineWithVar];
+                  const hasDash = originalLine.trim().startsWith('-');
+                  const prefix = hasDash ? '- ' : '';
+                  const replacement = `${indent}${prefix}${field}:\n${value.map(ip => `${indent}    - ${ip}`).join('\n')}`;
+                  
+                  // Replace the entire line
+                  lines[lineWithVar] = replacement;
+                  q = lines.join('\n');
+                  continue;
+                }
+              }
             }
+            
+            // Default replacement if not handled as special case
+            q = q.replaceAll(variable, value);
           }
-
+          
           question.filledQuery = q;
         }
       }
     },
+
     async convertPlaybookQueries(playbooks) {
       let queries = playbooks.map((pb) => pb.questions.map((q) => q.filledQuery)).flat();
 

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1961,3 +1961,127 @@ test('askQuestion', async () => {
   comp.$root.enableReverseLookup = false;
   resetPapi();
 });
+
+describe('queryVariableSubstitution', () => {
+  test('handles simple variable substitution', () => {
+    const event = {
+      'host.name': 'test-host',
+      'source.ip': '192.168.1.1'
+    };
+    const playbooks = [{
+      questions: [{
+        query: 'hostname: {host.name}\nsource_ip: {source.ip}'
+      }]
+    }];
+
+    comp.queryVariableSubstitution(event, playbooks);
+    expect(playbooks[0].questions[0].filledQuery).toBe(
+      'hostname: test-host\nsource_ip: 192.168.1.1'
+    );
+  });
+
+  test('handles array fields with proper indentation', () => {
+    const event = {
+      'network.private_ip': ['192.168.1.1', '10.0.0.1'],
+      'network.public_ip': ['203.0.113.1']
+    };
+    const playbooks = [{
+      questions: [{
+        query: '    private_ips: {network.private_ip}\n    public_ips: {network.public_ip}'
+      }]
+    }];
+
+    comp.queryVariableSubstitution(event, playbooks);
+    expect(playbooks[0].questions[0].filledQuery).toBe(
+      '    private_ips:\n        - 192.168.1.1\n        - 10.0.0.1\n    public_ips:\n        - 203.0.113.1'
+    );
+  });
+
+  test('handles missing fields with NODATA', () => {
+    const event = {
+      'host.name': 'test-host'
+    };
+    const playbooks = [{
+      questions: [{
+        query: 'hostname: {host.name}\nip: {missing.field}'
+      }]
+    }];
+
+    comp.queryVariableSubstitution(event, playbooks);
+    expect(playbooks[0].questions[0].filledQuery).toBe(
+      'hostname: test-host\nip: NODATA'
+    );
+  });
+
+  test('handles array fields with dashes', () => {
+    const event = {
+      'network.private_ip': ['192.168.1.1', '10.0.0.1']
+    };
+    const playbooks = [{
+      questions: [{
+        query: '    - private_ips: {network.private_ip}'
+      }]
+    }];
+
+    comp.queryVariableSubstitution(event, playbooks);
+    expect(playbooks[0].questions[0].filledQuery).toBe(
+      '    - private_ips:\n        - 192.168.1.1\n        - 10.0.0.1'
+    );
+  });
+
+  test('handles real-world query format', () => {
+    const event = {
+      'network.private_ip': ['192.168.1.1', '10.0.0.1'],
+      'dns.query_name': 'malicious.com',
+      'network.public_ip': ['203.0.113.1'],
+      'related.ip': ['203.0.113.1', '192.168.1.2'],
+    };
+    const playbooks = [{
+      questions: [{
+        query: `aggregation: false
+logsource:
+  category: network
+  service: dns
+detection:
+    selection:
+       - src_ip: '{network.private_ip}'
+       - dns.query.name|contains: '{dns.query_name}'
+       - dns.resolved_ip: '{network.public_ip}'
+    filter:
+      dst_ip: '{related.ip}'
+    condition: selection and filter
+fields:
+    - dns.query.name
+    - dns.query.type_name
+    - dns.resolved_ip
+    - dns.response.code_name`
+      }]
+    }];
+
+    comp.queryVariableSubstitution(event, playbooks);
+    expect(playbooks[0].questions[0].filledQuery).toBe(
+      `aggregation: false
+logsource:
+  category: network
+  service: dns
+detection:
+    selection:
+       - src_ip:
+           - 192.168.1.1
+           - 10.0.0.1
+       - dns.query.name|contains: 'malicious.com'
+       - dns.resolved_ip:
+           - 203.0.113.1
+    filter:
+      dst_ip:
+          - 203.0.113.1
+          - 192.168.1.2
+    condition: selection and filter
+fields:
+    - dns.query.name
+    - dns.query.type_name
+    - dns.resolved_ip
+    - dns.response.code_name`
+    );
+  });
+});

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1962,8 +1962,7 @@ test('askQuestion', async () => {
   resetPapi();
 });
 
-describe('queryVariableSubstitution', () => {
-  test('handles simple variable substitution', () => {
+test('queryVariableSubstitution - handles simple variable substitution', () => {
     const event = {
       'host.name': 'test-host',
       'source.ip': '192.168.1.1'
@@ -1980,7 +1979,7 @@ describe('queryVariableSubstitution', () => {
     );
   });
 
-  test('handles array fields with proper indentation', () => {
+test('queryVariableSubstitution - handles array fields with proper indentation', () => {
     const event = {
       'network.private_ip': ['192.168.1.1', '10.0.0.1'],
       'network.public_ip': ['203.0.113.1']
@@ -1997,7 +1996,7 @@ describe('queryVariableSubstitution', () => {
     );
   });
 
-  test('handles missing fields with NODATA', () => {
+test('queryVariableSubstitution - handles missing fields with NODATA', () => {
     const event = {
       'host.name': 'test-host'
     };
@@ -2013,7 +2012,7 @@ describe('queryVariableSubstitution', () => {
     );
   });
 
-  test('handles array fields with dashes', () => {
+test('queryVariableSubstitution - handles array fields with dashes', () => {
     const event = {
       'network.private_ip': ['192.168.1.1', '10.0.0.1']
     };
@@ -2029,7 +2028,7 @@ describe('queryVariableSubstitution', () => {
     );
   });
 
-  test('handles real-world query format', () => {
+test('queryVariableSubstitution - handles real-world query format', () => {
     const event = {
       'network.private_ip': ['192.168.1.1', '10.0.0.1'],
       'dns.query_name': 'malicious.com',
@@ -2084,4 +2083,3 @@ fields:
     - dns.response.code_name`
     );
   });
-});


### PR DESCRIPTION
Adds support for:

- If the source log does not contain the variable to be substituted, we default to `NODATA` - this allows queries to still be run
- If the variable to be substituted is an array, it splits it into a YAML list before submitting the YAML to the sigma converter