### PR TITLE
Zero Width Space Before Header

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -696,6 +696,10 @@ td {
   margin-top: 16px;
 }
 
+.ops-header::before {
+  content: "\200b";
+}
+
 .ops-value::after {
   content: "\00a0";
 }


### PR DESCRIPTION
Adding a zero-width space before header values helps manage double-click highlight behavior in browsers.