### PR TITLE
Keep Going After Playbook Error

### DIFF
--- a/server/modules/detections/handmock/mock_dir_entry.go
+++ b/server/modules/detections/handmock/mock_dir_entry.go
@@ -6,6 +6,7 @@
 package handmock
 
 import (
+	"errors"
 	"io/fs"
 	"time"
 )
@@ -46,4 +47,27 @@ func (mde *MockDirEntry) Sys() any {
 
 func (mde *MockDirEntry) Info() (fs.FileInfo, error) {
 	return mde, nil
+}
+
+type BadMockDirEntry struct {
+	Filename string
+	Dir      bool
+	FMode    fs.FileMode
+	ErrorStr string
+}
+
+func (bmde *BadMockDirEntry) Name() string {
+	return bmde.Filename
+}
+
+func (bmde *BadMockDirEntry) IsDir() bool {
+	return bmde.Dir
+}
+
+func (bmde *BadMockDirEntry) Type() fs.FileMode {
+	return bmde.FMode
+}
+
+func (bmde *BadMockDirEntry) Info() (fs.FileInfo, error) {
+	return nil, errors.New(bmde.ErrorStr)
 }

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -138,7 +138,7 @@ func (pdm *PlaybookDiskManager) scheduler() {
 	var timer *time.Timer
 
 	firstRun := sync.OnceFunc(func() {
-		pdm.Interrupt(pdm.srv.Context, true)
+		_ = pdm.Interrupt(pdm.srv.Context, true)
 	})
 
 	for pdm.isRunning {
@@ -261,12 +261,23 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 
 	err = pdm.IOManager.WalkDir(targetDir, func(p string, dir fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			// we can't process this file, but keep walking the dir
+			logger.WithError(err).WithFields(log.Fields{
+				"playbookDir": targetDir,
+				"path":        p,
+			}).Warn("error while walking playbook directory")
+			return nil
 		}
 
 		info, err := dir.Info()
 		if err != nil {
-			return err
+			// we can't process this file, but keep walking the dir
+			logger.WithError(err).WithFields(log.Fields{
+				"playbookDir": targetDir,
+				"path":        p,
+				"dirEntry":    dir,
+			}).Warn("error while walking playbook directory")
+			return nil
 		}
 
 		if info.IsDir() {
@@ -280,14 +291,24 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 
 		contents, err := pdm.ReadFile(p)
 		if err != nil {
-			return err
+			// we can't process this file, but keep walking the dir
+			logger.WithError(err).WithFields(log.Fields{
+				"playbookDir": targetDir,
+				"path":        p,
+			}).Warn("unable to read file while walking playbook directory")
+			return nil
 		}
 
 		pb := &model.Playbook{}
 
 		err = yaml.Unmarshal(contents, &pb)
 		if err != nil {
-			return err
+			// we can't process this file, but keep walking the dir
+			logger.WithError(err).WithFields(log.Fields{
+				"playbookDir": targetDir,
+				"path":        p,
+			}).Warn("unable to unmarshal playbook")
+			return nil
 		}
 
 		playbooks = append(playbooks, pb)

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -263,8 +263,8 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 		if err != nil {
 			// we can't process this file, but keep walking the dir
 			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir": targetDir,
-				"path":        p,
+				"playbookDir":  targetDir,
+				"playbookPath": p,
 			}).Warn("error while walking playbook directory")
 			return nil
 		}
@@ -273,9 +273,9 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 		if err != nil {
 			// we can't process this file, but keep walking the dir
 			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir": targetDir,
-				"path":        p,
-				"dirEntry":    dir,
+				"playbookDir":  targetDir,
+				"playbookPath": p,
+				"dirEntry":     dir,
 			}).Warn("error while walking playbook directory")
 			return nil
 		}
@@ -293,8 +293,8 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 		if err != nil {
 			// we can't process this file, but keep walking the dir
 			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir": targetDir,
-				"path":        p,
+				"playbookDir":  targetDir,
+				"playbookPath": p,
 			}).Warn("unable to read file while walking playbook directory")
 			return nil
 		}
@@ -305,8 +305,8 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 		if err != nil {
 			// we can't process this file, but keep walking the dir
 			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir": targetDir,
-				"path":        p,
+				"playbookDir":  targetDir,
+				"playbookPath": p,
 			}).Warn("unable to unmarshal playbook")
 			return nil
 		}

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -7,6 +7,7 @@ package playbook
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"os/exec"
@@ -20,6 +21,8 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/memory"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -693,4 +696,48 @@ func TestConvertQuestions(t *testing.T) {
 	assert.Equal(t, "b", converted[0].Fields[1])
 	assert.Equal(t, "b", converted[1].Fields[0])
 	assert.Equal(t, "c", converted[1].Fields[1])
+}
+
+func TestReadPlaybooks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+	pdm := PlaybookDiskManager{
+		playbookRepoUrl:    "http://github.com/user/repo",
+		playbookPathInRepo: "playbooks/dev",
+		playbookRepoPath:   "/tmp/playbooks",
+		IOManager:          iom,
+	}
+
+	iom.EXPECT().WalkDir("/tmp/playbooks/repo/playbooks/dev", gomock.Any()).DoAndReturn(func(path string, fn func(p string, dir fs.DirEntry, err error) error) error {
+		err := fn("does not exist", &handmock.MockDirEntry{}, errors.New("something went wrong"))
+		assert.NoError(t, err)
+
+		err = fn("bad info", &handmock.BadMockDirEntry{ErrorStr: "something went wrong"}, nil)
+		assert.NoError(t, err)
+
+		iom.EXPECT().ReadFile("cannot be read").Return(nil, errors.New("something went wrong"))
+		err = fn("cannot be read", &handmock.MockDirEntry{Filename: "a.yml"}, nil)
+		assert.NoError(t, err)
+
+		iom.EXPECT().ReadFile("unmarshal error").Return([]byte("&"), nil)
+		err = fn("unmarshal error", &handmock.MockDirEntry{Filename: "a.yml"}, nil)
+		assert.NoError(t, err)
+
+		iom.EXPECT().ReadFile("success").Return([]byte("id: x"), nil)
+		err = fn("success", &handmock.MockDirEntry{Filename: "a.yml"}, nil)
+		assert.NoError(t, err)
+
+		return nil
+	})
+
+	h := memory.New()
+	lg := &log.Logger{Handler: h, Level: log.DebugLevel}
+	logger := lg.WithField("test", true)
+
+	pbs, err := pdm.readPlaybooks(logger)
+	assert.NoError(t, err)
+	assert.Len(t, pbs, 1)
+	assert.Equal(t, "x", pbs[0].Id)
 }


### PR DESCRIPTION
If an error happens while updating playbooks, the error should not impact the loading, parsing, or organizing of other playbooks. Added a test.