### PR TITLE
Use Correct Field When Finding Newest

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2985,7 +2985,7 @@ const huntComponent = {
         }
       }
 
-      const q = parts.join(' AND ') + `| sortby event_data.@timestamp`;
+      const q = parts.join(' AND ') + `| sortby @timestamp`;
 
       let params = {
         query: q,


### PR DESCRIPTION
I assumed that since I was working with alerts, I would be working with events that contain event_data but that is not the correct approach. The alert's @timestamp is now used.