### PR TITLE
Cogburn/playbook bolt tightening

### DIFF
--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -130,7 +130,10 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 		folderName := repo.RulesetName
 
 		if folderName == "" {
-			parser, err := url.Parse(repo.Repo)
+			cleanedPath := repo.Repo
+			cleanedPath = strings.TrimRight(cleanedPath, string(os.PathSeparator))
+
+			parser, err := url.Parse(cleanedPath)
 			if err != nil {
 				log.WithError(err).WithField("repoUrl", repo.Repo).Error("Failed to parse repo URL, doing nothing with it")
 				continue

--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -363,7 +363,7 @@ func TestUpdateRepos(t *testing.T) {
 
 	repos := []*model.RuleRepo{
 		{
-			Repo:        "http://github.com/user/repo",
+			Repo:        "http://github.com/user/repo/",
 			RulesetName: "sigma-rules",
 		},
 		{
@@ -441,7 +441,7 @@ func TestUpdateReposAllowedRepoErrors(t *testing.T) {
 	}, nil)
 	iom.EXPECT().PullRepo(gomock.Any(), "baseRepoFolder/repo1", &branch).Return(true, false, false)
 	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo2", "http://github.com/user/repo2", nil).Return(transport.ErrEmptyRemoteRepository)
-	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo3", "file:///nsm/rules/repo3", nil).Return(transport.ErrRepositoryNotFound)
+	iom.EXPECT().CloneRepo(gomock.Any(), "baseRepoFolder/repo3", "file:///nsm/rules/repo3/", nil).Return(transport.ErrRepositoryNotFound)
 
 	isRunning := true
 
@@ -454,7 +454,7 @@ func TestUpdateReposAllowedRepoErrors(t *testing.T) {
 			Repo: "http://github.com/user/repo2",
 		},
 		{
-			Repo: "file:///nsm/rules/repo3",
+			Repo: "file:///nsm/rules/repo3/",
 		},
 	}
 

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -170,11 +170,18 @@ func (pdm *PlaybookDiskManager) scheduler() {
 			return
 		}
 
-		anythingNew, err := pdm.UpdateRepoOnDisk()
-		if err != nil {
-			logger.WithError(err).Error("unable to update playbook repo")
-			wasSuccessful = false
-			continue
+		var anythingNew bool
+
+		if pdm.autoUpdateEnabled {
+			var err error
+			anythingNew, err = pdm.UpdateRepoOnDisk()
+			if err != nil {
+				logger.WithError(err).Error("unable to update playbook repo")
+				wasSuccessful = false
+				continue
+			}
+		} else {
+			logger.Info("autoUpdateEnabled is disabled, skipping updating playbooks")
 		}
 
 		if !pdm.isRunning {
@@ -185,7 +192,7 @@ func (pdm *PlaybookDiskManager) scheduler() {
 		if anythingNew || force {
 			start := time.Now()
 
-			err = pdm.LoadPlaybooks(logger)
+			err := pdm.LoadPlaybooks(logger)
 			if err != nil {
 				logger.WithError(err).Error("unable to load playbooks")
 				wasSuccessful = false

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -504,6 +504,7 @@ func TestScheduler(t *testing.T) {
 	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
 		srv:                server.NewFakeAuthorizedServer(nil),
+		autoUpdateEnabled:  true,
 		playbookRepoPath:   "/tmp/playbooks",
 		playbookRepoUrl:    "https://github.com/playbooks/repo",
 		playbookRepoBranch: "dev",


### PR DESCRIPTION
Fix "blank folder" situation when assuming rulesetName in UpdateRepos.

Respect autoUpdateEnabled in playbook's config.