### PR TITLE
Playbook: Expand/Collapse All Questions

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1051,8 +1051,3 @@ ul ul ul {
   font-weight: unset !important;
   font-style: unset !important;
 }
-
-.playbook-toolbar {
-  min-height: 40px;
-  background-color: rgb(var(--v-theme-background-lighten-1)) !important;
-}

--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1051,3 +1051,8 @@ ul ul ul {
   font-weight: unset !important;
   font-style: unset !important;
 }
+
+.playbook-toolbar {
+  min-height: 40px;
+  background-color: rgb(var(--v-theme-background-lighten-1)) !important;
+}

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -746,6 +746,7 @@ const i18n = {
       pcapRetentionAbbr: 'PCAP Avail',
       pending: 'Pending',
       pendingDeletion: '(pending deletion)',
+      playbookFetchErr: 'Error fetching playbooks',
       playbooks: 'Playbooks',
       playbooksPivot: 'Pivot to Playbooks in Alerts',
       premiumSupport: 'Premium Support',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -175,6 +175,7 @@ const huntComponent = {
     activeTabs: {},
     expandedEvents: [],
     eventColumnWidth: 0,
+    expandedPlaybookQuestions: {},
   }},
   created() {
     this.$root.initializeCharts();
@@ -3075,6 +3076,20 @@ const huntComponent = {
       // }
 
       return '';
+    },
+    toggleAllQuestions(playbooks, index, expand) {
+      let count = 0;
+      if (!Array.isArray(this.expandedPlaybookQuestions[index]) || !expand) this.expandedPlaybookQuestions[index] = [];
+      if (expand) {
+        for (let pb of playbooks) {
+          for (const _ of pb.questions) {
+            if (!this.expandedPlaybookQuestions[index].includes(count)) {
+              this.expandedPlaybookQuestions[index].push(count);
+            }
+            count++;
+          }
+        }
+      }
     },
   }
 };

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -385,6 +385,7 @@ const huntComponent = {
       this.selectAllState = false;
       this.selectAllIndeterminate = false;
       this.selectedCount = 0;
+      this.expandedPlaybookQuestions = {};
 
       var onSuccess = () => {};
       var onFail = () => {
@@ -2758,25 +2759,36 @@ const huntComponent = {
       const publicId = event?.['rule.uuid'];
       if (!publicId) return;
 
-      const response = await this.$root.papi.get(`playbook/detection/${publicId}`);
+      let playbooks;
+      let pbErr = false;
 
-      const playbooks = response.data;
+      try {
+        const response = await this.$root.papi.get(`playbook/detection/${publicId}`);
 
-      this.queryVariableSubstitution(event, playbooks);
+        playbooks = response.data;
+      } catch (e) {
+        pbErr = true;
+        playbooks = null;
+      }
 
-      await this.convertPlaybookQueries(playbooks);
+      if (playbooks) {
+        this.queryVariableSubstitution(event, playbooks);
+        await this.convertPlaybookQueries(playbooks);
+      }
 
       event.playbooks = playbooks;
+      event.playbookErr = pbErr;
       delete event.playbookLoading;
 
-      for (let pb of event.playbooks) {
-        for (let q of pb.questions) {
-          await this.$nextTick();
-          await this.askQuestion(q, event);
+      if (playbooks) {
+        for (let pb of event.playbooks) {
+          for (let q of pb.questions) {
+            await this.$nextTick();
+            await this.askQuestion(q, event);
+          }
         }
       }
     },
-
     queryVariableSubstitution(event, playbooks) {
       // Fields that require special array handling
       const arrayFields = ['network.private_ip', 'network.public_ip', 'related.ip'];
@@ -3077,16 +3089,29 @@ const huntComponent = {
 
       return '';
     },
-    toggleAllQuestions(playbooks, index, expand) {
-      let count = 0;
-      if (!Array.isArray(this.expandedPlaybookQuestions[index]) || !expand) this.expandedPlaybookQuestions[index] = [];
-      if (expand) {
-        for (let pb of playbooks) {
-          for (const _ of pb.questions) {
-            if (!this.expandedPlaybookQuestions[index].includes(count)) {
-              this.expandedPlaybookQuestions[index].push(count);
+    toggleAllQuestions(event, index, expand) {
+      if (event.playbookErr) return;
+
+      event = (event || {}).newest || event;
+
+      if (event.playbookLoading || !('playbooks' in event)) {
+        setTimeout(() => {
+          this.toggleAllQuestions(event, index, expand);
+        }, 100)
+        return;
+      }
+
+      if (event.playbooks) {
+        let count = 0;
+        if (!Array.isArray(this.expandedPlaybookQuestions[index]) || !expand) this.expandedPlaybookQuestions[index] = [];
+        if (expand) {
+          for (let i = 0; i < event.playbooks.length; i++) {
+            for (let j = 0; j < event.playbooks[i].questions.length; j++) {
+              if (!this.expandedPlaybookQuestions[index].includes(count)) {
+                this.expandedPlaybookQuestions[index].push(count);
+              }
+              count++;
             }
-            count++;
           }
         }
       }

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -2172,3 +2172,107 @@ test('isComplexQuery', () => {
   expect(comp.isComplexQuery('foo:bar AND cat:(dog OR fish)')).toBe(true);
   expect(comp.isComplexQuery('foo:bar AND ((cat:(dog OR fish) OR some:thing))')).toBe(true);
 });
+
+test('toggleAllQuestions', () => {
+  let event = {
+    playbooks: [
+      {
+        questions: [{}, {}, {}],
+      },
+      {
+        questions: [{}],
+      },
+      {
+        questions: [{}, {}],
+      },
+    ],
+  };
+  let index = 0;
+  let expand = true;
+  comp.expandedPlaybookQuestions = {};
+
+  // expand
+  comp.toggleAllQuestions(event, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2, 3, 4, 5] });
+
+  // expand a different index
+  index = 1;
+  comp.toggleAllQuestions(event, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2, 3, 4, 5], 1: [0, 1, 2, 3, 4, 5] });
+
+  // collapse non-existing index
+  index = 2;
+  expand = false;
+  comp.toggleAllQuestions(event, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2, 3, 4, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+
+  // collapse existing, expanded index
+  index = 0;
+  comp.toggleAllQuestions(event, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+
+  // expand existing, partially expanded
+  comp.expandedPlaybookQuestions[0] = [2, 4];
+  expand = true;
+  comp.toggleAllQuestions(event, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+
+  // no changes when expanding an already expanded group, even if out of order
+  comp.toggleAllQuestions(event, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+
+  // no change when collapsing an already collapsed group
+  index = 2;
+  expand = false;
+  comp.toggleAllQuestions(event, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+
+  // handle aggregate event
+  let aggEvent = {
+    newest: event,
+  };
+
+  expand = true;
+  comp.toggleAllQuestions(aggEvent, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+
+  // handle event that doesn't have playbooks yet
+  const _setTimeout = global.setTimeout;
+  const setTimeoutMock = jest.fn();
+  global.setTimeout = setTimeoutMock;
+
+  let emptyEvent = {};
+  index = 0;
+  expand = true;
+
+  comp.toggleAllQuestions(emptyEvent, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(setTimeoutMock).toHaveBeenCalledTimes(1);
+
+  // handle agg event that doesn't have playbooks yet
+  aggEvent.newest = emptyEvent;
+  setTimeoutMock.mockClear();
+  
+  comp.toggleAllQuestions(aggEvent, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(setTimeoutMock).toHaveBeenCalledTimes(1);
+  
+  // handle event that's loading playbooks
+  emptyEvent.playbookLoading = true;
+  emptyEvent.playbooks = null;
+  setTimeoutMock.mockClear();
+  
+  comp.toggleAllQuestions(emptyEvent, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(setTimeoutMock).toHaveBeenCalledTimes(1);
+
+  // handle agg event that's loading playbooks
+  aggEvent.newest = emptyEvent;
+  setTimeoutMock.mockClear();
+  
+  comp.toggleAllQuestions(aggEvent, index, expand);
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(setTimeoutMock).toHaveBeenCalledTimes(1);
+
+  global.setTimeout = _setTimeout;
+});

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -335,13 +335,21 @@
 													<td :colspan="columns.length" class="px-0" :data-aid="'events_fields_' + category">
 														<div>
 															<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[index]" @update:model-value="if (activeTabs[index] === 'playbook') loadPlaybook(item.newest);">
-																<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[index] === 'alert' }" :style="{ 'width': (eventColumnWidth * 0.5) + 'px' }">
+																<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[index] === 'alert' }" :style="{ 'width': (eventColumnWidth * 0.5 - 28) + 'px' }" data-aid="alerts_agg_alertDetailsTab">
 																	<v-icon class="tab-icon">fa-bell</v-icon>
 																	<div class="d-none d-lg-block">{{i18n.alertDetails}}</div>
 																</v-tab>
-																<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[index] === 'playbook' }" :style="{ 'width': (eventColumnWidth * 0.5) + 'px' }">
+																<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[index] === 'playbook' }" :style="{ 'width': (eventColumnWidth * 0.5 - 28) + 'px' }" data-aid="alerts_agg_playbookTab">
 																	<v-icon class="tab-icon">fa-book</v-icon>
 																	<div class="d-none d-lg-block">{{i18n.guidedAnalysis}}</div>
+																	<template #append>
+																		<v-btn class="ml-9" variant="text" size="small" icon @click="toggleAllQuestions(item, index, false)" aria-label="collapse all" data-aid="alerts_agg_playbooks_collapseAll">
+																			<v-icon>fa-window-minimize</v-icon>
+																		</v-btn>
+																		<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item, index, true)" aria-label="expand all" data-aid="alerts_agg_playbooks_expandAll">
+																			<v-icon>fa-window-maximize</v-icon>
+																		</v-btn>
+																	</template>
 																</v-tab>
 															</v-tabs>
 															<v-tabs-window v-model="activeTabs[index]">
@@ -369,16 +377,6 @@
 																</v-tabs-window-item>
 																<v-tabs-window-item value="playbook">
 																	<template v-if="item.newest.playbooks">
-																		<div class="playbook-toolbar">
-																			<span class="ml-9">
-																				<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item.newest.playbooks, index, false)">
-																					<v-icon>fa-window-minimize</v-icon>
-																				</v-btn>
-																				<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item.newest.playbooks, index, true)">
-																					<v-icon>fa-window-maximize</v-icon>
-																				</v-btn>
-																			</span>
-																		</div>
 																		<v-expansion-panels @update:model-value="expandedPlaybookQuestions[index] = $event" :model-value="expandedPlaybookQuestions[index]" variant="accordion" multiple static="true">
 																			<template v-for="playbook in item.newest.playbooks">
 																				<v-expansion-panel v-for="question in playbook.questions">
@@ -470,6 +468,11 @@
 																				</v-expansion-panel>
 																			</template>
 																		</v-expansion-panels>
+																	</template>
+																	<template v-else-if="item.newest.playbookErr">
+																		<span class="my-6 inline" :style="{ 'margin-left': (this.eventColumnWidth / 2 - 75) + 'px' }">
+																			{{i18n.playbookFetchErr}}
+																		</span>
 																	</template>
 																	<template v-else>
 																		<v-progress-circular indeterminate :size="50" color="primary" class="my-6" :style="{ 'margin-left': (this.eventColumnWidth / 2 - 25) + 'px'}" data-aid="playbook_grouped_loading_circle"></v-progress-circular>
@@ -634,13 +637,21 @@
 										<td :colspan="columns.length" class="px-0" :data-aid="'events_fields_' + category">
 											<div>
 												<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[index]" @update:model-value="if (activeTabs[index] === 'playbook') loadPlaybook(item);">
-													<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[index] === 'alert' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }">
+													<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[index] === 'alert' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }" data-aid="alerts_alertDetailsTab">
 														<v-icon class="tab-icon">fa-bell</v-icon>
 														<div class="d-none d-lg-block">{{i18n.alertDetails}}</div>
 													</v-tab>
-													<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[index] === 'playbook' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }">
+													<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[index] === 'playbook' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }" data-aid="alerts_playbookTab">
 														<v-icon class="tab-icon">fa-book</v-icon>
 														<div class="d-none d-lg-block">{{i18n.guidedAnalysis}}</div>
+														<template #append>
+															<v-btn class="ml-9" variant="text" size="small" icon @click="toggleAllQuestions(item, index, false)" aria-label="collapse all" data-aid="alerts_playbooks_collapseAll">
+																<v-icon>fa-window-minimize</v-icon>
+															</v-btn>
+															<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item, index, true)" aria-label="expand all" data-aid="alerts_playbooks_expandAll">
+																<v-icon>fa-window-maximize</v-icon>
+															</v-btn>
+														</template>
 													</v-tab>
 												</v-tabs>
 												<v-tabs-window v-model="activeTabs[index]">
@@ -668,7 +679,7 @@
 													</v-tabs-window-item>
 													<v-tabs-window-item value="playbook">
 														<template v-if="item.playbooks">
-															<v-expansion-panels variant="accordion" multiple static="true">
+															<v-expansion-panels @update:model-value="expandedPlaybookQuestions[index] = $event" :model-value="expandedPlaybookQuestions[index]" variant="accordion" multiple static="true">
 																<template v-for="playbook in item.playbooks">
 																	<v-expansion-panel v-for="question in playbook.questions">
 																		<v-expansion-panel-title class="italic ws-normal spacious-lines" #default="{ expanded }">
@@ -759,6 +770,11 @@
 																	</v-expansion-panel>
 																</template>
 															</v-expansion-panels>
+														</template>
+														<template v-else-if="item.playbookErr">
+															<span class="my-6 inline" :style="{ 'margin-left': (this.eventColumnWidth / 2 - 75) + 'px' }">
+																{{i18n.playbookFetchErr}}
+															</span>
 														</template>
 														<template v-else>
 															<v-progress-circular indeterminate :size="50" color="primary" class="my-6" :style="{ 'margin-left': (this.eventColumnWidth / 2 - 25) + 'px' }" data-aid="playbook_loading_circle"></v-progress-circular>

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -369,7 +369,17 @@
 																</v-tabs-window-item>
 																<v-tabs-window-item value="playbook">
 																	<template v-if="item.newest.playbooks">
-																		<v-expansion-panels variant="accordion" multiple static="true">
+																		<div class="playbook-toolbar">
+																			<span class="ml-9">
+																				<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item.newest.playbooks, index, false)">
+																					<v-icon>fa-window-minimize</v-icon>
+																				</v-btn>
+																				<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item.newest.playbooks, index, true)">
+																					<v-icon>fa-window-maximize</v-icon>
+																				</v-btn>
+																			</span>
+																		</div>
+																		<v-expansion-panels @update:model-value="expandedPlaybookQuestions[index] = $event" :model-value="expandedPlaybookQuestions[index]" variant="accordion" multiple static="true">
 																			<template v-for="playbook in item.newest.playbooks">
 																				<v-expansion-panel v-for="question in playbook.questions">
 																					<v-expansion-panel-title class="italic ws-normal spacious-lines" #default="{ expanded }">


### PR DESCRIPTION
Show an error output when playbooks can't be fetched.

Clicking on an expand or collapse button before the playbook is fetched will fetch the playbook and then properly expand or collapse.

Collapse/Expand All buttons added to Guided Analysis tab.

Added some missing data-aid and aria-labels to some of the new additions.

Tests.
