### PR TITLE
Add Permissions to Playbooks

### DIFF
--- a/rbac/permissions
+++ b/rbac/permissions
@@ -38,6 +38,9 @@ roles/write:      user-admin
 users/read:       user-monitor
 users/write:      user-admin
 users/delete:     user-admin
+playbooks/read:   playbook-monitor
+playbooks/write:  playbook-admin
+playbooks/delete: playbook-admin
 
 # Define low-level permission set inheritence relationships
 # Syntax      => roleB: roleA
@@ -54,3 +57,5 @@ job-user:          job-admin
 node-monitor:      node-admin
 query-monitor:     query-admin
 user-monitor:      user-admin
+playbook-monitor:  playbook-admin
+detections-monitor: playbook-monitor

--- a/rbac/roles
+++ b/rbac/roles
@@ -28,3 +28,5 @@ job-monitor:       auditor
 job-processor:     agent
 query-admin:       superuser
 query-monitor:     superuser
+playbook-admin:    superuser
+playbook-monitor:  limited-analyst auditor limited-auditor

--- a/server/mock/mock_playbookstore.go
+++ b/server/mock/mock_playbookstore.go
@@ -9,6 +9,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	model "github.com/security-onion-solutions/securityonion-soc/model"
@@ -38,44 +39,61 @@ func (m *MockPlaybookstore) EXPECT() *MockPlaybookstoreMockRecorder {
 	return m.recorder
 }
 
