### PR TITLE
RulesetName

### DIFF
--- a/model/rulerepo.go
+++ b/model/rulerepo.go
@@ -11,11 +11,12 @@ import (
 )
 
 type RuleRepo struct {
-	Repo      string
-	Branch    *string
-	License   string
-	Folder    *string
-	Community bool
+	Repo        string
+	Branch      *string
+	License     string
+	Folder      *string
+	Community   bool
+	RulesetName string
 }
 
 func GetReposDefault(cfg map[string]interface{}, field string, dflt []*RuleRepo) ([]*RuleRepo, error) {
@@ -64,10 +65,13 @@ func GetReposDefault(cfg map[string]interface{}, field string, dflt []*RuleRepo)
 			}
 		}
 
+		rulesetName, _ := obj["rulesetName"].(string)
+
 		r := &RuleRepo{
-			Repo:      repo,
-			License:   license,
-			Community: isCommunity,
+			Repo:        repo,
+			License:     license,
+			Community:   isCommunity,
+			RulesetName: rulesetName,
 		}
 
 		folder, ok := obj["folder"].(string)

--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -97,6 +97,7 @@ func WriteStateFile(iom IOManager, path string) {
 type RepoOnDisk struct {
 	Repo        *model.RuleRepo
 	Path        string
+	RulesetName string
 	WasModified bool
 }
 
@@ -126,24 +127,30 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 			return nil, false, ErrModuleStopped
 		}
 
-		parser, err := url.Parse(repo.Repo)
-		if err != nil {
-			log.WithError(err).WithField("repoUrl", repo.Repo).Error("Failed to parse repo URL, doing nothing with it")
-			continue
+		folderName := repo.RulesetName
+
+		if folderName == "" {
+			parser, err := url.Parse(repo.Repo)
+			if err != nil {
+				log.WithError(err).WithField("repoUrl", repo.Repo).Error("Failed to parse repo URL, doing nothing with it")
+				continue
+			}
+
+			_, folderName = path.Split(parser.Path)
 		}
 
-		_, lastFolder := path.Split(parser.Path)
-		repoPath := filepath.Join(baseRepoFolder, lastFolder)
+		repoPath := filepath.Join(baseRepoFolder, folderName)
 
 		dirty := &RepoOnDisk{
-			Repo: repo,
-			Path: repoPath,
+			Repo:        repo,
+			Path:        repoPath,
+			RulesetName: folderName,
 		}
 
 		reclone := false
 		skipRepo := false
 
-		_, ok := existingRepos[lastFolder]
+		_, ok := existingRepos[folderName]
 		if ok {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
@@ -161,7 +168,7 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 				anythingNew = true
 			}
 
-			delete(existingRepos, lastFolder)
+			delete(existingRepos, folderName)
 		}
 
 		if reclone {

--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -347,7 +347,7 @@ func TestUpdateRepos(t *testing.T) {
 	iom := mock.NewMockIOManager(ctrl)
 	iom.EXPECT().ReadDir("baseRepoFolder").Return([]fs.DirEntry{
 		&handmock.MockDirEntry{
-			Filename: "repo1",
+			Filename: "sigma-rules",
 			Dir:      true,
 		},
 		&handmock.MockDirEntry{
@@ -355,18 +355,19 @@ func TestUpdateRepos(t *testing.T) {
 			Dir:      true,
 		},
 	}, nil)
-	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/repo1", nil).Return(false, false, false)
-	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo2", "http://github.com/user/repo2", &branch).Return(nil)
+	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/sigma-rules", nil).Return(false, false, false)
+	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo", "http://github.com/user/repo", &branch).Return(nil)
 	iom.EXPECT().RemoveAll("baseRepoFolder/repo3").Return(nil)
 
 	isRunning := true
 
 	repos := []*model.RuleRepo{
 		{
-			Repo: "http://github.com/user/repo1",
+			Repo:        "http://github.com/user/repo",
+			RulesetName: "sigma-rules",
 		},
 		{
-			Repo:   "http://github.com/user/repo2",
+			Repo:   "http://github.com/user/repo",
 			Branch: &branch,
 		},
 	}
@@ -375,12 +376,14 @@ func TestUpdateRepos(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, allRepos, len(repos))
 	assert.Equal(t, &RepoOnDisk{
-		Repo: repos[0],
-		Path: "baseRepoFolder/repo1",
+		Repo:        repos[0],
+		Path:        "baseRepoFolder/sigma-rules",
+		RulesetName: "sigma-rules",
 	}, allRepos[0])
 	assert.Equal(t, &RepoOnDisk{
 		Repo:        repos[1],
-		Path:        "baseRepoFolder/repo2",
+		Path:        "baseRepoFolder/repo",
+		RulesetName: "repo",
 		WasModified: true,
 	}, allRepos[1])
 	assert.True(t, anythingNew)
@@ -461,6 +464,7 @@ func TestUpdateReposAllowedRepoErrors(t *testing.T) {
 	assert.Equal(t, &RepoOnDisk{
 		Repo:        repos[0],
 		Path:        "baseRepoFolder/repo1",
+		RulesetName: "repo1",
 		WasModified: true,
 	}, allRepos[0])
 	assert.True(t, anythingNew)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -19,8 +19,10 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -1021,6 +1023,16 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 			baseDir = filepath.Join(baseDir, *repo.Repo.Folder)
 		}
 
+		ruleset := repo.RulesetName
+		if ruleset == "" {
+			parser, err := url.Parse(repo.Repo.Repo)
+			if err == nil {
+				_, ruleset = path.Split(parser.Path)
+			} else {
+				ruleset = repo.Repo.Repo
+			}
+		}
+
 		err := e.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				log.WithError(err).WithField("repoPath", path).Error("Failed to walk path")
@@ -1051,8 +1063,6 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 				errMap[path] = err
 				return nil
 			}
-
-			ruleset := filepath.Base(repo.Path)
 
 			det := rule.ToDetection(ruleset, repo.Repo.License, repo.Repo.Community)
 

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -15,8 +15,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -414,6 +416,16 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 			baseDir = filepath.Join(baseDir, *repo.Repo.Folder)
 		}
 
+		ruleset := repo.RulesetName
+		if ruleset == "" {
+			parser, err := url.Parse(repo.Repo.Repo)
+			if err == nil {
+				_, ruleset = path.Split(parser.Path)
+			} else {
+				ruleset = repo.Repo.Repo
+			}
+		}
+
 		err = e.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				logger.WithError(err).WithField("repoPath", path).Error("failed to walk path")
@@ -446,7 +458,7 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 			}
 
 			for _, rule := range parsed {
-				det := rule.ToDetection(repo.Repo.License, filepath.Base(repo.Path), repo.Repo.Community)
+				det := rule.ToDetection(repo.Repo.License, ruleset, repo.Repo.Community)
 				detects = append(detects, det)
 			}
 


### PR DESCRIPTION
Add rulesetName to RuleRepo to allow the user to specify the name of the ruleset. The ruleset name is used as the folder name when a repo is pulled allowing the user to avoid collisions. If a rulesetName is not specified, the last folder of the repo will be used.

Updated how we clone the repos to use this new value as the folder name. Updated the engines to use this field as the ruleset of the detections found in that repo. Updated tests.