### PR TITLE
Playbook LUTs

### DIFF
--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -56,10 +56,10 @@ type PlaybookDiskManager struct {
 	playbookImportFrequencySeconds int
 	playbookImportErrorSeconds     int
 
-	PlaybooksByDetectionId map[string][]*model.Playbook
-	PlaybooksByCategory    map[string][]*model.Playbook
-	PlaybooksByEngine      map[string][]*model.Playbook
-	PlaybooksByPlaybookId  map[string]*model.Playbook
+	PlaybooksByDetectionId map[string][]string
+	PlaybooksByCategory    map[string][]string
+	PlaybooksByEngine      map[string][]string
+	playbooksOnDisk        map[string]string
 
 	detections.IOManager
 }
@@ -232,22 +232,15 @@ func (pdm *PlaybookDiskManager) LoadPlaybooks(logger log.Interface) error {
 		"playbookCount":        len(playbooks),
 	}).Info("read playbooks")
 
-	start = time.Now()
-
-	err = pdm.organizePlaybooks(logger, playbooks)
-	if err != nil {
-		logger.WithError(err).Error("unable to organize playbooks")
-		return err
-	}
-
-	logger.WithFields(log.Fields{
-		"organizePlaybookDuration": time.Since(start).Seconds(),
-	}).Info("organized playbooks")
-
 	return nil
 }
 
 func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Playbook, error) {
+	byDetId := make(map[string][]string)
+	onDisk := make(map[string]string)
+	byCategory := make(map[string][]string)
+	byEngine := make(map[string][]string)
+
 	repo, err := url.Parse(pdm.playbookRepoUrl)
 	if err != nil {
 		return nil, err
@@ -260,6 +253,10 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 	playbooks := []*model.Playbook{}
 
 	err = pdm.IOManager.WalkDir(targetDir, func(p string, dir fs.DirEntry, err error) error {
+		if !pdm.isRunning {
+			return detections.ErrModuleStopped
+		}
+
 		if err != nil {
 			// we can't process this file, but keep walking the dir
 			logger.WithError(err).WithFields(log.Fields{
@@ -311,8 +308,39 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 			return nil
 		}
 
+		id := strings.ToLower(pb.Id)
 		playbooks = append(playbooks, pb)
 		files++
+
+		if pb.DetectionId != "" {
+			detId := strings.ToLower(pb.DetectionId)
+			byDetId[detId] = append(byDetId[detId], id)
+		}
+
+		if pb.DetectionCategory != "" {
+			category := strings.ToLower(pb.DetectionCategory)
+			byCategory[category] = append(byCategory[category], id)
+		}
+
+		if pb.DetectionId == "" && pb.DetectionCategory == "" {
+			switch strings.ToLower(pb.DetectionType) {
+			case "sigma":
+				byEngine[string(model.EngineNameElastAlert)] = append(byEngine[string(model.EngineNameElastAlert)], id)
+			case "strelka":
+				byEngine[string(model.EngineNameStrelka)] = append(byEngine[string(model.EngineNameStrelka)], id)
+			case "nids":
+				byEngine[string(model.EngineNameSuricata)] = append(byEngine[string(model.EngineNameSuricata)], id)
+			default:
+				logger.Warn("unexpected playbook detection_type: " + pb.DetectionType)
+			}
+		}
+
+		_, ok := onDisk[id]
+		if ok {
+			logger.WithField("playbookId", id).Warn("duplicate playbook id")
+		}
+
+		onDisk[id] = p
 
 		return nil
 	})
@@ -326,59 +354,16 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 		"fileCount":   files,
 	}).Info("read playbooks")
 
-	return playbooks, nil
-}
-
-func (pdm *PlaybookDiskManager) organizePlaybooks(logger log.Interface, playbooks []*model.Playbook) error {
-	byDetId := make(map[string][]*model.Playbook)
-	byPBId := make(map[string]*model.Playbook)
-	byCategory := make(map[string][]*model.Playbook)
-	byEngine := make(map[string][]*model.Playbook)
-
-	for _, pb := range playbooks {
-		if pb.DetectionId != "" {
-			key := strings.ToLower(pb.DetectionId)
-			byDetId[key] = append(byDetId[key], pb)
-		}
-
-		if pb.DetectionCategory != "" {
-			key := strings.ToLower(pb.DetectionCategory)
-			byCategory[key] = append(byCategory[key], pb)
-		}
-
-		if pb.DetectionId == "" && pb.DetectionCategory == "" {
-			switch strings.ToLower(pb.DetectionType) {
-			case "sigma":
-				byEngine[string(model.EngineNameElastAlert)] = append(byEngine[string(model.EngineNameElastAlert)], pb)
-			case "strelka":
-				byEngine[string(model.EngineNameStrelka)] = append(byEngine[string(model.EngineNameStrelka)], pb)
-			case "nids":
-				byEngine[string(model.EngineNameSuricata)] = append(byEngine[string(model.EngineNameSuricata)], pb)
-			default:
-				logger.Warn("unexpected playbook detection_type: " + pb.DetectionType)
-			}
-		}
-
-		key := strings.ToLower(pb.Id)
-
-		_, ok := byPBId[key]
-		if ok {
-			logger.WithField("playbookId", key).Warn("duplicate playbook id")
-		}
-
-		byPBId[key] = pb
-	}
-
 	pdm.pbUpdateMutex.Lock()
 
 	pdm.PlaybooksByEngine = byEngine
 	pdm.PlaybooksByCategory = byCategory
 	pdm.PlaybooksByDetectionId = byDetId
-	pdm.PlaybooksByPlaybookId = byPBId
+	pdm.playbooksOnDisk = onDisk
 
 	pdm.pbUpdateMutex.Unlock()
 
-	return nil
+	return playbooks, nil
 }
 
 func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, publicId string, detectCategory string, detectEngine model.EngineName) ([]*model.Playbook, error) {
@@ -398,27 +383,57 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 	forId := pdm.PlaybooksByDetectionId[publicId]
 	forCategory := pdm.PlaybooksByCategory[detectCategory]
 
-	results := append([]*model.Playbook{}, forId...)
+	results := append([]string{}, forId...)
 	results = append(results, forCategory...)
 
 	if len(results) == 0 {
 		results = pdm.PlaybooksByEngine[string(detectEngine)]
 	}
 
-	ids := make([]string, 0, len(results))
-	for _, pb := range results {
-		ids = append(ids, pb.Id)
+	pbs := make([]*model.Playbook, 0, len(results))
+	for _, id := range results {
+		path, ok := pdm.playbooksOnDisk[id]
+		if !ok {
+			logger.WithFields(log.Fields{
+				"publicId":   publicId,
+				"playbookId": id,
+			}).Warn("referenced playbook is not known to be on disk")
+			continue
+		}
+
+		raw, err := pdm.ReadFile(path)
+		if err != nil {
+			logger.WithFields(log.Fields{
+				"publicId":     publicId,
+				"playbookId":   id,
+				"playbookPath": path,
+			}).Error("unable to read playbook from disk")
+			continue
+		}
+
+		pb := &model.Playbook{}
+
+		err = yaml.Unmarshal(raw, &pb)
+		if err != nil {
+			logger.WithError(err).WithFields(log.Fields{
+				"playbookId":   id,
+				"playbookPath": path,
+			}).Error("unable to parse playbook from disk")
+			continue
+		}
+
+		pbs = append(pbs, pb)
 	}
 
 	logger.WithFields(log.Fields{
-		"playbookCount":  len(results),
+		"playbookCount":  len(pbs),
 		"publicId":       publicId,
 		"detectCategory": detectCategory,
 		"detectEngine":   detectEngine,
-		"playbookIds":    ids,
+		"playbookIds":    results,
 	}).Info("retrieving playbooks for detection")
 
-	return results, nil
+	return pbs, nil
 }
 
 func (pdm *PlaybookDiskManager) GetPlaybookById(ctx context.Context, id string) (pb *model.Playbook, err error) {
@@ -442,11 +457,32 @@ func (pdm *PlaybookDiskManager) GetPlaybookById(ctx context.Context, id string) 
 	pdm.pbUpdateMutex.RLock()
 	defer pdm.pbUpdateMutex.RUnlock()
 
-	var ok bool
-	pb, ok = pdm.PlaybooksByPlaybookId[id]
+	path, ok := pdm.playbooksOnDisk[id]
 
 	if !ok {
 		return nil, nil
+	}
+
+	raw, err := pdm.ReadFile(path)
+	if err != nil {
+		logger.WithError(err).WithFields(log.Fields{
+			"playbookPath": path,
+			"playbookId":   id,
+		}).Error("unable to read playbook off disk")
+
+		return nil, err
+	}
+
+	pb = &model.Playbook{}
+
+	err = yaml.Unmarshal(raw, &pb)
+	if err != nil {
+		logger.WithError(err).WithFields(log.Fields{
+			"playbookPath": path,
+			"playbookId":   id,
+		}).Error("unable to parse playbook from disk")
+
+		return nil, err
 	}
 
 	return pb, nil

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -395,8 +395,8 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 		path, ok := pdm.playbooksOnDisk[id]
 		if !ok {
 			logger.WithFields(log.Fields{
-				"publicId":   publicId,
-				"playbookId": id,
+				"detectionPublicId": publicId,
+				"playbookId":        id,
 			}).Warn("referenced playbook is not known to be on disk")
 			continue
 		}
@@ -404,9 +404,9 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 		raw, err := pdm.ReadFile(path)
 		if err != nil {
 			logger.WithFields(log.Fields{
-				"publicId":     publicId,
-				"playbookId":   id,
-				"playbookPath": path,
+				"detectionPublicId": publicId,
+				"playbookId":        id,
+				"playbookPath":      path,
 			}).Error("unable to read playbook from disk")
 			continue
 		}
@@ -426,11 +426,11 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 	}
 
 	logger.WithFields(log.Fields{
-		"playbookCount":  len(pbs),
-		"publicId":       publicId,
-		"detectCategory": detectCategory,
-		"detectEngine":   detectEngine,
-		"playbookIds":    results,
+		"playbookCount":     len(pbs),
+		"detectionPublicId": publicId,
+		"detectCategory":    detectCategory,
+		"detectEngine":      detectEngine,
+		"playbookIds":       results,
 	}).Info("retrieving playbooks for detection")
 
 	return pbs, nil

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -555,67 +555,65 @@ func TestScheduler(t *testing.T) {
 
 	assert.Equal(t, 1, len(pdm.PlaybooksByCategory))
 	assert.Equal(t, 1, len(pdm.PlaybooksByCategory["process_creation"]))
-	assert.Equal(t, "4f1db62f-cb41-41fb-8af3-11a67585b5db", pdm.PlaybooksByCategory["process_creation"][0].Id)
+	assert.Equal(t, "4f1db62f-cb41-41fb-8af3-11a67585b5db", pdm.PlaybooksByCategory["process_creation"][0])
 
 	assert.Equal(t, 1, len(pdm.PlaybooksByEngine))
 	assert.Equal(t, 1, len(pdm.PlaybooksByEngine["suricata"]))
-	assert.Equal(t, "1dfe7517-f105-454f-ae96-f2280c09e4b2", pdm.PlaybooksByEngine["suricata"][0].Id)
+	assert.Equal(t, "1dfe7517-f105-454f-ae96-f2280c09e4b2", pdm.PlaybooksByEngine["suricata"][0])
 
-	assert.Equal(t, 3, len(pdm.PlaybooksByPlaybookId))
-	assert.NotNil(t, pdm.PlaybooksByPlaybookId["1dfe7517-f105-454f-ae96-f2280c09e4b2"])
-	assert.NotNil(t, pdm.PlaybooksByPlaybookId["6f64990a-acda-40b6-ab71-134c073013b5"])
-	assert.NotNil(t, pdm.PlaybooksByPlaybookId["4f1db62f-cb41-41fb-8af3-11a67585b5db"])
+	assert.Equal(t, 3, len(pdm.playbooksOnDisk))
+	assert.Equal(t, "/tmp/playbooks/repo/playbook1.yaml", pdm.playbooksOnDisk["1dfe7517-f105-454f-ae96-f2280c09e4b2"])
+	assert.Equal(t, "/tmp/playbooks/repo/playbook2.yaml", pdm.playbooksOnDisk["6f64990a-acda-40b6-ab71-134c073013b5"])
+	assert.Equal(t, "/tmp/playbooks/repo/playbook3.yaml", pdm.playbooksOnDisk["4f1db62f-cb41-41fb-8af3-11a67585b5db"])
 }
 
 func TestGetPlaybooksForDetection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+
 	pdm := PlaybookDiskManager{
 		srv: server.NewFakeAuthorizedServer(nil),
-		PlaybooksByDetectionId: map[string][]*model.Playbook{
-			"1182f3b3-e716-4efa-99ab-d2685d04360f": {
-				&model.Playbook{
-					Auditable: model.Auditable{
-						Id: "6f64990a-acda-40b6-ab71-134c073013b5",
-					},
-				},
-			},
+		PlaybooksByDetectionId: map[string][]string{
+			"1182f3b3-e716-4efa-99ab-d2685d04360f": {"6f64990a-acda-40b6-ab71-134c073013b5"},
 		},
-		PlaybooksByCategory: map[string][]*model.Playbook{
-			"process_creation": {
-				&model.Playbook{
-					Auditable: model.Auditable{
-						Id: "4f1db62f-cb41-41fb-8af3-11a67585b5db",
-					},
-				},
-			},
+		PlaybooksByCategory: map[string][]string{
+			"process_creation": {"4f1db62f-cb41-41fb-8af3-11a67585b5db"},
 		},
-		PlaybooksByEngine: map[string][]*model.Playbook{
-			"suricata": {
-				&model.Playbook{
-					Auditable: model.Auditable{
-						Id: "1dfe7517-f105-454f-ae96-f2280c09e4b2",
-					},
-				},
-			},
+		PlaybooksByEngine: map[string][]string{
+			"suricata": {"1dfe7517-f105-454f-ae96-f2280c09e4b2"},
 		},
+		playbooksOnDisk: map[string]string{
+			"6f64990a-acda-40b6-ab71-134c073013b5": "/path/6f6",
+			"4f1db62f-cb41-41fb-8af3-11a67585b5db": "/path/4f1",
+			"1dfe7517-f105-454f-ae96-f2280c09e4b2": "/path/1df",
+		},
+		IOManager: iom,
 	}
 
 	ctx := context.Background()
 
+	iom.EXPECT().ReadFile("/path/6f6").Return([]byte("id: 6f64990a-acda-40b6-ab71-134c073013b5"), nil)
 	playbooks, err := pdm.GetPlaybooksForDetection(ctx, "1182f3b3-e716-4efa-99ab-d2685d04360f", "web_request", model.EngineNameElastAlert)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(playbooks))
 	assert.Equal(t, "6f64990a-acda-40b6-ab71-134c073013b5", playbooks[0].Id)
 
+	iom.EXPECT().ReadFile("/path/4f1").Return([]byte("id: 4f1db62f-cb41-41fb-8af3-11a67585b5db"), nil)
 	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "abc", "process_creation", model.EngineNameElastAlert)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(playbooks))
 	assert.Equal(t, "4f1db62f-cb41-41fb-8af3-11a67585b5db", playbooks[0].Id)
 
+	iom.EXPECT().ReadFile("/path/1df").Return([]byte("id: 1dfe7517-f105-454f-ae96-f2280c09e4b2"), nil)
 	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "abc", "network_access", model.EngineNameSuricata)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(playbooks))
 	assert.Equal(t, "1dfe7517-f105-454f-ae96-f2280c09e4b2", playbooks[0].Id)
 
