### PR TITLE
Playbook Repos

### DIFF
--- a/model/repo.go
+++ b/model/repo.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 )
 
-type RuleRepo struct {
-	Repo        string
+type Repo struct {
+	RepoUrl     string `json:"repo"`
 	Branch      *string
 	License     string
 	Folder      *string
@@ -19,7 +19,7 @@ type RuleRepo struct {
 	RulesetName string
 }
 
-func GetReposDefault(cfg map[string]interface{}, field string, dflt []*RuleRepo) ([]*RuleRepo, error) {
+func GetReposDefault(cfg map[string]interface{}, field string, licenseRequired bool, dflt []*Repo) ([]*Repo, error) {
 	cfgInter, ok := cfg[field]
 	if !ok {
 		// config doesn't have any rulesRepos, no error, return defaults
@@ -31,7 +31,7 @@ func GetReposDefault(cfg map[string]interface{}, field string, dflt []*RuleRepo)
 		return nil, fmt.Errorf(`top level config value "%s" is not an array of objects`, field)
 	}
 
-	repos := make([]*RuleRepo, 0, len(repoMaps))
+	repos := make([]*Repo, 0, len(repoMaps))
 
 	for _, repoMap := range repoMaps {
 		obj, ok := repoMap.(map[string]interface{})
@@ -45,7 +45,7 @@ func GetReposDefault(cfg map[string]interface{}, field string, dflt []*RuleRepo)
 		}
 
 		license, ok := obj["license"].(string)
-		if !ok {
+		if !ok && licenseRequired {
 			return nil, fmt.Errorf(`missing "license" from "%s" entry`, field)
 		}
 
@@ -67,8 +67,8 @@ func GetReposDefault(cfg map[string]interface{}, field string, dflt []*RuleRepo)
 
 		rulesetName, _ := obj["rulesetName"].(string)
 
-		r := &RuleRepo{
-			Repo:        repo,
+		r := &Repo{
+			RepoUrl:     repo,
 			License:     license,
 			Community:   isCommunity,
 			RulesetName: rulesetName,

--- a/model/repo_test.go
+++ b/model/repo_test.go
@@ -16,9 +16,9 @@ import (
 func TestGetRepos(t *testing.T) {
 	t.Parallel()
 
-	dflt := []*RuleRepo{
+	dflt := []*Repo{
 		{
-			Repo:    "https://github.com/Security-Onion-Solutions/securityonion-resources",
+			RepoUrl: "https://github.com/Security-Onion-Solutions/securityonion-resources",
 			License: "DRL",
 		},
 	}
@@ -26,7 +26,7 @@ func TestGetRepos(t *testing.T) {
 	table := []struct {
 		Name     string
 		Config   map[string]interface{}
-		Expected []*RuleRepo
+		Expected []*Repo
 		Error    *string
 	}{
 		{
@@ -56,24 +56,24 @@ func TestGetRepos(t *testing.T) {
 					},
 				},
 			},
-			Expected: []*RuleRepo{
+			Expected: []*Repo{
 				{
-					Repo:      "repo1",
+					RepoUrl:   "repo1",
 					License:   "MIT",
 					Community: true,
 				},
 				{
-					Repo:    "repo2",
+					RepoUrl: "repo2",
 					License: "GPL2",
 					Folder:  util.Ptr("sigma/stable"),
 				},
 				{
-					Repo:      "repo3",
+					RepoUrl:   "repo3",
 					License:   "DRL",
 					Community: true,
 				},
 				{
-					Repo:    "repo4",
+					RepoUrl: "repo4",
 					License: "DRL",
 				},
 			},
@@ -128,7 +128,7 @@ func TestGetRepos(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			repos, err := GetReposDefault(test.Config, "rulesRepos", dflt)
+			repos, err := GetReposDefault(test.Config, "rulesRepos", true, dflt)
 			if test.Error == nil {
 				assert.NoError(t, err)
 			} else {

--- a/server/modules/detections/ai_summary.go
+++ b/server/modules/detections/ai_summary.go
@@ -86,10 +86,10 @@ func updateAiRepo(isRunning *bool, baseRepoFolder string, repoUrl string, branch
 		branchPtr = &branch
 	}
 
-	_, _, err := UpdateRepos(isRunning, baseRepoFolder, []*model.RuleRepo{
+	_, _, err := UpdateRepos(isRunning, baseRepoFolder, []*model.Repo{
 		{
-			Repo:   repoUrl,
-			Branch: branchPtr,
+			RepoUrl: repoUrl,
+			Branch:  branchPtr,
 		},
 	}, iom)
 

--- a/server/modules/detections/detengine_helpers.go
+++ b/server/modules/detections/detengine_helpers.go
@@ -95,13 +95,13 @@ func WriteStateFile(iom IOManager, path string) {
 }
 
 type RepoOnDisk struct {
-	Repo        *model.RuleRepo
+	Repo        *model.Repo
 	Path        string
 	RulesetName string
 	WasModified bool
 }
 
-func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.RuleRepo, iom IOManager) (allRepos []*RepoOnDisk, anythingNew bool, err error) {
+func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Repo, iom IOManager) (allRepos []*RepoOnDisk, anythingNew bool, err error) {
 	allRepos = make([]*RepoOnDisk, 0, len(rulesRepos))
 
 	// read existing repos
@@ -130,12 +130,12 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 		folderName := repo.RulesetName
 
 		if folderName == "" {
-			cleanedPath := repo.Repo
+			cleanedPath := repo.RepoUrl
 			cleanedPath = strings.TrimRight(cleanedPath, string(os.PathSeparator))
 
 			parser, err := url.Parse(cleanedPath)
 			if err != nil {
-				log.WithError(err).WithField("repoUrl", repo.Repo).Error("Failed to parse repo URL, doing nothing with it")
+				log.WithError(err).WithField("repoUrl", repo.RepoUrl).Error("Failed to parse repo URL, doing nothing with it")
 				continue
 			}
 
@@ -189,7 +189,7 @@ func UpdateRepos(isRunning *bool, baseRepoFolder string, rulesRepos []*model.Rul
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
 
-			err = iom.CloneRepo(ctx, repoPath, repo.Repo, repo.Branch)
+			err = iom.CloneRepo(ctx, repoPath, repo.RepoUrl, repo.Branch)
 			if err != nil {
 				if errors.Is(err, transport.ErrRepositoryNotFound) {
 					log.WithField("repoPath", repoPath).Warn("repo not found, skipping")

--- a/server/modules/detections/detengine_helpers_test.go
+++ b/server/modules/detections/detengine_helpers_test.go
@@ -361,14 +361,14 @@ func TestUpdateRepos(t *testing.T) {
 
 	isRunning := true
 
-	repos := []*model.RuleRepo{
+	repos := []*model.Repo{
 		{
-			Repo:        "http://github.com/user/repo/",
+			RepoUrl:     "http://github.com/user/repo/",
 			RulesetName: "sigma-rules",
 		},
 		{
-			Repo:   "http://github.com/user/repo",
-			Branch: &branch,
+			RepoUrl: "http://github.com/user/repo",
+			Branch:  &branch,
 		},
 	}
 
@@ -410,13 +410,13 @@ func TestUpdateReposFailToClone(t *testing.T) {
 
 	isRunning := true
 
-	repos := []*model.RuleRepo{
+	repos := []*model.Repo{
 		{
-			Repo:   "http://github.com/user/repo2",
-			Branch: &branch,
+			RepoUrl: "http://github.com/user/repo2",
+			Branch:  &branch,
 		},
 		{
-			Repo: "http://github.com/user/repo1",
+			RepoUrl: "http://github.com/user/repo1",
 		},
 	}
 
@@ -445,16 +445,16 @@ func TestUpdateReposAllowedRepoErrors(t *testing.T) {
 
 	isRunning := true
 
-	repos := []*model.RuleRepo{
+	repos := []*model.Repo{
 		{
-			Repo:   "http://github.com/user/repo1",
-			Branch: &branch,
+			RepoUrl: "http://github.com/user/repo1",
+			Branch:  &branch,
 		},
 		{
-			Repo: "http://github.com/user/repo2",
+			RepoUrl: "http://github.com/user/repo2",
 		},
 		{
-			Repo: "file:///nsm/rules/repo3/",
+			RepoUrl: "file:///nsm/rules/repo3/",
 		},
 	}
 
@@ -490,13 +490,13 @@ func TestUpdateReposRepoRemoteGoneError(t *testing.T) {
 
 	isRunning := true
 
-	repos := []*model.RuleRepo{
+	repos := []*model.Repo{
 		{
-			Repo:   "http://github.com/user/repo1",
-			Branch: &branch,
+			RepoUrl: "http://github.com/user/repo1",
+			Branch:  &branch,
 		},
 		{
-			Repo: "http://github.com/user/repo2",
+			RepoUrl: "http://github.com/user/repo2",
 		},
 	}
 

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -80,9 +80,9 @@ type RuleCriteria struct {
 }
 
 var ( // treat as constant
-	DEFAULT_RULES_REPOS = []*model.RuleRepo{
+	DEFAULT_RULES_REPOS = []*model.Repo{
 		{
-			Repo:    "https://github.com/Security-Onion-Solutions/securityonion-resources",
+			RepoUrl: "https://github.com/Security-Onion-Solutions/securityonion-resources",
 			License: "DRL",
 			Folder:  util.Ptr("sigma/stable"),
 		},
@@ -119,7 +119,7 @@ type ElastAlertEngine struct {
 	highSeverityAlerterParams          string
 	criticalSeverityAlerters           []string
 	criticalSeverityAlerterParams      string
-	rulesRepos                         []*model.RuleRepo
+	rulesRepos                         []*model.Repo
 	reposFolder                        string
 	isRunning                          bool
 	interm                             sync.Mutex
@@ -294,7 +294,7 @@ func (e *ElastAlertEngine) Init(config module.ModuleConfig) (err error) {
 	e.parseSigmaPackages(pkgs)
 
 	e.reposFolder = module.GetStringDefault(config, "reposFolder", DEFAULT_REPOS_FOLDER)
-	e.rulesRepos, err = model.GetReposDefault(config, "rulesRepos", DEFAULT_RULES_REPOS)
+	e.rulesRepos, err = model.GetReposDefault(config, "rulesRepos", true, DEFAULT_RULES_REPOS)
 	if err != nil {
 		return fmt.Errorf("unable to parse ElastAlert's rulesRepos: %w", err)
 	}
@@ -1029,11 +1029,11 @@ func (e *ElastAlertEngine) parseRepoRules(allRepos []*detections.RepoOnDisk) (de
 
 		ruleset := repo.RulesetName
 		if ruleset == "" {
-			parser, err := url.Parse(repo.Repo.Repo)
+			parser, err := url.Parse(repo.Repo.RepoUrl)
 			if err == nil {
 				_, ruleset = path.Split(parser.Path)
 			} else {
-				ruleset = repo.Repo.Repo
+				ruleset = repo.Repo.RepoUrl
 			}
 		}
 

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -1057,8 +1057,8 @@ license: Elastic-2.0
 
 	repos := []*detections.RepoOnDisk{
 		{
-			Repo: &model.RuleRepo{
-				Repo:      "github.com/repo-user/repo-path",
+			Repo: &model.Repo{
+				RepoUrl:   "github.com/repo-user/repo-path",
 				License:   "DRL",
 				Community: true,
 			},
@@ -1554,9 +1554,9 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 		reposFolder:                   "repos",
 		rulesFingerprintFile:          "rulesFingerprintFile",
 		elastAlertRulesFolder:         "elastAlertRulesFolder",
-		rulesRepos: []*model.RuleRepo{
+		rulesRepos: []*model.Repo{
 			{
-				Repo:      "https://github.com/user/repo",
+				RepoUrl:   "https://github.com/user/repo",
 				Community: true,
 			},
 		},
@@ -1680,9 +1680,9 @@ func TestSyncChanges(t *testing.T) {
 		reposFolder:                   "repos",
 		rulesFingerprintFile:          "rulesFingerprintFile",
 		elastAlertRulesFolder:         "elastAlertRulesFolder",
-		rulesRepos: []*model.RuleRepo{
+		rulesRepos: []*model.Repo{
 			{
-				Repo:      "https://github.com/user/repo",
+				RepoUrl:   "https://github.com/user/repo",
 				Community: true,
 			},
 		},
@@ -1888,9 +1888,9 @@ func TestSyncUnchangedOverrides(t *testing.T) {
 		reposFolder:                   "repos",
 		rulesFingerprintFile:          "rulesFingerprintFile",
 		elastAlertRulesFolder:         "elastAlertRulesFolder",
-		rulesRepos: []*model.RuleRepo{
+		rulesRepos: []*model.Repo{
 			{
-				Repo:      "https://github.com/user/repo",
+				RepoUrl:   "https://github.com/user/repo",
 				Community: true,
 			},
 		},
@@ -2036,9 +2036,9 @@ func TestSyncStateFileNoCommunity(t *testing.T) {
 		reposFolder:                   "repos",
 		rulesFingerprintFile:          "rulesFingerprintFile",
 		elastAlertRulesFolder:         "elastAlertRulesFolder",
-		rulesRepos: []*model.RuleRepo{
+		rulesRepos: []*model.Repo{
 			{
-				Repo:      "https://github.com/user/repo",
+				RepoUrl:   "https://github.com/user/repo",
 				Community: true,
 			},
 		},

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -10,9 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"net/url"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -34,10 +32,17 @@ const (
 	DEFAULT_AUTO_UPDATE_ENABLED               = false
 	DEFAULT_PLAYBOOK_IMPORT_FREQUENCY_SECONDS = 24 * 60 * 60
 	DEFAULT_PLAYBOOK_IMPORT_ERROR_SECONDS     = 10 * 60
-	DEFAULT_PLAYBOOK_REPO                     = "https://github.com/Security-Onion-Solutions/securityonion-resources-playbooks"
-	DEFAULT_PLAYBOOK_REPO_BRANCH              = "main"
 	DEFAULT_PLAYBOOK_REPO_PATH                = "/opt/sensoroni/playbooks"
-	DEFAULT_PLAYBOOK_PATH_IN_REPO             = "securityonion-normalized"
+)
+
+var ( // treat as constant
+	DEFAULT_PLAYBOOK_REPOS = []*model.Repo{
+		{
+			RepoUrl: "https://github.com/Security-Onion-Solutions/securityonion-resources-playbooks",
+			Branch:  util.Ptr("main"),
+			Folder:  util.Ptr("securityonion-normalized"),
+		},
+	}
 )
 
 var ErrBadPermissions = fmt.Errorf("playbooks module not authorized to read playbooks")
@@ -45,10 +50,8 @@ var ErrBadPermissions = fmt.Errorf("playbooks module not authorized to read play
 type PlaybookDiskManager struct {
 	srv                            *server.Server
 	isRunning                      bool
-	playbookRepoUrl                string
-	playbookRepoBranch             string
+	playbookRepos                  []*model.Repo
 	playbookRepoPath               string
-	playbookPathInRepo             string
 	autoUpdateEnabled              bool
 	pbUpdateMutex                  sync.RWMutex
 	interm                         sync.Mutex
@@ -82,10 +85,12 @@ func (pdm *PlaybookDiskManager) Init(config module.ModuleConfig) (err error) {
 	pdm.autoUpdateEnabled = module.GetBoolDefault(config, "autoUpdateEnabled", DEFAULT_AUTO_UPDATE_ENABLED)
 	pdm.playbookImportFrequencySeconds = module.GetIntDefault(config, "playbookImportFrequencySeconds", DEFAULT_PLAYBOOK_IMPORT_FREQUENCY_SECONDS)
 	pdm.playbookImportErrorSeconds = module.GetIntDefault(config, "playbookImportErrorSeconds", DEFAULT_PLAYBOOK_IMPORT_ERROR_SECONDS)
-	pdm.playbookRepoUrl = module.GetStringDefault(config, "playbookRepoUrl", DEFAULT_PLAYBOOK_REPO)
-	pdm.playbookRepoBranch = module.GetStringDefault(config, "playbookRepoBranch", DEFAULT_PLAYBOOK_REPO_BRANCH)
 	pdm.playbookRepoPath = module.GetStringDefault(config, "playbookRepoPath", DEFAULT_PLAYBOOK_REPO_PATH)
-	pdm.playbookPathInRepo = module.GetStringDefault(config, "playbookPathInRepo", DEFAULT_PLAYBOOK_PATH_IN_REPO)
+
+	pdm.playbookRepos, err = model.GetReposDefault(config, "playbookRepos", false, DEFAULT_PLAYBOOK_REPOS)
+	if err != nil {
+		return fmt.Errorf("unable to parse Playbooks playbookRepos: %w", err)
+	}
 
 	return nil
 }
@@ -172,10 +177,11 @@ func (pdm *PlaybookDiskManager) scheduler() {
 		}
 
 		var anythingNew bool
+		var repos []*detections.RepoOnDisk
 
 		if pdm.autoUpdateEnabled {
 			var err error
-			anythingNew, err = pdm.UpdateRepoOnDisk()
+			repos, anythingNew, err = pdm.updateReposOnDisk()
 			if err != nil {
 				logger.WithError(err).Error("unable to update playbook repo")
 				wasSuccessful = false
@@ -193,7 +199,7 @@ func (pdm *PlaybookDiskManager) scheduler() {
 		if anythingNew || force {
 			start := time.Now()
 
-			err := pdm.LoadPlaybooks(logger)
+			err := pdm.LoadPlaybooks(logger, repos)
 			if err != nil {
 				logger.WithError(err).Error("unable to load playbooks")
 				wasSuccessful = false
@@ -208,24 +214,19 @@ func (pdm *PlaybookDiskManager) scheduler() {
 	}
 }
 
-func (pdm *PlaybookDiskManager) UpdateRepoOnDisk() (anythingNew bool, err error) {
-	_, anythingNew, err = detections.UpdateRepos(&pdm.isRunning, pdm.playbookRepoPath, []*model.RuleRepo{
-		{
-			Repo:   pdm.playbookRepoUrl,
-			Branch: util.Ptr(pdm.playbookRepoBranch),
-		},
-	}, pdm.IOManager)
+func (pdm *PlaybookDiskManager) updateReposOnDisk() (repos []*detections.RepoOnDisk, anythingNew bool, err error) {
+	repos, anythingNew, err = detections.UpdateRepos(&pdm.isRunning, pdm.playbookRepoPath, pdm.playbookRepos, pdm.IOManager)
 
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
-	return anythingNew, nil
+	return repos, anythingNew, nil
 }
 
-func (pdm *PlaybookDiskManager) LoadPlaybooks(logger log.Interface) error {
+func (pdm *PlaybookDiskManager) LoadPlaybooks(logger log.Interface, repos []*detections.RepoOnDisk) error {
 	start := time.Now()
-	playbooks, err := pdm.readPlaybooks(logger)
+	playbooks, err := pdm.readPlaybooks(logger, repos)
 	if err != nil {
 		logger.WithError(err).Error("unable to read playbooks")
 		return err
@@ -243,128 +244,135 @@ func (pdm *PlaybookDiskManager) LoadPlaybooks(logger log.Interface) error {
 	return nil
 }
 
-func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface) ([]*model.Playbook, error) {
+func (pdm *PlaybookDiskManager) readPlaybooks(logger log.Interface, repos []*detections.RepoOnDisk) ([]*model.Playbook, error) {
 	byDetId := make(map[string][]string)
 	onDisk := make(map[string]string)
 	byCategory := make(map[string][]string)
 	byEngine := make(map[string][]string)
 	types := make(map[string]string)
 
-	repo, err := url.Parse(pdm.playbookRepoUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	repoFolderName := path.Base(repo.Path)
-
-	targetDir := path.Join(pdm.playbookRepoPath, repoFolderName, pdm.playbookPathInRepo)
-	files := 0
+	total := 0
 	playbooks := []*model.Playbook{}
 
-	err = pdm.IOManager.WalkDir(targetDir, func(p string, dir fs.DirEntry, err error) error {
-		if !pdm.isRunning {
-			return detections.ErrModuleStopped
+	for _, pbRepo := range repos {
+		files := 0
+		targetDir := pbRepo.Path
+
+		if pbRepo.Repo.Folder != nil {
+			targetDir = filepath.Join(targetDir, *pbRepo.Repo.Folder)
 		}
 
-		if err != nil {
-			// we can't process this file, but keep walking the dir
-			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir":  targetDir,
-				"playbookPath": p,
-			}).Warn("error while walking playbook directory")
-			return nil
-		}
-
-		info, err := dir.Info()
-		if err != nil {
-			// we can't process this file, but keep walking the dir
-			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir":  targetDir,
-				"playbookPath": p,
-				"dirEntry":     dir,
-			}).Warn("error while walking playbook directory")
-			return nil
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		ext := strings.ToLower(filepath.Ext(info.Name()))
-		if ext != ".yaml" && ext != ".yml" {
-			return nil
-		}
-
-		contents, err := pdm.ReadFile(p)
-		if err != nil {
-			// we can't process this file, but keep walking the dir
-			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir":  targetDir,
-				"playbookPath": p,
-			}).Warn("unable to read file while walking playbook directory")
-			return nil
-		}
-
-		pb := &model.Playbook{}
-
-		err = yaml.Unmarshal(contents, &pb)
-		if err != nil {
-			// we can't process this file, but keep walking the dir
-			logger.WithError(err).WithFields(log.Fields{
-				"playbookDir":  targetDir,
-				"playbookPath": p,
-			}).Warn("unable to unmarshal playbook")
-			return nil
-		}
-
-		id := strings.ToLower(pb.Id)
-		playbooks = append(playbooks, pb)
-		files++
-
-		if pb.DetectionType != "" {
-			types[id] = strings.ToLower(pb.DetectionType)
-		}
-
-		if pb.DetectionId != "" {
-			detId := strings.ToLower(pb.DetectionId)
-			byDetId[detId] = append(byDetId[detId], id)
-		}
-
-		if pb.DetectionCategory != "" {
-			category := strings.ToLower(pb.DetectionCategory)
-			byCategory[category] = append(byCategory[category], id)
-		}
-
-		if pb.DetectionId == "" && pb.DetectionCategory == "" {
-			switch strings.ToLower(pb.DetectionType) {
-			case "sigma":
-				byEngine[string(model.EngineNameElastAlert)] = append(byEngine[string(model.EngineNameElastAlert)], id)
-			case "strelka":
-				byEngine[string(model.EngineNameStrelka)] = append(byEngine[string(model.EngineNameStrelka)], id)
-			case "nids":
-				byEngine[string(model.EngineNameSuricata)] = append(byEngine[string(model.EngineNameSuricata)], id)
-			default:
-				logger.Warn("unexpected playbook detection_type: " + pb.DetectionType)
+		err := pdm.IOManager.WalkDir(targetDir, func(p string, dir fs.DirEntry, err error) error {
+			if !pdm.isRunning {
+				return detections.ErrModuleStopped
 			}
+
+			if err != nil {
+				// we can't process this file, but keep walking the dir
+				logger.WithError(err).WithFields(log.Fields{
+					"playbookDir":  targetDir,
+					"playbookPath": p,
+				}).Warn("error while walking playbook directory")
+				return nil
+			}
+
+			info, err := dir.Info()
+			if err != nil {
+				// we can't process this file, but keep walking the dir
+				logger.WithError(err).WithFields(log.Fields{
+					"playbookDir":  targetDir,
+					"playbookPath": p,
+					"dirEntry":     dir,
+				}).Warn("error while walking playbook directory")
+				return nil
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			ext := strings.ToLower(filepath.Ext(info.Name()))
+			if ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+
+			contents, err := pdm.ReadFile(p)
+			if err != nil {
+				// we can't process this file, but keep walking the dir
+				logger.WithError(err).WithFields(log.Fields{
+					"playbookDir":  targetDir,
+					"playbookPath": p,
+				}).Warn("unable to read file while walking playbook directory")
+				return nil
+			}
+
+			pb := &model.Playbook{}
+
+			err = yaml.Unmarshal(contents, &pb)
+			if err != nil {
+				// we can't process this file, but keep walking the dir
+				logger.WithError(err).WithFields(log.Fields{
+					"playbookDir":  targetDir,
+					"playbookPath": p,
+				}).Warn("unable to unmarshal playbook")
+				return nil
+			}
+
+			id := strings.ToLower(pb.Id)
+			playbooks = append(playbooks, pb)
+			files++
+
+			if pb.DetectionType != "" {
+				types[id] = strings.ToLower(pb.DetectionType)
+			}
+
+			if pb.DetectionId != "" {
+				detId := strings.ToLower(pb.DetectionId)
+				byDetId[detId] = append(byDetId[detId], id)
+			}
+
+			if pb.DetectionCategory != "" {
+				category := strings.ToLower(pb.DetectionCategory)
+				byCategory[category] = append(byCategory[category], id)
+			}
+
+			if pb.DetectionId == "" && pb.DetectionCategory == "" {
+				switch strings.ToLower(pb.DetectionType) {
+				case "sigma":
+					byEngine[string(model.EngineNameElastAlert)] = append(byEngine[string(model.EngineNameElastAlert)], id)
+				case "strelka":
+					byEngine[string(model.EngineNameStrelka)] = append(byEngine[string(model.EngineNameStrelka)], id)
+				case "nids":
+					byEngine[string(model.EngineNameSuricata)] = append(byEngine[string(model.EngineNameSuricata)], id)
+				default:
+					logger.Warn("unexpected playbook detection_type: " + pb.DetectionType)
+				}
+			}
+
+			_, ok := onDisk[id]
+			if ok {
+				logger.WithField("playbookId", id).Warn("duplicate playbook id")
+			}
+
+			onDisk[id] = p
+
+			return nil
+		})
+		if err != nil {
+			logger.WithError(err).WithField("playbookDir", targetDir).Error("unable to read playbooks")
+			return nil, err
 		}
 
-		_, ok := onDisk[id]
-		if ok {
-			logger.WithField("playbookId", id).Warn("duplicate playbook id")
-		}
+		logger.WithFields(log.Fields{
+			"playbookDir":     targetDir,
+			"playbooksLoaded": files,
+		}).Info("read playbooks")
 
-		onDisk[id] = p
-
-		return nil
-	})
-	if err != nil {
-		logger.WithError(err).WithField("playbookDir", targetDir).Error("unable to read playbooks")
-		return nil, err
+		total += files
 	}
 
 	logger.WithFields(log.Fields{
-		"playbookDir": targetDir,
-		"fileCount":   files,
+		"fileCount": total,
 	}).Info("read playbooks")
 
 	pdm.pbUpdateMutex.Lock()

--- a/server/modules/playbook/playbook_test.go
+++ b/server/modules/playbook/playbook_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/handmock"
 	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections/mock"
 	"github.com/security-onion-solutions/securityonion-soc/util"
@@ -503,18 +504,22 @@ func TestScheduler(t *testing.T) {
 
 	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
-		srv:                server.NewFakeAuthorizedServer(nil),
-		autoUpdateEnabled:  true,
-		playbookRepoPath:   "/tmp/playbooks",
-		playbookRepoUrl:    "https://github.com/playbooks/repo",
-		playbookRepoBranch: "dev",
-		interruptChan:      make(chan bool, 1),
-		isRunning:          true,
-		IOManager:          iom,
+		srv:               server.NewFakeAuthorizedServer(nil),
+		autoUpdateEnabled: true,
+		playbookRepoPath:  "/tmp/playbooks",
+		playbookRepos: []*model.Repo{
+			{
+				RepoUrl: "https://github.com/playbooks/repo",
+				Branch:  util.Ptr("dev"),
+			},
+		},
+		interruptChan: make(chan bool, 1),
+		isRunning:     true,
+		IOManager:     iom,
 	}
 
 	iom.EXPECT().ReadDir(pdm.playbookRepoPath).Return(nil, nil)
-	iom.EXPECT().CloneRepo(gomock.Any(), "/tmp/playbooks/repo", pdm.playbookRepoUrl, util.Ptr(pdm.playbookRepoBranch)).Return(nil)
+	iom.EXPECT().CloneRepo(gomock.Any(), "/tmp/playbooks/repo", pdm.playbookRepos[0].RepoUrl, pdm.playbookRepos[0].Branch).Return(nil)
 
 	iom.EXPECT().WalkDir("/tmp/playbooks/repo", gomock.Any()).DoAndReturn(func(path string, fn func(p string, dir fs.DirEntry, err error) error) error {
 		err := fn("/tmp/playbooks/repo/playbook1.yaml", &handmock.MockDirEntry{
@@ -699,11 +704,25 @@ func TestReadPlaybooks(t *testing.T) {
 
 	iom := mock.NewMockIOManager(ctrl)
 	pdm := PlaybookDiskManager{
-		isRunning:          true,
-		playbookRepoUrl:    "http://github.com/user/repo",
-		playbookPathInRepo: "playbooks/dev",
-		playbookRepoPath:   "/tmp/playbooks",
-		IOManager:          iom,
+		isRunning:        true,
+		playbookRepoPath: "/tmp/playbooks",
+		IOManager:        iom,
+	}
+
+	repos := []*detections.RepoOnDisk{
+		{
+			Repo: &model.Repo{
+				RepoUrl: "http://github.com/user/repo",
+				Folder:  util.Ptr("playbooks/dev"),
+			},
+			Path: "/tmp/playbooks/repo",
+		},
+		{
+			Repo: &model.Repo{
+				RepoUrl: "file:///playbooks/myRepo",
+			},
+			Path: "/tmp/playbooks/myRepo",
+		},
 	}
 
 	iom.EXPECT().WalkDir("/tmp/playbooks/repo/playbooks/dev", gomock.Any()).DoAndReturn(func(path string, fn func(p string, dir fs.DirEntry, err error) error) error {
@@ -721,8 +740,20 @@ func TestReadPlaybooks(t *testing.T) {
 		err = fn("unmarshal error", &handmock.MockDirEntry{Filename: "a.yml"}, nil)
 		assert.NoError(t, err)
 
-		iom.EXPECT().ReadFile("success").Return([]byte("id: x"), nil)
+		iom.EXPECT().ReadFile("success").Return([]byte("id: repo1-pb1"), nil)
 		err = fn("success", &handmock.MockDirEntry{Filename: "a.yml"}, nil)
+		assert.NoError(t, err)
+
+		return nil
+	})
+
+	iom.EXPECT().WalkDir("/tmp/playbooks/myRepo", gomock.Any()).DoAndReturn(func(path string, fn func(p string, dir fs.DirEntry, err error) error) error {
+		iom.EXPECT().ReadFile("repo2-playbook1.yaml").Return([]byte("id: repo2-pb1"), nil)
+		err := fn("repo2-playbook1.yaml", &handmock.MockDirEntry{Filename: "repo2-playbook1.yaml"}, nil)
+		assert.NoError(t, err)
+
+		iom.EXPECT().ReadFile("repo2-playbook2.yaml").Return([]byte("id: repo2-pb2"), nil)
+		err = fn("repo2-playbook2.yaml", &handmock.MockDirEntry{Filename: "repo2-playbook2.yaml"}, nil)
 		assert.NoError(t, err)
 
 		return nil
@@ -732,13 +763,23 @@ func TestReadPlaybooks(t *testing.T) {
 	lg := &log.Logger{Handler: h, Level: log.DebugLevel}
 	logger := lg.WithField("test", true)
 
-	pbs, err := pdm.readPlaybooks(logger)
+	pbs, err := pdm.readPlaybooks(logger, repos)
 	assert.NoError(t, err)
-	assert.Len(t, pbs, 1)
-	assert.Equal(t, "x", pbs[0].Id)
+	assert.Len(t, pbs, 3)
 
-	assert.Equal(t, 1, len(pdm.playbooksOnDisk))
-	assert.Equal(t, "success", pdm.playbooksOnDisk["x"])
+	// Verify playbooks from both repos are loaded
+	playbookIds := make([]string, len(pbs))
+	for i, pb := range pbs {
+		playbookIds[i] = pb.Id
+	}
+	assert.Contains(t, playbookIds, "repo1-pb1")
+	assert.Contains(t, playbookIds, "repo2-pb1")
+	assert.Contains(t, playbookIds, "repo2-pb2")
+
+	assert.Equal(t, 3, len(pdm.playbooksOnDisk))
+	assert.Equal(t, "success", pdm.playbooksOnDisk["repo1-pb1"])
+	assert.Equal(t, "repo2-playbook1.yaml", pdm.playbooksOnDisk["repo2-pb1"])
+	assert.Equal(t, "repo2-playbook2.yaml", pdm.playbooksOnDisk["repo2-pb2"])
 }
 
 func TestGetPlaybooksForDetection_BaseCategoryMatching(t *testing.T) {
@@ -748,27 +789,27 @@ func TestGetPlaybooksForDetection_BaseCategoryMatching(t *testing.T) {
 	iom := mock.NewMockIOManager(ctrl)
 
 	pdm := PlaybookDiskManager{
-		srv: server.NewFakeAuthorizedServer(nil),
+		srv:                    server.NewFakeAuthorizedServer(nil),
 		PlaybooksByDetectionId: map[string][]string{},
 		PlaybooksByCategory: map[string][]string{
-			"scan": {"scan-playbook", "sigma-scan-playbook"},
+			"scan":    {"scan-playbook", "sigma-scan-playbook"},
 			"et scan": {"et-scan-playbook"},
-			"sql": {"sql-playbook"},
+			"sql":     {"sql-playbook"},
 			"generic": {"generic-playbook"},
 		},
 		PlaybooksByEngine: map[string][]string{},
 		playbooksOnDisk: map[string]string{
-			"scan-playbook": "/path/scan",
+			"scan-playbook":       "/path/scan",
 			"sigma-scan-playbook": "/path/sigma-scan",
-			"et-scan-playbook": "/path/et-scan",
-			"sql-playbook": "/path/sql",
-			"generic-playbook": "/path/generic",
+			"et-scan-playbook":    "/path/et-scan",
+			"sql-playbook":        "/path/sql",
+			"generic-playbook":    "/path/generic",
 		},
 		playbookTypes: map[string]string{
-			"scan-playbook": "nids",
+			"scan-playbook":       "nids",
 			"sigma-scan-playbook": "sigma",
-			"et-scan-playbook": "nids",
-			"sql-playbook": "nids",
+			"et-scan-playbook":    "nids",
+			"sql-playbook":        "nids",
 			// generic-playbook has no type - should match any engine
 		},
 		IOManager: iom,

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -70,7 +70,7 @@ type StrelkaEngine struct {
 	yaraRulesFolder                string
 	reposFolder                    string
 	autoEnabledYaraRules           []string
-	rulesRepos                     []*model.RuleRepo
+	rulesRepos                     []*model.Repo
 	compileYaraPythonScriptPath    string
 	notify                         bool
 	writeNoRead                    *string
@@ -129,9 +129,9 @@ func (e *StrelkaEngine) Init(config module.ModuleConfig) (err error) {
 	e.IntegrityCheckerData.FrequencySeconds = module.GetIntDefault(config, "integrityCheckFrequencySeconds", DEFAULT_INTEGRITY_CHECK_FREQUENCY_SECONDS)
 	e.autoUpdateEnabled = module.GetBoolDefault(config, "autoUpdateEnabled", DEFAULT_AUTO_UPDATE_ENABLED)
 
-	e.rulesRepos, err = model.GetReposDefault(config, "rulesRepos", []*model.RuleRepo{
+	e.rulesRepos, err = model.GetReposDefault(config, "rulesRepos", true, []*model.Repo{
 		{
-			Repo:    "https://github.com/Security-Onion-Solutions/securityonion-yara",
+			RepoUrl: "https://github.com/Security-Onion-Solutions/securityonion-yara",
 			License: "DRL",
 		},
 	})
@@ -439,11 +439,11 @@ func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 
 		ruleset := repo.RulesetName
 		if ruleset == "" {
-			parser, err := url.Parse(repo.Repo.Repo)
+			parser, err := url.Parse(repo.Repo.RepoUrl)
 			if err == nil {
 				_, ruleset = path.Split(parser.Path)
 			} else {
-				ruleset = repo.Repo.Repo
+				ruleset = repo.Repo.RepoUrl
 			}
 		}
 

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1018,9 +1018,9 @@ func TestSyncIncrementalNoChanges(t *testing.T) {
 		},
 		isRunning:   true,
 		reposFolder: "repos",
-		rulesRepos: []*model.RuleRepo{
+		rulesRepos: []*model.Repo{
 			{
-				Repo:      "https://github.com/user/repo",
+				RepoUrl:   "https://github.com/user/repo",
 				Community: true,
 			},
 		},
@@ -1114,9 +1114,9 @@ func TestSyncChanges(t *testing.T) {
 		},
 		isRunning:   true,
 		reposFolder: "repos",
-		rulesRepos: []*model.RuleRepo{
+		rulesRepos: []*model.Repo{
 			{
-				Repo:      "https://github.com/user/repo",
+				RepoUrl:   "https://github.com/user/repo",
 				Community: true,
 			},
 		},
@@ -1305,9 +1305,9 @@ func TestSyncStateFileNoCommunity(t *testing.T) {
 		},
 		isRunning:   true,
 		reposFolder: "repos",
-		rulesRepos: []*model.RuleRepo{
+		rulesRepos: []*model.Repo{
 			{
-				Repo:      "https://github.com/user/repo",
+				RepoUrl:   "https://github.com/user/repo",
 				Community: true,
 			},
 		},


### PR DESCRIPTION
Convert the config entry to an array of objects similar to repos listed in ElastAlert and Strelka.

Refactor RuleRepo to Repo. It's no longer just for Rules.

Playbooks don't require licenses so don't require it when parsing the config.