### PR TITLE
Detections Playbook Tab

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -283,7 +283,6 @@ $(document).ready(function () {
             }
           })
           .catch((error) => {
-            console.error('Unable to perform background action: ' + error);
             var link = action.backgroundFailureLinkFormatted;
             if (link) {
               link = route.replaceActionVar(link, "error", error.message, true)
@@ -298,7 +297,7 @@ $(document).ready(function () {
           try {
             content = btoa(content);
           } catch (e) {
-            console.error("Failed to base64 encode content: " + e);
+            console.log("Failed to base64 encode content: " + e);
           }
           return content;
         },
@@ -308,7 +307,7 @@ $(document).ready(function () {
               content = content.replace(/\\/g, "\\\\");
               content = content.replace(/\"/g, "\\\"");
             } catch (e) {
-              console.error("Failed to escape content: " + e);
+              console.log("Failed to escape content: " + e);
             }
           }
           return content
@@ -319,7 +318,7 @@ $(document).ready(function () {
             try {
               content = content.replace(/,/g, "\" OR process.entity_id:\"");
             } catch (e) {
-              console.error("Failed to set process ancestors for content: " + e);
+              console.log("Failed to set process ancestors for content: " + e);
             }
           }
           return content

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -742,6 +742,7 @@ const i18n = {
       pcapRetentionAbbr: 'PCAP Avail',
       pending: 'Pending',
       pendingDeletion: '(pending deletion)',
+      playbooks: 'Playbooks',
       premiumSupport: 'Premium Support',
       pro: 'Security Onion Pro',
       product: 'Security Onion',

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -594,7 +594,6 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			if (showLoadingIndicator) this.$root.startLoading();
 			try {
 				const response = await this.$root.papi.get(`playbook/detection/${this.detect.publicId}?raw=true`);
-				debugger;
 				if (response && response.data) {
 					this.joinedPlaybookSource = response.data;
 					this.playbookCount = this.joinedPlaybookSource.split('\n---\n').length;

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -187,6 +187,8 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			},
 			showUnreviewedAiSummaries: false,
 			MAX_OVERRIDE_NOTE_LENGTH: MAX_OVERRIDE_NOTE_LENGTH,
+			joinedPlaybookSource: '',
+			playbookCount: -1,
 	}},
 	created() {
 		this.$root.initializeEditor();
@@ -280,6 +282,7 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			this.extractLogic();
 			this.loadHistory();
 			this.loadComments();
+			this.loadPlaybooks();
 		},
 		extractSummary() {
 			switch (this.detect.engine) {
@@ -368,12 +371,12 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 		},
 		isValidUrl(urlString) {
 	  	var urlPattern = new RegExp('^(https?:\\/\\/)?'+ // validate protocol
-		'((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // validate domain name
-		'((\\d{1,3}\\.){3}\\d{1,3}))'+ // validate OR ip (v4) address
-		'(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // validate port and path
-		'(\\?[;&a-z\\d%_.~+=-]*)?'+ // validate query string
-		'(\\#[-a-z\\d_]*)?$','i'); // validate fragment locator
-	  return !!urlPattern.test(urlString);
+			'((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // validate domain name
+			'((\\d{1,3}\\.){3}\\d{1,3}))'+ // validate OR ip (v4) address
+			'(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // validate port and path
+			'(\\?[;&a-z\\d%_.~+=-]*)?'+ // validate query string
+			'(\\#[-a-z\\d_]*)?$','i'); // validate fragment locator
+			return !!urlPattern.test(urlString);
 		},
 		fixProtocol(url) {
 			if (!url.startsWith('http://') && !url.startsWith('https://')) {
@@ -586,6 +589,21 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			}
 
 			this.changedOverrideKeys[historyID] = overrideRetList;
+		},
+		async loadPlaybooks(showLoadingIndicator = false) {
+			if (showLoadingIndicator) this.$root.startLoading();
+			try {
+				const response = await this.$root.papi.get(`playbook/detection/${this.detect.publicId}?raw=true`);
+				debugger;
+				if (response && response.data) {
+					this.joinedPlaybookSource = response.data;
+					this.playbookCount = this.joinedPlaybookSource.split('\n---\n').length;
+				}
+			} catch (error) {
+				this.$root.showError(error);
+			} finally {
+				if (showLoadingIndicator) this.$root.stopLoading();
+			}
 		},
 		getDefaultPreset(preset) {
 			if (this.presets) {
@@ -1444,6 +1462,9 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			}
 
 			return Prism.highlight(code, grammar, language);
+		},
+		playbookHighlighter(code) {
+			return Prism.highlight(code, Prism.languages.yaml, 'yaml');
 		},
 		checkChangedKey(id, key) {
 			return this.changedKeys[id]?.includes(key);

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -1310,3 +1310,19 @@ test('pickValue', () => {
 	val = comp.pickValue(obj, opt);
 	expect(val).toBe('Track');
 });
+
+test('loadPlaybooks', async () => {
+	const rawDocs = 'A\n---\nB\n---\nC';
+	const mock = mockPapi('get', { data: rawDocs });
+
+	comp.detect = { publicId: 'public' };
+	
+	await comp.loadPlaybooks();
+
+	expect(comp.playbookCount).toBe(3);
+	expect(comp.joinedPlaybookSource).toBe(rawDocs);
+	expect(mock).toHaveBeenCalledTimes(1);
+	expect(mock).toHaveBeenCalledWith('playbook/detection/public?raw=true');
+
+	resetPapi();
+});

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2837,7 +2837,6 @@ const huntComponent = {
         } catch (e) {
           question.error = true;
           question.answers = [];
-          console.error('Error asking question:', e);
         }
       } else {
         // no range specified means we can find the answer on the event
@@ -2895,13 +2894,11 @@ const huntComponent = {
 
       let value = parseInt(range);
       if (isNaN(value)) {
-        console.error('Invalid range value:', range);
         return '';
       }
 
       unit = { d: 'days', h: 'hours', m: 'minutes', s: 'seconds' }[unit];
       if (!unit) {
-        console.error('Invalid range unit:', range);
         return '';
       }
 

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1906,7 +1906,6 @@ test('askQuestion', async () => {
     'soc_timestamp': '2023-10-01T12:00:00Z',
   };
 
-  debugger;
   await comp.askQuestion(question, event);
 
   expect(question.answers.length).toBe(1);

--- a/html/pages/detection.html
+++ b/html/pages/detection.html
@@ -60,6 +60,15 @@
 						</span>
 					</div>
 				</v-tab>
+				<v-tab id="detection_playbookTab" value="playbook" :class="{ 'theme-primary': activeTab === 'playbook' }" data-aid="detection_playbook_tab">
+					<v-icon class="tab-icon">fa-book</v-icon>
+					<div class="d-none d-lg-block">
+						{{ i18n.playbooks }}
+						<span v-if="playbookCount !== -1">
+							({{ playbookCount }})
+						</span>
+					</div>
+				</v-tab>
 				<v-tab id="detection_historyTab" value="history" :class="{ 'theme-primary': activeTab === 'history' }" data-aid="detection_history_tab">
 					<v-icon class="tab-icon">fa-history</v-icon>
 					<div class="d-none d-lg-block">{{ i18n.history }}</div>
@@ -564,6 +573,13 @@
 							</tr>
 						</template>
 					</v-data-table>
+				</v-tabs-window-item>
+				<v-tabs-window-item value="playbook" data-aid="detection_playbook">
+					<v-col class="contrast-bg rounded rounded-md pa-4">
+						<span data-aid="detection_source_input">
+							<prism-editor class="prism" :highlight="playbookHighlighter" v-model="joinedPlaybookSource" readonly></prism-editor>
+						</span>
+					</v-col>
 				</v-tabs-window-item>
 				<v-tabs-window-item value="history" data-aid="detection_history">
 					<v-row>

--- a/model/case.go
+++ b/model/case.go
@@ -27,15 +27,15 @@ type Auditable struct {
 	// The ID assigned to this object by the server. This is a read-only field.
 	Id string `json:"id,omitempty" yaml:"id" example:"PdFc-JIBLkNJ8-bDfz47"`
 	// The date and time that this object was created. This is a read-only field.
-	CreateTime *time.Time `json:"createTime" example:"2024-11-14T15:03:22Z"`
+	CreateTime *time.Time `json:"createTime" yaml:"-" example:"2024-11-14T15:03:22Z"`
 	// The date and time that this object was last modified. This is a read-only field.
-	UpdateTime *time.Time `json:"updateTime,omitempty" example:"2024-11-14T15:33:02Z"`
+	UpdateTime *time.Time `json:"updateTime,omitempty" yaml:"-" example:"2024-11-14T15:33:02Z"`
 	// The user ID (or API client ID) that initiated this event. This is a read-only field.
-	UserId string `json:"userId" example:"socl_my_new_client"`
+	UserId string `json:"userId" yaml:"-" example:"socl_my_new_client"`
 	// The kind of object. This is a read-only field.
 	Kind string `json:"kind,omitempty" yaml:"type" example:"case"`
 	// The operation that was applied to the object. This is a read-only field.
-	Operation string `json:"operation,omitempty" example:"create"`
+	Operation string `json:"operation,omitempty" yaml:"-" example:"create"`
 }
 
 type Case struct {

--- a/model/playbook.go
+++ b/model/playbook.go
@@ -8,9 +8,9 @@ package model
 import "time"
 
 type Playbook struct {
-	Auditable `yaml:",inline"`
 	// The name of the playbook.
-	Name string `json:"name" example:"Sample Playbook"`
+	Name      string `json:"name" example:"Sample Playbook"`
+	Auditable `yaml:",inline"`
 	// The description of the playbook.
 	Description string `json:"description" example:"This is a sample playbook"`
 	// The date the playbook was created.
@@ -34,12 +34,12 @@ type Question struct {
 	Question string `json:"question" example:"What is the source IP address of the alert?"`
 	// Some context to be provided to the user. This describes why the answer might be useful.
 	Context string `json:"context" example:"Knowing if the attack comes from inside or outside the network can help determine if this is a false positive or a real attack."`
+	// An indicator for what time range the query should be limited to in order to find the answer.
+	Range *string `json:"range" yaml:",omitempty" example:"+/-3d"`
 	// Where the answer to this question can be found.
 	AnswerSources []string `yaml:"answer_sources" json:"answer_sources"`
 	// A raw YAML Sigma query that can be used to find the answer to this question. May contain variables that will be replaced with values from the alert.
 	Query string `json:"query"`
-	// An indicator for what time range the query should be limited to in order to find the answer.
-	Range *string `json:"range" example:"+/-3d"`
 }
 
 type ConvertedQuery struct {

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -508,11 +508,6 @@ func (store *ElasticDetectionstore) GetDetection(ctx context.Context, detectId s
 }
 
 func (store *ElasticDetectionstore) GetDetectionByPublicId(ctx context.Context, publicId string) (detect *model.Detection, err error) {
-	err = store.server.CheckAuthorized(ctx, "read", "detections")
-	if err != nil {
-		return nil, err
-	}
-
 	err = store.validatePublicId(publicId, "publicId")
 	if err != nil {
 		return nil, err

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -508,6 +508,11 @@ func (store *ElasticDetectionstore) GetDetection(ctx context.Context, detectId s
 }
 
 func (store *ElasticDetectionstore) GetDetectionByPublicId(ctx context.Context, publicId string) (detect *model.Detection, err error) {
+	err = store.server.CheckAuthorized(ctx, "read", "detections")
+	if err != nil {
+		return nil, err
+	}
+
 	err = store.validatePublicId(publicId, "publicId")
 	if err != nil {
 		return nil, err

--- a/server/playbookhandler.go
+++ b/server/playbookhandler.go
@@ -7,12 +7,15 @@ package server
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 
 	"github.com/apex/log"
 	"github.com/go-chi/chi/v5"
+	"gopkg.in/yaml.v3"
 )
 
 type PlaybookHandler struct {
@@ -77,10 +80,13 @@ func (h *PlaybookHandler) GetPlaybook(w http.ResponseWriter, r *http.Request) {
 // @Description  Retrieves playbooks that apply to the indicated detection.
 // @Tags         Playbooks
 // @Param        id  path  string  true        "The public Id for the detection" example(6F64990A-ACDA-40B6-AB71-134C073013B5)
+// @Param        raw query bool    false       "If true, return the playbook in raw YAML format"
 // @Success      200  {array}  model.Playbook  "The playbook was successfully retrieved"
 // @Failure      401                           "Request was not properly authenticated"
-// @Failure      404                           "Playbook not found"
+// @Failure      404                           "Detection not found"
 // @Failure      500                           "Internal SOC error; review SOC logs"
+// @Produce      application/json
+// @Produce      application/x-yaml
 // @Router       /connect/playbook/detection/{id} [get]
 func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -99,11 +105,19 @@ func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *htt
 		return
 	}
 
+	raw := r.URL.Query().Get("raw")
+	rawResponse, _ := strconv.ParseBool(raw)
+
 	det, err := h.server.Detectionstore.GetDetectionByPublicId(ctx, publicId)
 	if err != nil {
 		logger.WithError(err).Error("unable to get detection")
 		web.Respond(w, r, http.StatusInternalServerError, err)
 
+		return
+	}
+
+	if det == nil {
+		web.Respond(w, r, http.StatusNotFound, nil)
 		return
 	}
 
@@ -135,6 +149,25 @@ func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *htt
 
 	if len(pbs) == 0 {
 		pbs = []*model.Playbook{}
+	}
+
+	if rawResponse {
+		parts := make([]string, 0, len(pbs))
+		for _, pb := range pbs {
+			rawOutput, err := yaml.Marshal(pb)
+			if err != nil {
+				logger.WithError(err).Error("unable to marshal playbooks")
+				web.Respond(w, r, http.StatusInternalServerError, err)
+
+				return
+			}
+			parts = append(parts, strings.TrimSpace(string(rawOutput)))
+		}
+
+		w.Header().Set("Content-Type", "application/x-yaml")
+
+		web.Respond(w, r, http.StatusOK, strings.Join(parts, "\n---\n"))
+		return
 	}
 
 	web.Respond(w, r, http.StatusOK, pbs)

--- a/server/playbookhandler.go
+++ b/server/playbookhandler.go
@@ -80,7 +80,7 @@ func (h *PlaybookHandler) GetPlaybook(w http.ResponseWriter, r *http.Request) {
 // @Summary      Get Playbook
 // @Description  Retrieves playbooks that apply to the indicated detection.
 // @Tags         Playbooks
-// @Security     bearer[playbooks/read, detections/read]
+// @Security     bearer[playbooks/read, detections/read, events/read]
 // @Param        id  path  string  true        "The public Id for the detection" example(6F64990A-ACDA-40B6-AB71-134C073013B5)
 // @Param        raw query bool    false       "If true, return the playbook in raw YAML format"
 // @Success      200  {array}  model.Playbook  "The playbook was successfully retrieved"
@@ -101,6 +101,12 @@ func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *htt
 	}
 
 	err = h.server.CheckAuthorized(ctx, "read", "detections")
+	if err != nil {
+		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
+	}
+
+	err = h.server.CheckAuthorized(ctx, "read", "events")
 	if err != nil {
 		web.Respond(w, r, http.StatusUnauthorized, err)
 		return

--- a/server/playbookhandler.go
+++ b/server/playbookhandler.go
@@ -41,7 +41,7 @@ func RegisterPlaybookRoutes(srv *Server, r chi.Router, prefix string) {
 // @Summary      Get Playbook
 // @Description  Retrieves playbooks given an internal playbook ID.
 // @Tags         Playbooks
-// @Security     [playbooks/read]
+// @Security     bearer[playbooks/read]
 // @Param        id  path  string  true         "The playbook ID to retrieve" example(6F64990A-ACDA-40B6-AB71-134C073013B5)
 // @Success      200  {object}  model.Playbook  "The playbook was successfully retrieved"
 // @Failure      401                            "Request was not properly authenticated"
@@ -80,7 +80,7 @@ func (h *PlaybookHandler) GetPlaybook(w http.ResponseWriter, r *http.Request) {
 // @Summary      Get Playbook
 // @Description  Retrieves playbooks that apply to the indicated detection.
 // @Tags         Playbooks
-// @Security     [playbooks/read]
+// @Security     bearer[playbooks/read, detections/read]
 // @Param        id  path  string  true        "The public Id for the detection" example(6F64990A-ACDA-40B6-AB71-134C073013B5)
 // @Param        raw query bool    false       "If true, return the playbook in raw YAML format"
 // @Success      200  {array}  model.Playbook  "The playbook was successfully retrieved"
@@ -95,6 +95,12 @@ func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *htt
 	logger := log.FromContext(ctx)
 
 	err := h.server.CheckAuthorized(ctx, "read", "playbooks")
+	if err != nil {
+		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
+	}
+
+	err = h.server.CheckAuthorized(ctx, "read", "detections")
 	if err != nil {
 		web.Respond(w, r, http.StatusUnauthorized, err)
 		return
@@ -178,7 +184,7 @@ func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *htt
 // @Summary      Get Playbook
 // @Description  Converts the questions of a playbook from Sigma to OQL.
 // @Tags         Playbooks
-// @Security     [playbooks/read]
+// @Security     bearer[playbooks/read]
 // @Param        request body	[]string  true         "The variable substituted Sigma queries to convert"
 // @Success      200  {array}  model.ConvertedQuery  "The playbook was successfully retrieved"
 // @Failure      401                                 "Request was not properly authenticated"

--- a/server/playbookhandler.go
+++ b/server/playbookhandler.go
@@ -41,6 +41,7 @@ func RegisterPlaybookRoutes(srv *Server, r chi.Router, prefix string) {
 // @Summary      Get Playbook
 // @Description  Retrieves playbooks given an internal playbook ID.
 // @Tags         Playbooks
+// @Security     [playbooks/read]
 // @Param        id  path  string  true         "The playbook ID to retrieve" example(6F64990A-ACDA-40B6-AB71-134C073013B5)
 // @Success      200  {object}  model.Playbook  "The playbook was successfully retrieved"
 // @Failure      401                            "Request was not properly authenticated"
@@ -79,6 +80,7 @@ func (h *PlaybookHandler) GetPlaybook(w http.ResponseWriter, r *http.Request) {
 // @Summary      Get Playbook
 // @Description  Retrieves playbooks that apply to the indicated detection.
 // @Tags         Playbooks
+// @Security     [playbooks/read]
 // @Param        id  path  string  true        "The public Id for the detection" example(6F64990A-ACDA-40B6-AB71-134C073013B5)
 // @Param        raw query bool    false       "If true, return the playbook in raw YAML format"
 // @Success      200  {array}  model.Playbook  "The playbook was successfully retrieved"
@@ -176,6 +178,7 @@ func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *htt
 // @Summary      Get Playbook
 // @Description  Converts the questions of a playbook from Sigma to OQL.
 // @Tags         Playbooks
+// @Security     [playbooks/read]
 // @Param        request body	[]string  true         "The variable substituted Sigma queries to convert"
 // @Success      200  {array}  model.ConvertedQuery  "The playbook was successfully retrieved"
 // @Failure      401                                 "Request was not properly authenticated"


### PR DESCRIPTION
The /playbook/detection/{id} route respects a new query string parameter `raw`. If added on with a true value, the response will be in application/x-yaml. This is so the YAML is returned properly, avoiding a lot of problems around returning a YAML playbook in JSON and converting it back to YAML client side.

The detections page now has a Playbook tab where the source of all playbooks that apply to that detection are displayed in a read-only, syntax highlighted view.