+	iom.EXPECT().ReadFile("/path/6f6").Return([]byte("id: 6f64990a-acda-40b6-ab71-134c073013b5"), nil)
+	iom.EXPECT().ReadFile("/path/4f1").Return([]byte("id: 4f1db62f-cb41-41fb-8af3-11a67585b5db"), nil)
 	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "1182F3B3-E716-4EFA-99AB-D2685D04360F", "PROCESS_CREATION", model.EngineNameSuricata)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(playbooks))
@@ -624,37 +622,33 @@ func TestGetPlaybooksForDetection(t *testing.T) {
 }
 
 func TestGetPlaybookById(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
 		srv: server.NewFakeAuthorizedServer(nil),
-		PlaybooksByPlaybookId: map[string]*model.Playbook{
-			"1182f3b3-e716-4efa-99ab-d2685d04360f": {
-				Auditable: model.Auditable{
-					Id: "1182f3b3-e716-4efa-99ab-d2685d04360f",
-				},
-			},
-			"4f1db62f-cb41-41fb-8af3-11a67585b5db": {
-				Auditable: model.Auditable{
-					Id: "4f1db62f-cb41-41fb-8af3-11a67585b5db",
-				},
-			},
-			"1dfe7517-f105-454f-ae96-f2280c09e4b2": {
-				Auditable: model.Auditable{
-					Id: "1dfe7517-f105-454f-ae96-f2280c09e4b2",
-				},
-			},
+		playbooksOnDisk: map[string]string{
+			"1182f3b3-e716-4efa-99ab-d2685d04360f": "/path/118",
+			"4f1db62f-cb41-41fb-8af3-11a67585b5db": "/path/4f1",
+			"1dfe7517-f105-454f-ae96-f2280c09e4b2": "/path/1df",
 		},
+		IOManager: iom,
 	}
 
 	ctx := context.Background()
 
+	iom.EXPECT().ReadFile("/path/118").Return([]byte("id: 1182f3b3-e716-4efa-99ab-d2685d04360f"), nil)
 	playbook, err := pdm.GetPlaybookById(ctx, "1182f3b3-e716-4efa-99ab-d2685d04360f")
 	assert.NoError(t, err)
 	assert.Equal(t, "1182f3b3-e716-4efa-99ab-d2685d04360f", playbook.Id)
 
+	iom.EXPECT().ReadFile("/path/4f1").Return([]byte("id: 4f1db62f-cb41-41fb-8af3-11a67585b5db"), nil)
 	playbook, err = pdm.GetPlaybookById(ctx, "4f1db62f-cb41-41fb-8af3-11a67585b5db")
 	assert.NoError(t, err)
 	assert.Equal(t, "4f1db62f-cb41-41fb-8af3-11a67585b5db", playbook.Id)
 
+	iom.EXPECT().ReadFile("/path/1df").Return([]byte("id: 1dfe7517-f105-454f-ae96-f2280c09e4b2"), nil)
 	playbook, err = pdm.GetPlaybookById(ctx, "1dfe7517-f105-454f-ae96-f2280c09e4b2")
 	assert.NoError(t, err)
 	assert.Equal(t, "1dfe7517-f105-454f-ae96-f2280c09e4b2", playbook.Id)
@@ -704,6 +698,7 @@ func TestReadPlaybooks(t *testing.T) {
 
 	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
+		isRunning:          true,
 		playbookRepoUrl:    "http://github.com/user/repo",
 		playbookPathInRepo: "playbooks/dev",
 		playbookRepoPath:   "/tmp/playbooks",
@@ -740,4 +735,7 @@ func TestReadPlaybooks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pbs, 1)
 	assert.Equal(t, "x", pbs[0].Id)
+
+	assert.Equal(t, 1, len(pdm.playbooksOnDisk))
+	assert.Equal(t, "success", pdm.playbooksOnDisk["x"])
 }


### PR DESCRIPTION
Playbooks are no longer stored in memory after being read in. Because of the large number of playbooks expected, the new approach reads all the playbooks once, organizes their IDs instead of the entire playbook, and keeps a reference of which IDs were found in which files on disk. When playbooks are requested, they're read from disk and returned.