### PR TITLE
Fix Sorting Alerts Causing New Rows

### DIFF
--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -252,7 +252,7 @@
 										</div>
 										<v-data-table v-if="!group.chart_type" :id="'group-' + groupIdx" class="elevation-1"
 											:search="groupByFilter" density="compact" v-model:expanded="expandedEvents"
-											:items-per-page-options="groupByFooters" item-value="rule.uuid" :items-per-page="groupByItemsPerPage"
+											:items-per-page-options="groupByFooters" :items-per-page="groupByItemsPerPage"
 											@update:items-per-page="val => groupByItemsPerPage = val" :headers="group.headers"
 											:items="group.data" v-model:sort-by="group.sortBy" must-sort @update:sort-by="updateGroupBySort(groupIdx)"
 											:data-aid="'groups_table_' + category">


### PR DESCRIPTION
Cannot specify the item-value of the alerts data table to `rule.uuid`. That works fine for "Group By Name, Module" but in any other view the `rule.uuid` of the alert may not be unique in the list of alerts. This is causing UI errors when a different grouping method is selected and the columns are then sorted, resulting in extra rows visible in the UI. Not specifying the `item-value` remedies the issue.