-// GetPlaybookById mocks base method.
-func (m *MockPlaybookstore) GetPlaybookById(arg0 string) (*model.Playbook, error) {
+// ConvertQuestions mocks base method.
+func (m *MockPlaybookstore) ConvertQuestions(arg0 context.Context, arg1 []string) ([]*model.ConvertedQuery, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlaybookById", arg0)
+	ret := m.ctrl.Call(m, "ConvertQuestions", arg0, arg1)
+	ret0, _ := ret[0].([]*model.ConvertedQuery)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ConvertQuestions indicates an expected call of ConvertQuestions.
+func (mr *MockPlaybookstoreMockRecorder) ConvertQuestions(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertQuestions", reflect.TypeOf((*MockPlaybookstore)(nil).ConvertQuestions), arg0, arg1)
+}
+
+// GetPlaybookById mocks base method.
+func (m *MockPlaybookstore) GetPlaybookById(arg0 context.Context, arg1 string) (*model.Playbook, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlaybookById", arg0, arg1)
 	ret0, _ := ret[0].(*model.Playbook)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPlaybookById indicates an expected call of GetPlaybookById.
-func (mr *MockPlaybookstoreMockRecorder) GetPlaybookById(arg0 any) *gomock.Call {
+func (mr *MockPlaybookstoreMockRecorder) GetPlaybookById(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlaybookById", reflect.TypeOf((*MockPlaybookstore)(nil).GetPlaybookById), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlaybookById", reflect.TypeOf((*MockPlaybookstore)(nil).GetPlaybookById), arg0, arg1)
 }
 
 // GetPlaybooksForDetection mocks base method.
-func (m *MockPlaybookstore) GetPlaybooksForDetection(arg0, arg1 string, arg2 model.EngineName) ([]*model.Playbook, error) {
+func (m *MockPlaybookstore) GetPlaybooksForDetection(arg0 context.Context, arg1, arg2 string, arg3 model.EngineName) ([]*model.Playbook, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlaybooksForDetection", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetPlaybooksForDetection", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*model.Playbook)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPlaybooksForDetection indicates an expected call of GetPlaybooksForDetection.
-func (mr *MockPlaybookstoreMockRecorder) GetPlaybooksForDetection(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockPlaybookstoreMockRecorder) GetPlaybooksForDetection(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlaybooksForDetection", reflect.TypeOf((*MockPlaybookstore)(nil).GetPlaybooksForDetection), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlaybooksForDetection", reflect.TypeOf((*MockPlaybookstore)(nil).GetPlaybooksForDetection), arg0, arg1, arg2, arg3)
 }
 
 // Interrupt mocks base method.
-func (m *MockPlaybookstore) Interrupt(arg0 bool) {
+func (m *MockPlaybookstore) Interrupt(arg0 context.Context, arg1 bool) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Interrupt", arg0)
+	ret := m.ctrl.Call(m, "Interrupt", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Interrupt indicates an expected call of Interrupt.
-func (mr *MockPlaybookstoreMockRecorder) Interrupt(arg0 any) *gomock.Call {
+func (mr *MockPlaybookstoreMockRecorder) Interrupt(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Interrupt", reflect.TypeOf((*MockPlaybookstore)(nil).Interrupt), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Interrupt", reflect.TypeOf((*MockPlaybookstore)(nil).Interrupt), arg0, arg1)
 }

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -52,9 +52,9 @@ type PlaybookDiskManager struct {
 	autoUpdateEnabled              bool
 	pbUpdateMutex                  sync.RWMutex
 	interm                         sync.Mutex
-	InterruptChan                  chan bool
-	PlaybookImportFrequencySeconds int
-	PlaybookImportErrorSeconds     int
+	interruptChan                  chan bool
+	playbookImportFrequencySeconds int
+	playbookImportErrorSeconds     int
 
 	PlaybooksByDetectionId map[string][]*model.Playbook
 	PlaybooksByCategory    map[string][]*model.Playbook
@@ -76,11 +76,11 @@ func (pdm *PlaybookDiskManager) PrerequisiteModules() []string {
 }
 
 func (pdm *PlaybookDiskManager) Init(config module.ModuleConfig) (err error) {
-	pdm.InterruptChan = make(chan bool, 1)
+	pdm.interruptChan = make(chan bool, 1)
 
 	pdm.autoUpdateEnabled = module.GetBoolDefault(config, "autoUpdateEnabled", DEFAULT_AUTO_UPDATE_ENABLED)
-	pdm.PlaybookImportFrequencySeconds = module.GetIntDefault(config, "playbookImportFrequencySeconds", DEFAULT_PLAYBOOK_IMPORT_FREQUENCY_SECONDS)
-	pdm.PlaybookImportErrorSeconds = module.GetIntDefault(config, "playbookImportErrorSeconds", DEFAULT_PLAYBOOK_IMPORT_ERROR_SECONDS)
+	pdm.playbookImportFrequencySeconds = module.GetIntDefault(config, "playbookImportFrequencySeconds", DEFAULT_PLAYBOOK_IMPORT_FREQUENCY_SECONDS)
+	pdm.playbookImportErrorSeconds = module.GetIntDefault(config, "playbookImportErrorSeconds", DEFAULT_PLAYBOOK_IMPORT_ERROR_SECONDS)
 	pdm.playbookRepoUrl = module.GetStringDefault(config, "playbookRepoUrl", DEFAULT_PLAYBOOK_REPO)
 	pdm.playbookRepoBranch = module.GetStringDefault(config, "playbookRepoBranch", DEFAULT_PLAYBOOK_REPO_BRANCH)
 	pdm.playbookRepoPath = module.GetStringDefault(config, "playbookRepoPath", DEFAULT_PLAYBOOK_REPO_PATH)
@@ -117,8 +117,8 @@ func (pdm *PlaybookDiskManager) Interrupt(ctx context.Context, force bool) error
 	pdm.interm.Lock()
 	defer pdm.interm.Unlock()
 
-	if len(pdm.InterruptChan) == 0 {
-		pdm.InterruptChan <- force
+	if len(pdm.interruptChan) == 0 {
+		pdm.interruptChan <- force
 	}
 
 	return nil
@@ -128,8 +128,8 @@ func (pdm *PlaybookDiskManager) resetInterrupt() {
 	pdm.interm.Lock()
 	defer pdm.interm.Unlock()
 
-	if len(pdm.InterruptChan) != 0 {
-		<-pdm.InterruptChan
+	if len(pdm.interruptChan) != 0 {
+		<-pdm.interruptChan
 	}
 }
 
@@ -137,23 +137,15 @@ func (pdm *PlaybookDiskManager) scheduler() {
 	wasSuccessful := false
 	var timer *time.Timer
 
-	err := pdm.checkPermissions(time.Second * 15)
-	if err != nil {
-		log.WithError(err).Error("playbooks module not authorized to read playbooks, stopping module")
-		pdm.Stop()
-
-		return
-	}
-
 	firstRun := sync.OnceFunc(func() {
-		_ = pdm.Interrupt(pdm.srv.Context, true)
+		pdm.Interrupt(pdm.srv.Context, true)
 	})
 
 	for pdm.isRunning {
 		if wasSuccessful {
-			timer = time.NewTimer(time.Second * time.Duration(pdm.PlaybookImportFrequencySeconds))
+			timer = time.NewTimer(time.Second * time.Duration(pdm.playbookImportFrequencySeconds))
 		} else {
-			timer = time.NewTimer(time.Second * time.Duration(pdm.PlaybookImportErrorSeconds))
+			timer = time.NewTimer(time.Second * time.Duration(pdm.playbookImportErrorSeconds))
 		}
 
 		force := false
@@ -162,7 +154,7 @@ func (pdm *PlaybookDiskManager) scheduler() {
 		firstRun()
 
 		select {
-		case inter := <-pdm.InterruptChan:
+		case inter := <-pdm.interruptChan:
 			force = inter
 		case <-timer.C:
 		}
@@ -206,24 +198,6 @@ func (pdm *PlaybookDiskManager) scheduler() {
 			wasSuccessful = true
 		}
 	}
-}
-
-func (pdm *PlaybookDiskManager) checkPermissions(wait time.Duration) error {
-	begin := time.Now()
-	for pdm.isRunning {
-		err := pdm.srv.CheckAuthorized(pdm.srv.Context, "read", "playbooks")
-		if err == nil {
-			break
-		}
-
-		if time.Since(begin) > wait {
-			return ErrBadPermissions
-		}
-
-		time.Sleep(time.Millisecond * 200)
-	}
-
-	return nil
 }
 
 func (pdm *PlaybookDiskManager) UpdateRepoOnDisk() (anythingNew bool, err error) {

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -40,6 +40,8 @@ const (
 	DEFAULT_PLAYBOOK_PATH_IN_REPO             = "playbook/dev"
 )
 
+var ErrBadPermissions = fmt.Errorf("playbooks module not authorized to read playbooks")
+
 type PlaybookDiskManager struct {
 	srv                            *server.Server
 	isRunning                      bool
@@ -106,13 +108,20 @@ func (pdm *PlaybookDiskManager) IsRunning() bool {
 	return pdm.isRunning
 }
 
-func (pdm *PlaybookDiskManager) Interrupt(force bool) {
+func (pdm *PlaybookDiskManager) Interrupt(ctx context.Context, force bool) error {
+	err := pdm.srv.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		return err
+	}
+
 	pdm.interm.Lock()
 	defer pdm.interm.Unlock()
 
 	if len(pdm.InterruptChan) == 0 {
 		pdm.InterruptChan <- force
 	}
+
+	return nil
 }
 
 func (pdm *PlaybookDiskManager) resetInterrupt() {
@@ -128,8 +137,16 @@ func (pdm *PlaybookDiskManager) scheduler() {
 	wasSuccessful := false
 	var timer *time.Timer
 
+	err := pdm.checkPermissions(time.Second * 15)
+	if err != nil {
+		log.WithError(err).Error("playbooks module not authorized to read playbooks, stopping module")
+		pdm.Stop()
+
+		return
+	}
+
 	firstRun := sync.OnceFunc(func() {
-		pdm.Interrupt(true)
+		_ = pdm.Interrupt(pdm.srv.Context, true)
 	})
 
 	for pdm.isRunning {
@@ -189,6 +206,24 @@ func (pdm *PlaybookDiskManager) scheduler() {
 			wasSuccessful = true
 		}
 	}
+}
+
+func (pdm *PlaybookDiskManager) checkPermissions(wait time.Duration) error {
+	begin := time.Now()
+	for pdm.isRunning {
+		err := pdm.srv.CheckAuthorized(pdm.srv.Context, "read", "playbooks")
+		if err == nil {
+			break
+		}
+
+		if time.Since(begin) > wait {
+			return ErrBadPermissions
+		}
+
+		time.Sleep(time.Millisecond * 200)
+	}
+
+	return nil
 }
 
 func (pdm *PlaybookDiskManager) UpdateRepoOnDisk() (anythingNew bool, err error) {
@@ -354,6 +389,11 @@ func (pdm *PlaybookDiskManager) organizePlaybooks(logger log.Interface, playbook
 func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, publicId string, detectCategory string, detectEngine model.EngineName) ([]*model.Playbook, error) {
 	logger := log.FromContext(ctx)
 
+	err := pdm.srv.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		return nil, err
+	}
+
 	publicId = strings.ToLower(publicId)
 	detectCategory = strings.ToLower(detectCategory)
 
@@ -388,6 +428,12 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 
 func (pdm *PlaybookDiskManager) GetPlaybookById(ctx context.Context, id string) (pb *model.Playbook, err error) {
 	logger := log.FromContext(ctx)
+
+	err = pdm.srv.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		return nil, err
+	}
+
 	defer func() {
 		l := logger.WithField("playbookId", id)
 		if err != nil {
@@ -413,6 +459,11 @@ func (pdm *PlaybookDiskManager) GetPlaybookById(ctx context.Context, id string) 
 
 func (pdm *PlaybookDiskManager) ConvertQuestions(ctx context.Context, queries []string) ([]*model.ConvertedQuery, error) {
 	logger := log.FromContext(ctx)
+
+	err := pdm.srv.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		return nil, err
+	}
 
 	args := []string{"convert", "-t", "security_onion", "-p", "/opt/sensoroni/sigma_final_pipeline.yaml", "-p", "/opt/sensoroni/sigma_so_pipeline.yaml", "-p", "windows-logsources", "-p", "ecs_windows", "--disable-pipeline-check", "/dev/stdin"}
 

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -500,11 +500,10 @@ func TestScheduler(t *testing.T) {
 
 	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
-		srv:                server.NewFakeAuthorizedServer(nil),
 		playbookRepoPath:   "/tmp/playbooks",
 		playbookRepoUrl:    "https://github.com/playbooks/repo",
 		playbookRepoBranch: "dev",
-		InterruptChan:      make(chan bool, 1),
+		interruptChan:      make(chan bool, 1),
 		isRunning:          true,
 		IOManager:          iom,
 	}
@@ -693,22 +692,4 @@ func TestConvertQuestions(t *testing.T) {
 	assert.Equal(t, "b", converted[0].Fields[1])
 	assert.Equal(t, "b", converted[1].Fields[0])
 	assert.Equal(t, "c", converted[1].Fields[1])
-}
-
-func TestCheckPermissions(t *testing.T) {
-	pdm := NewPlaybookDiskManager(server.NewFakeAuthorizedServer(nil))
-	pdm.isRunning = true
-
-	err := pdm.checkPermissions(0)
-	assert.NoError(t, err)
-
-	pdm = NewPlaybookDiskManager(server.NewFakeUnauthorizedServer())
-	pdm.isRunning = true
-
-	dur := time.Millisecond * 500
-	begin := time.Now()
-	err = pdm.checkPermissions(dur)
-	assert.Error(t, err)
-	assert.Equal(t, ErrBadPermissions, err)
-	assert.GreaterOrEqual(t, time.Since(begin), dur)
 }

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -500,6 +500,7 @@ func TestScheduler(t *testing.T) {
 
 	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
+		srv:                server.NewFakeAuthorizedServer(nil),
 		playbookRepoPath:   "/tmp/playbooks",
 		playbookRepoUrl:    "https://github.com/playbooks/repo",
 		playbookRepoBranch: "dev",
@@ -565,6 +566,7 @@ func TestScheduler(t *testing.T) {
 
 func TestGetPlaybooksForDetection(t *testing.T) {
 	pdm := PlaybookDiskManager{
+		srv: server.NewFakeAuthorizedServer(nil),
 		PlaybooksByDetectionId: map[string][]*model.Playbook{
 			"1182f3b3-e716-4efa-99ab-d2685d04360f": {
 				&model.Playbook{
@@ -620,6 +622,7 @@ func TestGetPlaybooksForDetection(t *testing.T) {
 
 func TestGetPlaybookById(t *testing.T) {
 	pdm := PlaybookDiskManager{
+		srv: server.NewFakeAuthorizedServer(nil),
 		PlaybooksByPlaybookId: map[string]*model.Playbook{
 			"1182f3b3-e716-4efa-99ab-d2685d04360f": {
 				Auditable: model.Auditable{
@@ -664,9 +667,7 @@ func TestConvertQuestions(t *testing.T) {
 
 	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
-		srv: &server.Server{
-			Context: context.Background(),
-		},
+		srv:       server.NewFakeAuthorizedServer(nil),
 		IOManager: iom,
 	}
 
@@ -692,4 +693,22 @@ func TestConvertQuestions(t *testing.T) {
 	assert.Equal(t, "b", converted[0].Fields[1])
 	assert.Equal(t, "b", converted[1].Fields[0])
 	assert.Equal(t, "c", converted[1].Fields[1])
+}
+
+func TestCheckPermissions(t *testing.T) {
+	pdm := NewPlaybookDiskManager(server.NewFakeAuthorizedServer(nil))
+	pdm.isRunning = true
+
+	err := pdm.checkPermissions(0)
+	assert.NoError(t, err)
+
+	pdm = NewPlaybookDiskManager(server.NewFakeUnauthorizedServer())
+	pdm.isRunning = true
+
+	dur := time.Millisecond * 500
+	begin := time.Now()
+	err = pdm.checkPermissions(dur)
+	assert.Error(t, err)
+	assert.Equal(t, ErrBadPermissions, err)
+	assert.GreaterOrEqual(t, time.Since(begin), dur)
 }

--- a/server/modules/staticrbac/staticrbacauthorizer.go
+++ b/server/modules/staticrbac/staticrbacauthorizer.go
@@ -322,6 +322,7 @@ func (impl *StaticRbacAuthorizer) scanNow() {
 		impl.AddRoleToUser(impl.server.Agent, "agent")
 		impl.AddRoleToUser(impl.server.Agent, "config-admin")
 		impl.AddRoleToUser(impl.server.Agent, "event-monitor")
+		impl.AddRoleToUser(impl.server.Agent, "playbook-monitor")
 
 		impl.previousUserHash = hash
 	}

--- a/server/modules/staticrbac/staticrbacauthorizer.go
+++ b/server/modules/staticrbac/staticrbacauthorizer.go
@@ -51,6 +51,9 @@ func (impl *StaticRbacAuthorizer) Init(userFiles []string, roleFiles []string, s
 		return errors.New("scanIntervalMs must be a positive integer")
 	}
 	impl.scanIntervalMs = scanIntervalMs
+
+	impl.Reload()
+
 	return nil
 }
 

--- a/server/playbookhandler.go
+++ b/server/playbookhandler.go
@@ -48,6 +48,12 @@ func (h *PlaybookHandler) GetPlaybook(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.FromContext(ctx)
 
+	err := h.server.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
+	}
+
 	playbookId := chi.URLParam(r, "id")
 	if playbookId == "" {
 		logger.Error("playbook id required")
@@ -79,6 +85,12 @@ func (h *PlaybookHandler) GetPlaybook(w http.ResponseWriter, r *http.Request) {
 func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.FromContext(ctx)
+
+	err := h.server.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
+	}
 
 	publicId := chi.URLParam(r, "id")
 	if publicId == "" {
@@ -140,8 +152,14 @@ func (h *PlaybookHandler) ConvertPlaybook(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	logger := log.FromContext(ctx)
 
+	err := h.server.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
+	}
+
 	queries := []string{}
-	err := web.ReadJson(r, &queries)
+	err = web.ReadJson(r, &queries)
 	if err != nil {
 		logger.WithError(err).Error("unable to read queries")
 		web.Respond(w, r, http.StatusBadRequest, err)

--- a/server/playbookstore.go
+++ b/server/playbookstore.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Playbookstore interface {
-	Interrupt(force bool)
+	Interrupt(ctx context.Context, force bool) error
 	GetPlaybooksForDetection(ctx context.Context, detectId string, detectCategory string, detectEngine model.EngineName) ([]*model.Playbook, error)
 	GetPlaybookById(ctx context.Context, id string) (*model.Playbook, error)
 	ConvertQuestions(ctx context.Context, queries []string) ([]*model.ConvertedQuery, error)


### PR DESCRIPTION
I've added write and read permissions to the rbac files. I've added read permissions to the API. Write permissions will be used later.

I updated the Interrupt function to pass in a context and out an error so that it too can have permissions checked although it is currently unused.

Because modules are all started at approximately the same time, the playbooks module needs to wait for the rbac module to load it's files. New logic has been added to the playbook module to verify permissions before it begins. It will check for up to 15 seconds, after that it returns an error, writes to the log, and turns off the module. In a properly configured system, it may slow down the starting of the playbook module by a few hundred milliseconds at most.