### PR TITLE
Generic categories

### DIFF
--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -397,9 +397,25 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 	forId := pdm.PlaybooksByDetectionId[publicId]
 	forCategory := []string{}
 
-	// First try exact match
+	// First try exact match, filtered by detection type for engine consistency
 	if matches := pdm.PlaybooksByCategory[detectCategory]; len(matches) > 0 {
-		forCategory = append(forCategory, matches...)
+		expectedType := ""
+		switch detectEngine {
+		case model.EngineNameSuricata:
+			expectedType = "nids"
+		case model.EngineNameElastAlert:
+			expectedType = "sigma"
+		case model.EngineNameStrelka:
+			expectedType = "strelka"
+		}
+
+		for _, playbookId := range matches {
+			playbookType, ok := pdm.playbookTypes[playbookId]
+			if !ok || playbookType == expectedType {
+				// Include playbooks with matching type or no type specified
+				forCategory = append(forCategory, playbookId)
+			}
+		}
 	}
 
 	// For NIDS engine, try matching base category without prefix

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -406,7 +406,7 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 		case model.EngineNameElastAlert:
 			expectedType = "sigma"
 		case model.EngineNameStrelka:
-			expectedType = "strelka"
+			expectedType = "yara"
 		}
 
 		for _, playbookId := range matches {

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -60,6 +60,7 @@ type PlaybookDiskManager struct {
 	PlaybooksByCategory    map[string][]string
 	PlaybooksByEngine      map[string][]string
 	playbooksOnDisk        map[string]string
+	playbookTypes          map[string]string // Maps playbook ID to detection type
 
 	detections.IOManager
 }
@@ -247,6 +248,7 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 	onDisk := make(map[string]string)
 	byCategory := make(map[string][]string)
 	byEngine := make(map[string][]string)
+	types := make(map[string]string)
 
 	repo, err := url.Parse(pdm.playbookRepoUrl)
 	if err != nil {
@@ -319,6 +321,10 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 		playbooks = append(playbooks, pb)
 		files++
 
+		if pb.DetectionType != "" {
+			types[id] = strings.ToLower(pb.DetectionType)
+		}
+
 		if pb.DetectionId != "" {
 			detId := strings.ToLower(pb.DetectionId)
 			byDetId[detId] = append(byDetId[detId], id)
@@ -367,6 +373,7 @@ func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Pl
 	pdm.PlaybooksByCategory = byCategory
 	pdm.PlaybooksByDetectionId = byDetId
 	pdm.playbooksOnDisk = onDisk
+	pdm.playbookTypes = types
 
 	pdm.pbUpdateMutex.Unlock()
 
@@ -403,7 +410,13 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 			// Last part is the base category (e.g. "SCAN")
 			baseCategory := strings.ToLower(parts[len(parts)-1])
 			if matches := pdm.PlaybooksByCategory[baseCategory]; len(matches) > 0 {
-				forCategory = append(forCategory, matches...)
+				// Filter matches to only include NIDS playbooks
+				for _, playbookId := range matches {
+					playbookType, ok := pdm.playbookTypes[playbookId]
+					if ok && playbookType == "nids" {
+						forCategory = append(forCategory, playbookId)
+					}
+				}
 			}
 		}
 	}

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -388,7 +388,25 @@ func (pdm *PlaybookDiskManager) GetPlaybooksForDetection(ctx context.Context, pu
 	defer pdm.pbUpdateMutex.RUnlock()
 
 	forId := pdm.PlaybooksByDetectionId[publicId]
-	forCategory := pdm.PlaybooksByCategory[detectCategory]
+	forCategory := []string{}
+
+	// First try exact match
+	if matches := pdm.PlaybooksByCategory[detectCategory]; len(matches) > 0 {
+		forCategory = append(forCategory, matches...)
+	}
+
+	// For NIDS engine, try matching base category without prefix
+	if detectEngine == model.EngineNameSuricata && detectCategory != "" {
+		// Split category into parts (e.g. "ET SCAN" -> ["ET", "SCAN"])
+		parts := strings.Fields(detectCategory)
+		if len(parts) > 1 {
+			// Last part is the base category (e.g. "SCAN")
+			baseCategory := strings.ToLower(parts[len(parts)-1])
+			if matches := pdm.PlaybooksByCategory[baseCategory]; len(matches) > 0 {
+				forCategory = append(forCategory, matches...)
+			}
+		}
+	}
 
 	results := append([]string{}, forId...)
 	results = append(results, forCategory...)

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -740,3 +740,77 @@ func TestReadPlaybooks(t *testing.T) {
 	assert.Equal(t, 1, len(pdm.playbooksOnDisk))
 	assert.Equal(t, "success", pdm.playbooksOnDisk["x"])
 }
+
+func TestGetPlaybooksForDetection_BaseCategoryMatching(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+
+	pdm := PlaybookDiskManager{
+		srv: server.NewFakeAuthorizedServer(nil),
+		PlaybooksByDetectionId: map[string][]string{},
+		PlaybooksByCategory: map[string][]string{
+			"scan": {"scan-playbook", "sigma-scan-playbook"},
+			"et scan": {"et-scan-playbook"},
+			"sql": {"sql-playbook"},
+		},
+		PlaybooksByEngine: map[string][]string{},
+		playbooksOnDisk: map[string]string{
+			"scan-playbook": "/path/scan",
+			"sigma-scan-playbook": "/path/sigma-scan",
+			"et-scan-playbook": "/path/et-scan",
+			"sql-playbook": "/path/sql",
+		},
+		playbookTypes: map[string]string{
+			"scan-playbook": "nids",
+			"sigma-scan-playbook": "sigma",
+			"et-scan-playbook": "nids",
+			"sql-playbook": "nids",
+		},
+		IOManager: iom,
+	}
+
+	ctx := context.Background()
+
+	// Set up expectations for all possible file reads
+	iom.EXPECT().ReadFile("/path/et-scan").Return([]byte("id: et-scan-playbook"), nil).AnyTimes()
+	iom.EXPECT().ReadFile("/path/scan").Return([]byte("id: scan-playbook"), nil).AnyTimes()
+	iom.EXPECT().ReadFile("/path/sigma-scan").Return([]byte("id: sigma-scan-playbook"), nil).AnyTimes()
+	iom.EXPECT().ReadFile("/path/sql").Return([]byte("id: sql-playbook"), nil).AnyTimes()
+
+	// Test case 1: NIDS engine with "ET SCAN" category should match both "et scan" and NIDS "scan" (but not Sigma "scan")
+	playbooks, err := pdm.GetPlaybooksForDetection(ctx, "", "ET SCAN", model.EngineNameSuricata)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(playbooks))
+	assert.Equal(t, "et-scan-playbook", playbooks[0].Id)
+	assert.Equal(t, "scan-playbook", playbooks[1].Id)
+
+	// Test case 2: NIDS engine with "GPL SQL" category should match "sql"
+	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "GPL SQL", model.EngineNameSuricata)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(playbooks))
+	assert.Equal(t, "sql-playbook", playbooks[0].Id)
+
+	// Test case 3: Non-NIDS engine should not do base category matching (but still does exact match)
+	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "ET SCAN", model.EngineNameElastAlert)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(playbooks))
+	assert.Equal(t, "et-scan-playbook", playbooks[0].Id)
+
+	// Test case 4: Single word category should not do base category matching
+	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "scan", model.EngineNameSuricata)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(playbooks))
+	// Should get both NIDS and Sigma playbooks for exact match
+	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "scan-playbook")
+	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "sigma-scan-playbook")
+
+	// Test case 5: Verify Sigma detection gets the Sigma playbook for "scan" category
+	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "scan", model.EngineNameElastAlert)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(playbooks))
+	// Should get both playbooks since this is an exact match
+	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "scan-playbook")
+	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "sigma-scan-playbook")
+}

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -754,6 +754,7 @@ func TestGetPlaybooksForDetection_BaseCategoryMatching(t *testing.T) {
 			"scan": {"scan-playbook", "sigma-scan-playbook"},
 			"et scan": {"et-scan-playbook"},
 			"sql": {"sql-playbook"},
+			"generic": {"generic-playbook"},
 		},
 		PlaybooksByEngine: map[string][]string{},
 		playbooksOnDisk: map[string]string{
@@ -761,12 +762,14 @@ func TestGetPlaybooksForDetection_BaseCategoryMatching(t *testing.T) {
 			"sigma-scan-playbook": "/path/sigma-scan",
 			"et-scan-playbook": "/path/et-scan",
 			"sql-playbook": "/path/sql",
+			"generic-playbook": "/path/generic",
 		},
 		playbookTypes: map[string]string{
 			"scan-playbook": "nids",
 			"sigma-scan-playbook": "sigma",
 			"et-scan-playbook": "nids",
 			"sql-playbook": "nids",
+			// generic-playbook has no type - should match any engine
 		},
 		IOManager: iom,
 	}
