### PR TITLE
Factor in Ack/Escalate State When Fetching Newest

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2979,18 +2979,31 @@ const huntComponent = {
       let parts = [];
 
       for (let field in item) {
+        let label = field;
         if (field.startsWith('event_data.')) {
-          field = field.replace('event_data.', '');
+          label = field.replace('event_data.', '');
         }
 
-        if (field.toLowerCase() === 'count') continue;
+        if (label.toLowerCase() === 'count') continue;
 
-        if (item[field] && item[field].length > 0) {
-          parts.push(`${field}:"${item[field]}"`);
+        if (item[field] && !Array.isArray(item[field])) {
+          parts.push(`${label}:"${item[field]}"`);
         }
       }
 
-      const q = parts.join(' AND ') + `| sortby @timestamp`;
+      if (this.isFilterToggleEnabled('acknowledged')) {
+        parts.push('event.acknowledged:true');
+      } else {
+        parts.push('NOT event.acknowledged:true');
+      }
+
+      if (this.isFilterToggleEnabled('escalated')) {
+        parts.push('event.escalated:true');
+      } else {
+        parts.push('NOT event.escalated:true');
+      }
+
+      const q = parts.join(' AND ') + ` | sortby @timestamp`;
 
       let params = {
         query: q,

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -2082,3 +2082,67 @@ fields:
     - dns.response.code_name`
   );
 });
+
+test('fetchNewestEvent', async () => {
+  const eventSearch = mockPapi('get', { data: { events: [{ id: '100', payload: { a: 1, b: "2", c: true } }] } });
+  
+  comp.filterToggles = [
+    {
+      name: 'acknowledged',
+      enabled: false,
+    },
+    {
+      name: 'escalated',
+      enabled: false,
+    },
+  ];
+  comp.dateRange = 'x - y';
+  comp.zone = 'zone';
+
+  var item = {
+    a: 1,
+    b: "2",
+    'event_data.c': true,
+    count: 10,
+  };
+
+  await comp.fetchNewestEvent(item);
+
+  expect(item.newest.soc_id).toBe('100');
+  
+  expect(eventSearch).toHaveBeenCalledTimes(1);
+  expect(eventSearch).toHaveBeenCalledWith('events/', {
+    params: {
+      query: 'a:"1" AND b:"2" AND c:"true" AND NOT event.acknowledged:true AND NOT event.escalated:true | sortby @timestamp',
+      range: 'x - y',
+      format: comp.i18n.timePickerSample,
+      zone: 'zone',
+      eventLimit: 1,
+      metricLimit: 0,
+    }
+  });
+
+  comp.filterToggles[0].enabled = true;
+  comp.filterToggles[1].enabled = true;
+  delete item.newest;
+  resetPapi();
+  const eventSearch2 = mockPapi('get', { data: { events: [{ id: '100', payload: { a: 1, b: "2", c: true } }] } });
+
+  await comp.fetchNewestEvent(item);
+
+  expect(item.newest.soc_id).toBe('100');
+  
+  expect(eventSearch2).toHaveBeenCalledTimes(1);
+  expect(eventSearch2).toHaveBeenCalledWith('events/', {
+    params: {
+      query: 'a:"1" AND b:"2" AND c:"true" AND event.acknowledged:true AND event.escalated:true | sortby @timestamp',
+      range: 'x - y',
+      format: comp.i18n.timePickerSample,
+      zone: 'zone',
+      eventLimit: 1,
+      metricLimit: 0,
+    }
+  });
+
+  resetPapi();
+});


### PR DESCRIPTION
The Ack/Escalate toggles were being ignored when fetching the newest alert in a group. Now they're factored in. Tests added.