### PR TITLE
Give Alerts Unique IDs for the UI

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -737,7 +737,7 @@ const huntComponent = {
           docEvent["soc_id"] = item["soc_id"];
         } else {
           for (let field of Object.keys(item)) {
-            if (field !== 'newest') docEvent[field] = item[field]
+            if (field !== 'newest' && !field.startsWith('_')) docEvent[field] = item[field]
           }
         }
         var isAlert = ('rule.name' in item || 'event.severity_label' in item);
@@ -1207,7 +1207,7 @@ const huntComponent = {
       return this.buildGroupOptionRoute(groupIdx, removals, '');
     },
     countDrilldown(event) {
-      const keys = Object.keys(event).filter(field => field != 'newest');
+      const keys = Object.keys(event).filter(field => field != 'newest' && !field.startsWith('_'));
       if ( (keys.length == 2 && keys[0] == "count") || (keys.length == 5 && keys[0] == "count" && keys[1] == "rule.name" && keys[2] == "event.module" && keys[3] == "event.severity_label" && keys[4] == "rule.uuid") ) {
         this.filterRouteDrilldown = this.buildFilterRoute(keys[1], event[keys[1]], FILTER_DRILLDOWN);
         this.$router.push(this.filterRouteDrilldown);
@@ -1438,6 +1438,7 @@ const huntComponent = {
       data.forEach(function(row, index) {
         var record = {
           count: row.value,
+          _index: index,
         };
         fields.forEach(function(field, index) {
           record[field] = route.localizeValue(row.keys[index]);
@@ -1643,6 +1644,8 @@ const huntComponent = {
           if (multiSelect) {
             record._isSelected = false;
           }
+
+          record._index = index;
 
           records.push(record);
 
@@ -3016,6 +3019,7 @@ const huntComponent = {
 
       for (let field in item) {
         let label = field;
+        if (field.startsWith('_')) continue;
         if (field.startsWith('event_data.')) {
           label = field.replace('event_data.', '');
         }

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -252,7 +252,7 @@
 										</div>
 										<v-data-table v-if="!group.chart_type" :id="'group-' + groupIdx" class="elevation-1"
 											:search="groupByFilter" density="compact" v-model:expanded="expandedEvents"
-											:items-per-page-options="groupByFooters" :items-per-page="groupByItemsPerPage"
+											:items-per-page-options="groupByFooters" item-value="_index" :items-per-page="groupByItemsPerPage"
 											@update:items-per-page="val => groupByItemsPerPage = val" :headers="group.headers"
 											:items="group.data" v-model:sort-by="group.sortBy" must-sort @update:sort-by="updateGroupBySort(groupIdx)"
 											:data-aid="'groups_table_' + category">
@@ -334,12 +334,12 @@
 												<tr>
 													<td :colspan="columns.length" class="px-0" :data-aid="'events_fields_' + category">
 														<div>
-															<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[index]" @update:model-value="if (activeTabs[index] === 'playbook') loadPlaybook(item.newest);">
-																<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[index] === 'alert' }" :style="{ 'width': (eventColumnWidth * 0.5 - 28) + 'px' }" data-aid="alerts_agg_alertDetailsTab">
+															<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[item._index]" @update:model-value="if (activeTabs[item._index] === 'playbook') loadPlaybook(item.newest);">
+																<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[item._index] === 'alert' }" :style="{ 'width': (eventColumnWidth * 0.5 - 28) + 'px' }" data-aid="alerts_agg_alertDetailsTab">
 																	<v-icon class="tab-icon">fa-bell</v-icon>
 																	<div class="d-none d-lg-block">{{i18n.alertDetails}}</div>
 																</v-tab>
-																<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[index] === 'playbook' }" :style="{ 'width': (eventColumnWidth * 0.5 - 28) + 'px' }" data-aid="alerts_agg_playbookTab">
+																<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[item._index] === 'playbook' }" :style="{ 'width': (eventColumnWidth * 0.5 - 28) + 'px' }" data-aid="alerts_agg_playbookTab">
 																	<v-icon class="tab-icon">fa-book</v-icon>
 																	<div class="d-none d-lg-block">{{i18n.guidedAnalysis}}</div>
 																	<template #append>
@@ -352,7 +352,7 @@
 																	</template>
 																</v-tab>
 															</v-tabs>
-															<v-tabs-window v-model="activeTabs[index]">
+															<v-tabs-window v-model="activeTabs[item._index]">
 																<v-tabs-window-item value="alert">
 																	<v-data-table density="compact" hide-default-header hide-default-footer :headers="expandedHeaders" :items="getExpandedData(item.newest)" items-per-page="-1">
 																		<template #item="{ item: kvp }">
@@ -640,12 +640,12 @@
 									<tr>
 										<td :colspan="columns.length" class="px-0" :data-aid="'events_fields_' + category">
 											<div>
-												<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[index]" @update:model-value="if (activeTabs[index] === 'playbook') loadPlaybook(item);">
-													<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[index] === 'alert' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }" data-aid="alerts_alertDetailsTab">
+												<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[item._index]" @update:model-value="if (activeTabs[item._index] === 'playbook') loadPlaybook(item);">
+													<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[item._index] === 'alert' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }" data-aid="alerts_alertDetailsTab">
 														<v-icon class="tab-icon">fa-bell</v-icon>
 														<div class="d-none d-lg-block">{{i18n.alertDetails}}</div>
 													</v-tab>
-													<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[index] === 'playbook' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }" data-aid="alerts_playbookTab">
+													<v-tab id="alerts_playbookTab" value="playbook" :class="{ 'theme-primary': activeTabs[item._index] === 'playbook' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }" data-aid="alerts_playbookTab">
 														<v-icon class="tab-icon">fa-book</v-icon>
 														<div class="d-none d-lg-block">{{i18n.guidedAnalysis}}</div>
 														<template #append>
@@ -658,7 +658,7 @@
 														</template>
 													</v-tab>
 												</v-tabs>
-												<v-tabs-window v-model="activeTabs[index]">
+												<v-tabs-window v-model="activeTabs[item._index]">
 													<v-tabs-window-item value="alert">
 														<v-data-table density="compact" hide-default-header hide-default-footer :headers="expandedHeaders" :items="getExpandedData(item)" items-per-page="-1">
 															<template #item="{ item: kvp }">


### PR DESCRIPTION
We now generate a pseudo-ID for alerts. It only needs to be unique per object so it's the index at the time of retrieval. The IDs are then used for identifying individual rows when working with v-data-table. The new field has been exempted from existing functions that utilize all alert fields. These refactors make it possible to delete events and continue to use the page without refreshing but did require a bit of refactor. The result is a stabler state as the user moves around the Alerts page.