@@ -778,6 +781,7 @@ func TestGetPlaybooksForDetection_BaseCategoryMatching(t *testing.T) {
 	iom.EXPECT().ReadFile("/path/scan").Return([]byte("id: scan-playbook"), nil).AnyTimes()
 	iom.EXPECT().ReadFile("/path/sigma-scan").Return([]byte("id: sigma-scan-playbook"), nil).AnyTimes()
 	iom.EXPECT().ReadFile("/path/sql").Return([]byte("id: sql-playbook"), nil).AnyTimes()
+	iom.EXPECT().ReadFile("/path/generic").Return([]byte("id: generic-playbook"), nil).AnyTimes()
 
 	// Test case 1: NIDS engine with "ET SCAN" category should match both "et scan" and NIDS "scan" (but not Sigma "scan")
 	playbooks, err := pdm.GetPlaybooksForDetection(ctx, "", "ET SCAN", model.EngineNameSuricata)
@@ -792,25 +796,31 @@ func TestGetPlaybooksForDetection_BaseCategoryMatching(t *testing.T) {
 	assert.Equal(t, 1, len(playbooks))
 	assert.Equal(t, "sql-playbook", playbooks[0].Id)
 
-	// Test case 3: Non-NIDS engine should not do base category matching (but still does exact match)
+	// Test case 3: Non-NIDS engine should not do base category matching and should filter exact matches by type
 	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "ET SCAN", model.EngineNameElastAlert)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(playbooks))
