### PR TITLE
No Line Wrap Except Last Column

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1030,13 +1030,17 @@ ul ul ul {
   cursor: default;
   border: 1px solid rgba(var(--v-theme-text), 0.12);
   padding: 10px;
-  max-width: 20vw;
   white-space: normal;
-  word-break: break-word;
 }
 
 .simple-table td {
   font-weight: bolder;
+  white-space: nowrap;
+}
+
+.simple-table td:last-child {
+  white-space: normal !important;
+  word-break: break-all;
 }
 
 .cursor-pointer {


### PR DESCRIPTION
In instant insights, every cell now has CSS to prevent line wrapping EXCEPT the last column. The last column will grow to use up all table space before attempting to wrap it's contents.