### PR TITLE
Cogburn/duplicate detection changes

### DIFF
--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -527,7 +527,7 @@
 						</template>
 						<v-col ref="eventColumn" cols="12" style="position: relative;">
 							<v-data-table ref="eventTable" :search="eventFilter" :sort-by="sortBy" @update:sort-by="val => sortBy = val" item-value="soc_id" :items-per-page-options="itemsPerPageOptions" :data-aid="'events_table_' + category"
-								:items-per-page="itemsPerPage" must-sort :headers="eventHeaders" :items="eventData" v-model:page="eventPage" show-select :custom-sort="sortEvents" density="compact" @current-items="val => eventCurrentItems = val"
+								v-model:items-per-page="itemsPerPage" must-sort :headers="eventHeaders" :items="eventData" v-model:page="eventPage" show-select :custom-sort="sortEvents" density="compact" @current-items="val => eventCurrentItems = val"
 								v-model:expanded="expandedEvents">
 								<template #top="data">
 									<!-- not-fancy way to access the current page of items:

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -303,7 +303,7 @@ func (h *DetectionHandler) CreateDetection(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	errMap, err := syncLocalDetections(ctx, h.server, []*model.Detection{detect})
+	errMap, err := h.syncLocalDetections(ctx, []*model.Detection{detect})
 	if err != nil {
 		web.Respond(w, r, http.StatusInternalServerError, err)
 		return
@@ -484,7 +484,7 @@ func (h *DetectionHandler) UpdateDetection(w http.ResponseWriter, r *http.Reques
 
 	disabledAfterSync := false
 
-	errMap, err := syncLocalDetections(ctx, h.server, []*model.Detection{detect})
+	errMap, err := h.syncLocalDetections(ctx, []*model.Detection{detect})
 	if err != nil {
 		if detect.IsEnabled && !filterApplied {
 			var uerr error
@@ -495,7 +495,7 @@ func (h *DetectionHandler) UpdateDetection(w http.ResponseWriter, r *http.Reques
 
 			detect, uerr = h.server.Detectionstore.UpdateDetection(ctx, detect)
 			if uerr == nil {
-				errMap, err = syncLocalDetections(ctx, h.server, []*model.Detection{detect})
+				errMap, err = h.syncLocalDetections(ctx, []*model.Detection{detect})
 				disabledAfterSync = true
 			} else {
 				err = uerr
@@ -630,7 +630,7 @@ func (h *DetectionHandler) DeleteDetection(w http.ResponseWriter, r *http.Reques
 	old.IsEnabled = false
 	old.PendingDelete = true
 
-	errMap, err := syncLocalDetections(ctx, h.server, []*model.Detection{old})
+	errMap, err := h.syncLocalDetections(ctx, []*model.Detection{old})
 	if err != nil {
 		web.Respond(w, r, http.StatusInternalServerError, err)
 		return
@@ -981,7 +981,7 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 
 	start = time.Now()
 
-	errMap, err = syncLocalDetections(ctx, h.server, dirty)
+	errMap, err = h.syncLocalDetections(ctx, dirty)
 	if err != nil {
 		logger.WithError(err).WithField("errMap", util.TruncateMap(errMap, 5)).Error("unable to sync detections after bulk update")
 		return
@@ -998,7 +998,7 @@ func (h *DetectionHandler) bulkUpdateDetectionAsync(ctx context.Context, body *B
 	syncDur = time.Since(start)
 }
 
-func syncLocalDetections(ctx context.Context, srv *Server, detections []*model.Detection) (errMap map[string]string, err error) {
+func (h *DetectionHandler) syncLocalDetections(ctx context.Context, detections []*model.Detection) (errMap map[string]string, err error) {
 	errMap = map[string]string{} // map[det.PublicID]error
 	defer func() {
 		if len(errMap) == 0 {
@@ -1006,7 +1006,7 @@ func syncLocalDetections(ctx context.Context, srv *Server, detections []*model.D
 		}
 	}()
 
-	err = srv.CheckAuthorized(ctx, "write", "detections")
+	err = h.server.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
 		return nil, err
 	}
@@ -1016,7 +1016,7 @@ func syncLocalDetections(ctx context.Context, srv *Server, detections []*model.D
 		byEngine[detect.Engine] = append(byEngine[detect.Engine], detect)
 	}
 
-	srv.DetectionEngines.Range(func(n, engineInt interface{}) bool {
+	h.server.DetectionEngines.Range(func(n, engineInt interface{}) bool {
 		name := n.(model.EngineName)
 		engine := engineInt.(DetectionEngine)
 

--- a/server/modules/context/context.go
+++ b/server/modules/context/context.go
@@ -7,7 +7,8 @@ import (
 type ContextKey string
 
 const (
-	ctxKeySkipAudit ContextKey = "skipAudit"
+	ctxKeySkipAudit         ContextKey = "skipAudit"
+	ctxKeyOverrideOperation ContextKey = "overrideOperation"
 )
 
 func WriteSkipAudit(ctx context.Context, skipAudit bool) context.Context {
@@ -17,4 +18,17 @@ func WriteSkipAudit(ctx context.Context, skipAudit bool) context.Context {
 func ReadSkipAudit(ctx context.Context) bool {
 	skipAudit, _ := ctx.Value(ctxKeySkipAudit).(bool)
 	return skipAudit
+}
+
+func WriteOverrideOperation(ctx context.Context, op string) context.Context {
+	return context.WithValue(ctx, ctxKeyOverrideOperation, op)
+}
+
+func ReadOverrideOperation(ctx context.Context) *string {
+	overrideOp, ok := ctx.Value(ctxKeyOverrideOperation).(string)
+	if ok {
+		return &overrideOp
+	}
+
+	return nil
 }

--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -40,7 +40,7 @@ type GetterByPublicId interface {
 //go:generate mockgen -destination mock/mock_iomanager.go -package mock . IOManager
 
 func DetermineWaitTime(iom IOManager, path string, importFrequency time.Duration) (*uint64, time.Duration) {
-	lastImport, err := readStateFile(iom, path)
+	lastImport, err := ReadStateFile(iom, path)
 	if err != nil {
 		log.WithError(err).Error("unable to read state file, deleting it")
 
@@ -66,7 +66,7 @@ func DetermineWaitTime(iom IOManager, path string, importFrequency time.Duration
 	return lastImport, timerDur
 }
 
-func readStateFile(iom IOManager, path string) (lastImport *uint64, err error) {
+func ReadStateFile(iom IOManager, path string) (lastImport *uint64, err error) {
 	raw, err := iom.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/server/modules/detections/integrity_check.go
+++ b/server/modules/detections/integrity_check.go
@@ -16,6 +16,7 @@ import (
 
 var ErrIntCheckerStopped = fmt.Errorf("integrity checker has stopped running")
 var ErrIntCheckFailed = fmt.Errorf("integrity check failed; discrepancies found")
+var ErrStateFileNoCommunity = fmt.Errorf("state file present but 0 community rules found")
 
 type IntegrityChecked interface {
 	IntegrityCheck(bool, *log.Entry) ([]string, []string, error)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1158,6 +1158,7 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 			detect.Overrides = orig.Overrides
 			detect.CreateTime = orig.CreateTime
 		} else {
+			detect.Id = util.ToUUID(detect.PublicID)
 			detect.CreateTime = util.Ptr(time.Now())
 			checkRulesetEnabled(e, detect)
 		}
@@ -1240,9 +1241,10 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 			}).Info("creating new Sigma detection")
 
 			err = bulk.Add(ctx, esutil.BulkIndexerItem{
-				Index:  index,
-				Action: "create",
-				Body:   bytes.NewReader(document),
+				Index:      index,
+				Action:     "create",
+				DocumentID: detect.Id,
+				Body:       bytes.NewReader(document),
 				OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem) {
 					auditMut.Lock()
 					defer auditMut.Unlock()

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -699,16 +699,18 @@ func (e *ElastAlertEngine) Sync(logger *log.Entry, forceSync bool) error {
 		zipHashes[pkg] = base64.StdEncoding.EncodeToString(h[:])
 	}
 
+	// if we're not forcing a sync, check to see if anything has changed
+	// if nothing has changed, the sync is finished
+	raw, err := e.ReadFile(e.rulesFingerprintFile)
+	if err != nil && !os.IsNotExist(err) {
+		logger.WithError(err).WithField("fingerprintPath", e.rulesFingerprintFile).Error("unable to read rules fingerprint file")
+
+		return detections.ErrSyncFailed
+	}
+
+	fingerprintFilePresent := len(raw) != 0
+
 	if !forceSync {
-		// if we're not forcing a sync, check to see if anything has changed
-		// if nothing has changed, the sync is finished
-		raw, err := e.ReadFile(e.rulesFingerprintFile)
-		if err != nil && !os.IsNotExist(err) {
-			logger.WithError(err).WithField("fingerprintPath", e.rulesFingerprintFile).Error("unable to read rules fingerprint file")
-
-			return detections.ErrSyncFailed
-		}
-
 		oldHashes := map[string]string{}
 
 		err = json.Unmarshal(raw, &oldHashes)
@@ -776,10 +778,12 @@ func (e *ElastAlertEngine) Sync(logger *log.Entry, forceSync bool) error {
 
 	detects = detections.DeduplicateByPublicId(detects)
 
-	errMap, err = e.syncCommunityDetections(e.srv.Context, logger, detects)
+	errMap, err = e.syncCommunityDetections(e.srv.Context, logger, detects, fingerprintFilePresent)
 	if err != nil {
 		if errors.Is(err, detections.ErrModuleStopped) {
 			logger.Info("incomplete sync of elastalert community detections due to module stopping")
+			return err
+		} else if errors.Is(err, detections.ErrStateFileNoCommunity) {
 			return err
 		}
 
@@ -1079,7 +1083,7 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 	return detects, errMap
 }
 
-func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *log.Entry, detects []*model.Detection) (errMap map[string]error, err error) {
+func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *log.Entry, detects []*model.Detection, fingerprintFilePresent bool) (errMap map[string]error, err error) {
 	existing, err := e.IndexExistingRules()
 	if err != nil {
 		return nil, err
@@ -1088,6 +1092,23 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 	community, err := e.srv.Detectionstore.GetAllDetections(ctx, model.WithEngine(model.EngineNameElastAlert), model.WithCommunity(true))
 	if err != nil {
 		return nil, err
+	}
+
+	if fingerprintFilePresent && len(community) == 0 {
+		// Two conflicting facts appear to be true:
+		// 1) We have imported rules before, the fingerprint file exists
+		// 2) There are 0 imported community rules
+		// This lines up perfectly with the weird glitch of double-imported
+		// detections we've been tracking. Mark the sync as a failure.
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameElastAlert,
+				Status: "error",
+			})
+		}
+
+		return nil, detections.ErrStateFileNoCommunity
 	}
 
 	index := map[string]string{}
@@ -2037,7 +2058,7 @@ func (e *ElastAlertEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) 
 
 	if logger == nil {
 		logger = log.WithFields(log.Fields{
-			"detectionEngine": model.EngineNameSuricata,
+			"detectionEngine": model.EngineNameElastAlert,
 		})
 	}
 

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"os"
 	"os/exec"
 	"slices"
 	"sort"
@@ -1702,6 +1703,7 @@ func TestSyncChanges(t *testing.T) {
 
 	// checkSigmaPipelines
 	iom.EXPECT().ReadFile("sigmaPipelineFinal").Return([]byte("data"), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return(nil, os.ErrNotExist)
 	iom.EXPECT().ReadFile("sigmaPipelineSO").Return([]byte("data"), nil)
 	iom.EXPECT().ReadFile("sigmaPipelinesFingerprintFile").Return([]byte("a different hash"), nil)
 	// downloadSigmaPackages
@@ -1908,6 +1910,7 @@ func TestSyncUnchangedOverrides(t *testing.T) {
 
 	// checkSigmaPipelines
 	iom.EXPECT().ReadFile("sigmaPipelineFinal").Return([]byte("data"), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return(nil, os.ErrNotExist)
 	iom.EXPECT().ReadFile("sigmaPipelineSO").Return([]byte("data"), nil)
 	iom.EXPECT().ReadFile("sigmaPipelinesFingerprintFile").Return([]byte("a different hash"), nil)
 	// downloadSigmaPackages
@@ -1996,6 +1999,107 @@ func TestSyncUnchangedOverrides(t *testing.T) {
 	assert.False(t, eng.EngineState.MigrationFailure)
 	assert.False(t, eng.EngineState.Importing)
 	assert.False(t, eng.EngineState.SyncFailure)
+
+	assert.Len(t, workItems, 0)
+}
+
+func TestSyncStateFileNoCommunity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	buf := bytes.NewBuffer([]byte{})
+
+	writer := zip.NewWriter(buf)
+	sr, err := writer.Create("rules/simple_rule.yml")
+	assert.NoError(t, err)
+
+	_, err = sr.Write([]byte(SimpleRule))
+	assert.NoError(t, err)
+
+	assert.NoError(t, writer.Close())
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+	// bim := servermock.NewMockBulkIndexer(ctrl)
+
+	eng := &ElastAlertEngine{
+		srv: &server.Server{
+			Context:        context.Background(),
+			Detectionstore: detStore,
+		},
+		isRunning:                     true,
+		sigmaPipelineFinal:            "sigmaPipelineFinal",
+		sigmaPipelineSO:               "sigmaPipelineSO",
+		sigmaPipelinesFingerprintFile: "sigmaPipelinesFingerprintFile",
+		sigmaRulePackages:             []string{"core+"},
+		sigmaPackageDownloadTemplate:  "https://github.com/SigmaHQ/sigma/releases/latest/download/sigma_%s.zip",
+		reposFolder:                   "repos",
+		rulesFingerprintFile:          "rulesFingerprintFile",
+		elastAlertRulesFolder:         "elastAlertRulesFolder",
+		rulesRepos: []*model.RuleRepo{
+			{
+				Repo:      "https://github.com/user/repo",
+				Community: true,
+			},
+		},
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager:       iom,
+		showAiSummaries: false,
+	}
+
+	logger := log.WithField("detectionEngine", "test-elastalert")
+
+	workItems := []esutil.BulkIndexerItem{}
+
+	// checkSigmaPipelines
+	iom.EXPECT().ReadFile("sigmaPipelineFinal").Return([]byte("data"), nil)
+	iom.EXPECT().ReadFile("sigmaPipelineSO").Return([]byte("data"), nil)
+	iom.EXPECT().ReadFile("sigmaPipelinesFingerprintFile").Return([]byte("a different hash"), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return([]byte("something"), nil)
+	// downloadSigmaPackages
+	iom.EXPECT().MakeRequest(gomock.Any()).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(buf),
+	}, nil)
+	// UpdateRepos
+	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: "repo",
+			Dir:      true,
+		},
+	}, nil)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(false, false, false)
+	// parseRepoRules
+	iom.EXPECT().WalkDir("repos/repo", gomock.Any()).DoAndReturn(func(path string, fn fs.WalkDirFunc) error {
+		files := []fs.DirEntry{
+			&handmock.MockDirEntry{
+				Filename: "rules/123.yml",
+			},
+		}
+
+		for _, file := range files {
+			err := fn(file.Name(), file, nil)
+			assert.NoError(t, err)
+		}
+
+		return nil
+	})
+	iom.EXPECT().ReadFile("rules/123.yml").Return([]byte(SimpleRule), nil)
+	// syncCommunityDetections
+	iom.EXPECT().ReadDir("elastAlertRulesFolder").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: SimpleRuleSID + ".yml",
+		},
+	}, nil) // IndexExistingRules
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{}, nil)
+
+	err = eng.Sync(logger, true)
+	assert.Equal(t, detections.ErrStateFileNoCommunity, err)
 
 	assert.Len(t, workItems, 0)
 }

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1749,7 +1749,7 @@ func TestSyncChanges(t *testing.T) {
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		SimpleRuleSID: {
 			Auditable: model.Auditable{
-				Id:         "abc",
+				Id:         "9e7087bd-61f3-4a8c-baf2-16a53ddbc188",
 				CreateTime: util.Ptr(time.Now()),
 			},
 			PublicID:  SimpleRuleSID,
@@ -1757,7 +1757,7 @@ func TestSyncChanges(t *testing.T) {
 		},
 		"00000000-0000-0000-0000-000000000000": {
 			Auditable: model.Auditable{
-				Id: "deleteme",
+				Id: "48f3cde9-f9ed-44f9-bb62-9e545a9bdb39",
 			},
 			PublicID: "00000000-0000-0000-0000-000000000000",
 		},
@@ -1767,7 +1767,7 @@ func TestSyncChanges(t *testing.T) {
 	bim.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, item esutil.BulkIndexerItem) error {
 		if item.OnSuccess != nil {
 			resp := esutil.BulkIndexerResponseItem{
-				DocumentID: "id",
+				DocumentID: item.DocumentID,
 			}
 			item.OnSuccess(ctx, item, resp)
 		}
@@ -1850,7 +1850,7 @@ func TestSyncChanges(t *testing.T) {
 		return item.DocumentID
 	})
 
-	assert.Equal(t, []string{"abc", "", "deleteme"}, workDocIds) // update has an id, create does not, delete does
+	assert.Equal(t, []string{"9e7087bd-61f3-4a8c-baf2-16a53ddbc188", "47bd3bbf-3c67-42c7-b70b-6b76bb5cf04f", "48f3cde9-f9ed-44f9-bb62-9e545a9bdb39"}, workDocIds)
 }
 
 func TestSyncUnchangedOverrides(t *testing.T) {

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -444,9 +444,13 @@ func (store *ElasticDetectionstore) DetectionScroll(ctx context.Context, criteri
 func (store *ElasticDetectionstore) prepareForSave(ctx context.Context, obj *model.Auditable) string {
 	obj.UserId, _ = ctx.Value(web.ContextKeyRequestorId).(string)
 
+	hasOpOverride := modcontext.ReadOverrideOperation(ctx) != nil
+
 	// Don't waste space by saving the these values which are already part of ES documents
 	id := obj.Id
-	obj.Id = ""
+	if !hasOpOverride {
+		obj.Id = ""
+	}
 	obj.UpdateTime = nil
 
 	return id

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -191,6 +191,7 @@ func (store *ElasticDetectionstore) save(ctx context.Context, obj interface{}, k
 	}
 
 	skipAudit := modcontext.ReadSkipAudit(ctx)
+	overrideOp := modcontext.ReadOverrideOperation(ctx)
 
 	document := ConvertObjectToDocumentMap(kind, obj, store.schemaPrefix)
 	document[store.schemaPrefix+"kind"] = kind
@@ -199,10 +200,14 @@ func (store *ElasticDetectionstore) save(ctx context.Context, obj interface{}, k
 	if err == nil && !skipAudit {
 		document[store.schemaPrefix+AUDIT_DOC_ID] = results.DocumentId
 
-		if id == "" {
-			document[store.schemaPrefix+"operation"] = "create"
+		if overrideOp != nil {
+			document[store.schemaPrefix+"operation"] = *overrideOp
 		} else {
-			document[store.schemaPrefix+"operation"] = "update"
+			if id == "" {
+				document[store.schemaPrefix+"operation"] = "create"
+			} else {
+				document[store.schemaPrefix+"operation"] = "update"
+			}
 		}
 
 		_, err = store.Index(ctx, store.auditIndex, document, "")
@@ -468,21 +473,22 @@ func (store *ElasticDetectionstore) CreateDetection(ctx context.Context, detect 
 		return nil, errors.New("Unexpected ID found in new comment")
 	}
 
-	if detect.PublicID != "" {
-		duplicates, err := store.getAll(ctx, fmt.Sprintf(`_index:"%s" AND %skind:"%s" AND %sdetection.publicId:"%s" AND %sdetection.engine:"%s"`, store.index, store.schemaPrefix, "detection", store.schemaPrefix, detect.PublicID, store.schemaPrefix, detect.Engine), 1)
-		if err != nil {
-			return nil, err
-		}
+	duplicates, err := store.getAll(ctx, fmt.Sprintf(`_index:"%s" AND %skind:"%s" AND %sdetection.publicId:"%s" AND %sdetection.engine:"%s"`, store.index, store.schemaPrefix, "detection", store.schemaPrefix, detect.PublicID, store.schemaPrefix, detect.Engine), 1)
+	if err != nil {
+		return nil, err
+	}
 
-		if len(duplicates) > 0 {
-			return nil, errors.New("publicId already exists for this engine")
-		}
+	if len(duplicates) > 0 {
+		return nil, errors.New("publicId already exists for this engine")
 	}
 
 	now := time.Now()
 	detect.CreateTime = &now
+	detect.Id = util.ToUUID(detect.PublicID)
 
 	var results *model.EventIndexResults
+
+	ctx = modcontext.WriteOverrideOperation(ctx, "create")
 
 	results, err = store.save(ctx, detect, "detection", store.prepareForSave(ctx, &detect.Auditable))
 	if err == nil {

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -416,12 +416,15 @@ func TestCreateDetectionValid(t *testing.T) {
 
 	fakeStore.SearchResults = []*model.EventSearchResults{
 		{
+			TotalEvents: 0,
+		},
+		{
 			TotalEvents: 1,
 			Events: []*model.EventRecord{
 				{
 					Payload: map[string]interface{}{
 						"so_detection.userId":      "myRequestorId",
-						"so_detection.publicId":    "",
+						"so_detection.publicId":    "201234",
 						"so_detection.title":       "myTitle",
 						"so_detection.severity":    "low",
 						"so_detection.author":      "Jane Doe",
@@ -444,6 +447,7 @@ func TestCreateDetectionValid(t *testing.T) {
 						},
 						"so_kind": "detection",
 					},
+					Id: "fa7e7b78-b2ad-4345-b390-39fa0b0b505c",
 				},
 			},
 		},
@@ -458,6 +462,7 @@ func TestCreateDetectionValid(t *testing.T) {
 		Severity:    "low",
 		Author:      "Jane Doe",
 		Description: "myDescription",
+		PublicID:    "201234",
 		Content:     "myContent",
 		IsEnabled:   true,
 		IsReporting: true,
@@ -471,6 +476,9 @@ func TestCreateDetectionValid(t *testing.T) {
 		},
 		Tags: []string{"myTag"},
 	}
+	detWithId := util.Copy(det)
+	detWithId.Id = "fa7e7b78-b2ad-4345-b390-39fa0b0b505c"
+	detWithId.UserId = "myRequestorId"
 
 	body1 := `{"result":"created", "_id":"ABC123"}`
 	body2 := `{"result":"created", "_id":"DEF456"}`
@@ -494,14 +502,14 @@ func TestCreateDetectionValid(t *testing.T) {
 	assert.NotNil(t, postDet.Overrides[0].CreatedAt)
 	assert.NotNil(t, postDet.Overrides[0].UpdatedAt)
 	assert.Equal(t, "detection", postDet.Kind)
-	det.CreateTime = nil
+	detWithId.CreateTime = nil
 	postDet.CreateTime = nil
 	postDet.UpdateTime = nil
 	postDet.Kind = ""
 	postDet.Overrides = nil
-	det.Overrides = nil
+	detWithId.Overrides = nil
 
-	assert.Equal(t, det, postDet)
+	assert.Equal(t, detWithId, postDet)
 
 	reqs := mocktrans.GetRequests()
 
@@ -514,7 +522,7 @@ func TestCreateDetectionValid(t *testing.T) {
 	assert.NotNil(t, reqDet.Overrides[0].UpdatedAt)
 	reqDet.CreateTime = nil
 	reqDet.Overrides = nil
-	assert.Equal(t, det, reqDet)
+	assert.Equal(t, detWithId, reqDet)
 
 	body, err := io.ReadAll(reqs[1].Body)
 	assert.NoError(t, err)
@@ -533,7 +541,7 @@ func TestCreateDetectionValid(t *testing.T) {
 	reqDet.CreateTime = nil
 	reqDet.Overrides = nil
 
-	assert.Equal(t, det, reqDet)
+	assert.Equal(t, detWithId, reqDet)
 
 	kind := gjson.Get(string(body), "so_kind").Str
 	assert.Equal(t, "detection", kind)

--- a/server/modules/elastic/elasticeventstore.go
+++ b/server/modules/elastic/elasticeventstore.go
@@ -316,6 +316,16 @@ func (store *ElasticEventstore) Scroll(ctx context.Context, criteria *model.Even
 			return finalResults, err
 		}
 
+		if len(finalResults.Events) == 0 && strings.Contains(query, "so_detection.engine") {
+			// only 2 actions call this Scroll function: GetAllDetections used in
+			// DetectionEngine Syncs, and Bulk Updates of Detections. If the query
+			// contains a condition for the engine, then it's a GetAllDetections call
+			logger.WithFields(log.Fields{
+				"scrollQuery":      query,
+				"fullJsonResponse": json,
+			}).Info("scrolled for 0 results")
+		}
+
 		logger.WithFields(log.Fields{
 			"batchNum": batchNum,
 			"hitCount": len(finalResults.Events),

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -526,6 +526,7 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 			detect.Overrides = orig.Overrides
 			detect.CreateTime = orig.CreateTime
 		} else {
+			detect.Id = util.ToUUID(detect.PublicID)
 			detect.CreateTime = util.Ptr(time.Now())
 			checkRulesetEnabled(e, detect)
 		}
@@ -607,9 +608,10 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 			}).Info("creating new YARA detection")
 
 			err = bulk.Add(e.srv.Context, esutil.BulkIndexerItem{
-				Index:  index,
-				Action: "create",
-				Body:   bytes.NewReader(document),
+				Index:      index,
+				Action:     "create",
+				DocumentID: detect.Id,
+				Body:       bytes.NewReader(document),
 				OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem) {
 					auditMut.Lock()
 					defer auditMut.Unlock()

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -375,6 +375,10 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 		return detections.ErrModuleStopped
 	}
 
+	state, _ := detections.ReadStateFile(e.IOManager, e.StateFilePath)
+
+	hasFP := state != nil && *state != 0
+
 	communityDetections, err := e.srv.Detectionstore.GetAllDetections(e.srv.Context, model.WithEngine(model.EngineNameStrelka), model.WithCommunity(true))
 	if err != nil {
 		logger.WithError(err).Error("failed to get all community SIDs")
@@ -387,6 +391,23 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 		}
 
 		return detections.ErrSyncFailed
+	}
+
+	if hasFP && len(communityDetections) == 0 {
+		// Two conflicting facts appear to be true:
+		// 1) We have imported rules before, the fingerprint file exists
+		// 2) There are 0 imported community rules
+		// This lines up perfectly with the weird glitch of double-imported
+		// detections we've been tracking. Mark the sync as a failure.
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameStrelka,
+				Status: "error",
+			})
+		}
+
+		return detections.ErrStateFileNoCommunity
 	}
 
 	if !e.isRunning {
@@ -664,7 +685,7 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 
 		if e.notify {
 			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-				Engine: model.EngineNameElastAlert,
+				Engine: model.EngineNameStrelka,
 				Status: "error",
 			})
 		}
@@ -1239,7 +1260,7 @@ func (e *StrelkaEngine) IntegrityCheck(canInterrupt bool, logger *log.Entry) (de
 
 	if logger == nil {
 		logger = log.WithFields(log.Fields{
-			"detectionEngine": model.EngineNameSuricata,
+			"detectionEngine": model.EngineNameStrelka,
 		})
 	}
 

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1150,7 +1150,7 @@ func TestSyncChanges(t *testing.T) {
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		"dummy": {
 			Auditable: model.Auditable{
-				Id:         "abc",
+				Id:         "09e98cc8-9df7-4891-ba16-9e1e14fd8cf6",
 				CreateTime: util.Ptr(time.Now()),
 			},
 			PublicID:  "dummy",
@@ -1158,7 +1158,7 @@ func TestSyncChanges(t *testing.T) {
 		},
 		"delete": {
 			Auditable: model.Auditable{
-				Id: "deleteme",
+				Id: "e59b4d9a-1f2f-4dc5-b5e4-77c962292c74",
 			},
 			PublicID: "delete",
 		},
@@ -1186,7 +1186,7 @@ func TestSyncChanges(t *testing.T) {
 	bim.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, item esutil.BulkIndexerItem) error {
 		if item.OnSuccess != nil {
 			resp := esutil.BulkIndexerResponseItem{
-				DocumentID: "id",
+				DocumentID: item.DocumentID,
 			}
 			item.OnSuccess(ctx, item, resp)
 		}
@@ -1285,7 +1285,7 @@ func TestSyncChanges(t *testing.T) {
 		return item.DocumentID
 	})
 
-	assert.Equal(t, []string{"abc", "", "deleteme"}, workDocIds) // update has an id, create does not, delete does
+	assert.Equal(t, []string{"09e98cc8-9df7-4891-ba16-9e1e14fd8cf6", "4a9dae8e-383f-41c5-b426-b458c1b453bc", "e59b4d9a-1f2f-4dc5-b5e4-77c962292c74"}, workDocIds) // update has an id, create does not, delete does
 }
 
 func TestLoadAndMergeAuxiliaryData(t *testing.T) {

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1147,6 +1147,7 @@ func TestSyncChanges(t *testing.T) {
 	}, nil)
 	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(true, false, false)
 	// Sync
+	iom.EXPECT().ReadFile("stateFilePath").Return(nil, os.ErrNotExist)
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		"dummy": {
 			Auditable: model.Auditable{
@@ -1286,6 +1287,59 @@ func TestSyncChanges(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"09e98cc8-9df7-4891-ba16-9e1e14fd8cf6", "4a9dae8e-383f-41c5-b426-b458c1b453bc", "e59b4d9a-1f2f-4dc5-b5e4-77c962292c74"}, workDocIds) // update has an id, create does not, delete does
+}
+
+func TestSyncStateFileNoCommunity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+
+	eng := &StrelkaEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+			Context:        ctx,
+		},
+		isRunning:   true,
+		reposFolder: "repos",
+		rulesRepos: []*model.RuleRepo{
+			{
+				Repo:      "https://github.com/user/repo",
+				Community: true,
+			},
+		},
+		autoEnabledYaraRules:        []string{"repo"},
+		yaraRulesFolder:             "yaraRulesFolder",
+		compileYaraPythonScriptPath: "compile_yara.py",
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager:       iom,
+		showAiSummaries: false,
+	}
+
+	logger := log.WithField("detectionEngine", "test-strelka")
+
+	// UpdateRepos
+	iom.EXPECT().ReadDir("repos").Return([]fs.DirEntry{
+		&handmock.MockDirEntry{
+			Filename: "repo",
+			Dir:      true,
+		},
+	}, nil)
+	iom.EXPECT().PullRepo(gomock.Any(), "repos/repo", nil).Return(true, false, false)
+	// Sync
+	iom.EXPECT().ReadFile("stateFilePath").Return([]byte("1000"), nil)
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{}, nil)
+
+	err := eng.Sync(logger, true)
+	assert.Equal(t, detections.ErrStateFileNoCommunity, err)
 }
 
 func TestLoadAndMergeAuxiliaryData(t *testing.T) {

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1277,6 +1277,7 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *lo
 			detect.Overrides = orig.Overrides
 			detect.CreateTime = orig.CreateTime
 		} else {
+			detect.Id = util.ToUUID(detect.PublicID)
 			detect.CreateTime = util.Ptr(time.Now())
 		}
 
@@ -1389,9 +1390,10 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *lo
 			}).Info("creating new Suricata detection")
 
 			err = bulk.Add(ctx, esutil.BulkIndexerItem{
-				Index:  index,
-				Action: "create",
-				Body:   bytes.NewReader(document),
+				Index:      index,
+				Action:     "create",
+				DocumentID: detect.Id,
+				Body:       bytes.NewReader(document),
 				OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem) {
 					auditMut.Lock()
 					defer auditMut.Unlock()

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -360,7 +360,7 @@ func (e *SuricataEngine) Sync(logger *log.Entry, forceSync bool) error {
 	if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, e.writeNoRead) {
 		if e.notify {
 			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
-				Engine: model.EngineNameStrelka,
+				Engine: model.EngineNameSuricata,
 				Status: "error",
 			})
 		}
@@ -408,13 +408,13 @@ func (e *SuricataEngine) Sync(logger *log.Entry, forceSync bool) error {
 		return detections.ErrSyncFailed
 	}
 
-	if !forceSync {
-		fingerprint, haveFP, err := e.readFingerprint(e.rulesFingerprintFile)
-		if err != nil {
-			logger.WithError(err).Error("unable to read rules fingerprint file")
-			return detections.ErrSyncFailed
-		}
+	fingerprint, haveFP, err := e.readFingerprint(e.rulesFingerprintFile)
+	if err != nil {
+		logger.WithError(err).Error("unable to read rules fingerprint file")
+		return detections.ErrSyncFailed
+	}
 
+	if !forceSync {
 		if haveFP && strings.EqualFold(*fingerprint, hash) {
 			// if we have a fingerprint and the hashes are equal, there's nothing to do
 			logger.Info("community rule sync found no changes")
@@ -501,10 +501,12 @@ func (e *SuricataEngine) Sync(logger *log.Entry, forceSync bool) error {
 
 	commDetections = detections.DeduplicateByPublicId(commDetections)
 
-	errMap, err := e.syncCommunityDetections(e.srv.Context, logger, commDetections, true, allSettings)
+	errMap, err := e.syncCommunityDetections(e.srv.Context, logger, commDetections, haveFP, true, allSettings)
 	if err != nil {
 		if errors.Is(err, detections.ErrModuleStopped) {
 			logger.Info("incomplete sync of suricata community detections due to module stopping")
+			return err
+		} else if errors.Is(err, detections.ErrStateFileNoCommunity) {
 			return err
 		}
 
@@ -853,7 +855,9 @@ func (e *SuricataEngine) SyncLocalDetections(ctx context.Context, detects []*mod
 	errMap = map[string]string{} // map[sid]error
 
 	if len(communityDets) != 0 {
-		eMap, err := e.syncCommunityDetections(ctx, nil, communityDets, false, allSettings)
+		_, haveFP, _ := e.readFingerprint(e.rulesFingerprintFile)
+
+		eMap, err := e.syncCommunityDetections(ctx, nil, communityDets, haveFP, false, allSettings)
 		if err != nil {
 			return eMap, err
 		}
@@ -1169,7 +1173,7 @@ func removeFromIndex(lines []string, index map[string]int, sid string) {
 	}
 }
 
-func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *log.Entry, detects []*model.Detection, deleteUnreferenced bool, allSettings []*model.Setting) (errMap map[string]string, err error) {
+func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *log.Entry, detects []*model.Detection, fingerprintFilePresent bool, deleteUnreferenced bool, allSettings []*model.Setting) (errMap map[string]string, err error) {
 	defer func() {
 		if len(errMap) == 0 {
 			errMap = nil
@@ -1226,6 +1230,23 @@ func (e *SuricataEngine) syncCommunityDetections(ctx context.Context, logger *lo
 	commSIDs, err := e.srv.Detectionstore.GetAllDetections(ctx, model.WithEngine(model.EngineNameSuricata), model.WithCommunity(true))
 	if err != nil {
 		return nil, err
+	}
+
+	if fingerprintFilePresent && len(commSIDs) == 0 {
+		// Two conflicting facts appear to be true:
+		// 1) We have imported rules before, the fingerprint file exists
+		// 2) There are 0 imported community rules
+		// This lines up perfectly with the weird glitch of double-imported
+		// detections we've been tracking. Mark the sync as a failure.
+
+		if e.notify {
+			e.srv.Host.Broadcast("detection-sync", "detections", server.SyncStatus{
+				Engine: model.EngineNameSuricata,
+				Status: "error",
+			})
+		}
+
+		return nil, detections.ErrStateFileNoCommunity
 	}
 
 	toDelete := map[string]struct{}{}

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -912,6 +912,7 @@ func TestSyncCommunitySuricata(t *testing.T) {
 	table := []struct {
 		Name             string
 		InitialSettings  []*model.Setting
+		HasFP            bool
 		Detections       []*model.Detection // Content (Valid Rule), PublicID, IsEnabled
 		ChangedByUser    bool
 		InitMock         func(*servermock.MockDetectionstore)
@@ -1110,6 +1111,7 @@ func TestSyncCommunitySuricata(t *testing.T) {
 				DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 				Detectionstore:   detStore,
 			})
+			mod.rulesFingerprintFile = "rulesFingerprintFile"
 			mod.srv.DetectionEngines.Store(model.EngineNameSuricata, mod)
 
 			mod.isRunning = true
@@ -1120,7 +1122,7 @@ func TestSyncCommunitySuricata(t *testing.T) {
 				}
 			}
 
-			errMap, err := mod.syncCommunityDetections(ctx, nil, test.Detections, false, test.InitialSettings)
+			errMap, err := mod.syncCommunityDetections(ctx, nil, test.Detections, test.HasFP, false, test.InitialSettings)
 
 			assert.Equal(t, test.ExpectedErr, err)
 			assert.Equal(t, test.ExpectedErrMap, errMap)
@@ -2328,6 +2330,7 @@ func TestSyncChanges(t *testing.T) {
 
 	// readAndHash
 	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule+"\n"+FlowbitsRuleA), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return(nil, os.ErrNotExist)
 	// syncCommunityDetections
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		SimpleRuleSID: {
@@ -2491,6 +2494,7 @@ func TestSyncModifiedByFilter(t *testing.T) {
 
 	// readAndHash
 	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return(nil, os.ErrNotExist)
 	// syncCommunityDetections
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		SimpleRuleSID: {
@@ -2654,6 +2658,7 @@ func TestSyncUnchangedOverrides(t *testing.T) {
 
 	// readAndHash
 	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return(nil, os.ErrNotExist)
 	// syncCommunityDetections
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		SimpleRuleSID: {
@@ -2723,6 +2728,65 @@ func TestSyncUnchangedOverrides(t *testing.T) {
 	assert.Equal(t, "{}\n", threshold.Value)
 
 	assert.Len(t, workItems, 0)
+}
+
+func TestSyncStateFileNoCommunity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	migrationChecked := false
+	checkMigration := func() {
+		migrationChecked = true
+	}
+
+	ctx := context.Background()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+	cfgStore := server.NewMemConfigStore([]*model.Setting{
+		{Id: "idstools.rules.local__rules", Value: SimpleRule},
+		{Id: "idstools.sids.enabled", Value: SimpleRuleSID},
+		{Id: "idstools.sids.disabled"},
+		{Id: "idstools.sids.modify", Value: SimpleRuleSID + ` "rev:1" "rev:2"`},
+		{Id: "suricata.thresholding.sids__yaml"},
+		{Id: "idstools.config.ruleset", Value: "repo"},
+		{Id: "soc.config.server.modules.suricataengine.ignoredSidRanges"},
+	})
+
+	eng := &SuricataEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+			Configstore:    cfgStore,
+			Context:        ctx,
+		},
+		isRunning:            true,
+		communityRulesFile:   "communityRulesFile",
+		rulesFingerprintFile: "rulesFingerprintFile",
+		allRulesFile:         "allRulesFile",
+		checkMigrationsOnce:  sync.OnceFunc(checkMigration),
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		IntegrityCheckerData: detections.IntegrityCheckerData{
+			IsRunning: true,
+		},
+		IOManager:       iom,
+		showAiSummaries: false,
+	}
+
+	logger := log.WithField("detectionEngine", "test-suricata")
+
+	// readAndHash
+	iom.EXPECT().ReadFile("communityRulesFile").Return([]byte(SimpleRule), nil)
+	iom.EXPECT().ReadFile("rulesFingerprintFile").Return([]byte("1000"), nil)
+	// syncCommunityDetections
+	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{}, nil)
+
+	err := eng.Sync(logger, true)
+	assert.Equal(t, detections.ErrStateFileNoCommunity, err)
+
+	// migration requires that GetAllDetections actually returns all detections
+	assert.False(t, migrationChecked)
 }
 
 func TestApplyFilters(t *testing.T) {

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -2332,23 +2332,23 @@ func TestSyncChanges(t *testing.T) {
 	detStore.EXPECT().GetAllDetections(gomock.Any(), gomock.Any()).Return(map[string]*model.Detection{
 		SimpleRuleSID: {
 			Auditable: model.Auditable{
-				Id:         "abc",
+				Id:         "9e466416-2d7a-4ab3-b798-7f6b0cff3660",
 				CreateTime: util.Ptr(time.Now()),
 			},
 			IsEnabled: true,
 		},
 		"99999": {
 			Auditable: model.Auditable{
-				Id: "deleteme",
+				Id: "88de5ebe-1c13-4818-b397-d4c3afaa32d8",
 			},
 		}, // to be deleted
 	}, nil)
 	detStore.EXPECT().BuildBulkIndexer(gomock.Any(), gomock.Any()).Return(bim, nil)
-	detStore.EXPECT().ConvertObjectToDocument(gomock.Any(), "detection", gomock.Any(), gomock.Any(), gomock.Any(), nil, nil).Return([]byte("document"), "index", nil).Times(3)
+	detStore.EXPECT().ConvertObjectToDocument(gomock.Any(), "detection", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil).Return([]byte("document"), "index", nil).Times(3)
 	bim.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, item esutil.BulkIndexerItem) error {
 		if item.OnSuccess != nil {
 			resp := esutil.BulkIndexerResponseItem{
-				DocumentID: "id",
+				DocumentID: item.DocumentID,
 			}
 			item.OnSuccess(ctx, item, resp)
 		}
@@ -2360,7 +2360,7 @@ func TestSyncChanges(t *testing.T) {
 	bim.EXPECT().Close(gomock.Any()).Return(nil)
 	bim.EXPECT().Stats().Return(esutil.BulkIndexerStats{})
 	detStore.EXPECT().BuildBulkIndexer(gomock.Any(), gomock.Any()).Return(auditm, nil)
-	detStore.EXPECT().ConvertObjectToDocument(gomock.Any(), "detection", gomock.Any(), gomock.Any(), gomock.Any(), util.Ptr("id"), gomock.Any()).Return([]byte("document"), "index", nil).Times(3)
+	detStore.EXPECT().ConvertObjectToDocument(gomock.Any(), "detection", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("document"), "index", nil).Times(3)
 	auditm.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, item esutil.BulkIndexerItem) error {
 		if item.OnSuccess != nil {
 			resp := esutil.BulkIndexerResponseItem{
@@ -2434,7 +2434,7 @@ func TestSyncChanges(t *testing.T) {
 		return item.DocumentID
 	})
 
-	assert.Equal(t, []string{"abc", "", "deleteme"}, workDocIds) // update has an id, create does not, delete does
+	assert.Equal(t, []string{"9e466416-2d7a-4ab3-b798-7f6b0cff3660", "67c2c34e-de94-42c3-b67f-a687a2a3cf98", "88de5ebe-1c13-4818-b397-d4c3afaa32d8"}, workDocIds)
 }
 
 func TestSyncModifiedByFilter(t *testing.T) {

--- a/util/strings.go
+++ b/util/strings.go
@@ -5,7 +5,12 @@
 
 package util
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
 
 func Unquote(value string) string {
 	if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
@@ -47,4 +52,27 @@ func ComparePtrs[T comparable](a, b *T) bool {
 	}
 
 	return *a == *b
+}
+
+func ToUUID(s string) string {
+	// Convert a string to a UUID deterministically
+
+	// hash the string, get 32 bytes
+	hash := sha256.Sum256([]byte(s))
+
+	// 32 bytes => 16 bytes
+	for i := 0; i < 16; i++ {
+		hash[i] = hash[i] ^ hash[16+i]
+	}
+	h := hash[:16]
+
+	// 16 bytes => 15 bytes
+	h[0] = h[0] ^ h[15]
+	h = h[:15]
+
+	// 15 bytes => 30 hex chars
+	hx := hex.EncodeToString(h)
+
+	// 00000000-0000-4000-b000-000000000000
+	return fmt.Sprintf("%s-%s-4%s-b%s-%s", hx[:8], hx[8:12], hx[12:15], hx[15:18], hx[18:])
 }

--- a/util/strings_test.go
+++ b/util/strings_test.go
@@ -6,6 +6,7 @@
 package util
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,4 +151,34 @@ func TestCompare(t *testing.T) {
 	assert.False(t, ComparePtrs(z, o))
 	assert.False(t, ComparePtrs(o, z))
 	assert.False(t, ComparePtrs(x, z))
+}
+
+func TestToUUID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", "b51e85a6-fc67-48f5-b83e-6e6dd3e13d01"},
+		{"test", "21399f9a-a347-4ff4-b94b-7286b575aada"},
+		{"example", "2b9a9ab7-92d6-48ce-bac9-a94603dc33ff"},
+	}
+
+	for _, test := range tests {
+		got := ToUUID(test.input)
+		assert.Equal(t, test.expected, got)
+	}
+}
+
+func TestToUUID_FormatCheck(t *testing.T) {
+	uuid := ToUUID("format-check")
+	matched, err := regexp.MatchString(`^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-b[a-f0-9]{3}-[a-f0-9]{12}$`, uuid)
+	assert.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestToUUID_ConsistencyCheck(t *testing.T) {
+	got := ToUUID("repeat-test")
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, got, ToUUID("repeat-test"))
+	}
 }


### PR DESCRIPTION
This PR changes how we handle Detection IDs. We now generate a deterministic UUID from their PublicIDs. This is to prevent sync from importing detections twice. To help with root cause analysis, there's a new piece of logging that happens when we scroll ElasticSearch returning 0 results. The entire response is written to the log so minor errors can be investigated, just grep the logs for `scrolled for 0 results`.