-	assert.Equal(t, "et-scan-playbook", playbooks[0].Id)
+	assert.Equal(t, 0, len(playbooks)) // No matches since et-scan-playbook is NIDS type
 
-	// Test case 4: Single word category should not do base category matching
+	// Test case 4: Single word category with exact match should only return NIDS playbook for NIDS engine
 	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "scan", model.EngineNameSuricata)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(playbooks))
-	// Should get both NIDS and Sigma playbooks for exact match
-	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "scan-playbook")
-	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "sigma-scan-playbook")
+	assert.Equal(t, 1, len(playbooks))
+	assert.Equal(t, "scan-playbook", playbooks[0].Id)
 
-	// Test case 5: Verify Sigma detection gets the Sigma playbook for "scan" category
+	// Test case 5: Verify Sigma detection gets only the Sigma playbook for "scan" category
 	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "scan", model.EngineNameElastAlert)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(playbooks))
-	// Should get both playbooks since this is an exact match
-	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "scan-playbook")
-	assert.Contains(t, []string{playbooks[0].Id, playbooks[1].Id}, "sigma-scan-playbook")
+	assert.Equal(t, 1, len(playbooks))
+	assert.Equal(t, "sigma-scan-playbook", playbooks[0].Id)
+
+	// Test case 6: Verify playbooks without detection_type are included for any engine (backward compatibility)
+	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "generic", model.EngineNameSuricata)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(playbooks))
+	assert.Equal(t, "generic-playbook", playbooks[0].Id)
+
+	playbooks, err = pdm.GetPlaybooksForDetection(ctx, "", "generic", model.EngineNameElastAlert)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(playbooks))
+	assert.Equal(t, "generic-playbook", playbooks[0].Id)
 }


### PR DESCRIPTION
Match a NIDS rule base category - for example:

A NIDS Playbook with the `SQL` category would match:
- `GPL SQL`
- `ET SQL`
- `ETPRO SQL`