### PR TITLE
Specify Origin in Config

### DIFF
--- a/html/js/routes/config.test.js
+++ b/html/js/routes/config.test.js
@@ -1148,14 +1148,7 @@ test('moveEntryWrapWithoutPlus', () => {
 
 test('getSettingLink', () => {
   const setting = { id: 'test.setting', advanced: true };
-  global.window = Object.create(window);
-  const url = "https://example.com/#/config";
-  Object.defineProperty(window, 'location', {
-    value: {
-      href: url,
-      origin: "https://example.com",
-    }
-  });
+
   comp.$route = { path: '/config' };
   const link = comp.getSettingLink(setting);
   expect(link).toBe('https://example.com/#/config?s=test.setting&a=1');

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1054,13 +1054,13 @@ test('addToCase', () => {
   comp.addToCase(false);
 
   expect(window.open).toHaveBeenCalledTimes(1);
-  expect(window.open).toHaveBeenCalledWith('http://localhost/#/case/create?type=evidence&value=test', '_self');
+  expect(window.open).toHaveBeenCalledWith('https://example.com/#/case/create?type=evidence&value=test', '_self');
   expect(comp.addToCaseDialogVisible).toBe(false);
 
   comp.addToCase(true)
 
   expect(window.open).toHaveBeenCalledTimes(2);
-  expect(window.open).toHaveBeenCalledWith('http://localhost/#/case/create?type=evidence&value=test', '_blank');
+  expect(window.open).toHaveBeenCalledWith('https://example.com/#/case/create?type=evidence&value=test', '_blank');
   expect(comp.addToCaseDialogVisible).toBe(false);
 
   comp.selectedMruCase = { id: '1', title: 'Case 1' };
@@ -1068,7 +1068,7 @@ test('addToCase', () => {
   comp.addToCase(true);
 
   expect(window.open).toHaveBeenCalledTimes(3);
-  expect(window.open).toHaveBeenCalledWith('http://localhost/#/case/1?type=evidence&value=test', '1');
+  expect(window.open).toHaveBeenCalledWith('https://example.com/#/case/1?type=evidence&value=test', '1');
   expect(comp.addToCaseDialogVisible).toBe(false);
 
   window.open = origOpen;

--- a/html/js/test_common.js
+++ b/html/js/test_common.js
@@ -12,7 +12,6 @@ global.$ = function(doc) {
 };
 global.document.ready = function(fn) { fn(); };
 global.window.scrollTo = jest.fn();
-global.location = { hash: "" };
 ////////////////////////////////////
 // Mock Vue Internals (not exported)
 ////////////////////////////////////

--- a/jest.config.js
+++ b/jest.config.js
@@ -141,7 +141,9 @@ module.exports = {
   testEnvironment: "jsdom",
 
   // Options that will be passed to the testEnvironment
-  // testEnvironmentOptions: {},
+  testEnvironmentOptions: {
+    url: "https://example.com",
+  },
 
   // Adds a location field to test results
   // testLocationInResults: false,


### PR DESCRIPTION
We can no longer change the window.location.origin on the fly. The jest-environment-jsdom plugin now properly simulates window.location as a read-only object which is having side effects. To remedy, I'm setting the URL in the config so all window.location.origin checks are now non-localhost. This fixes a config test and impacts a hunt test. Refactored the hunt test to work with the new origin.

Removed old polyfill code from test_common.js.