### PR TITLE
Sort Playbook Questions by Results

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1068,13 +1068,13 @@ ul ul ul {
 }
 
 .has-answers {
-  border-left: 3px solid #2196F3;
+  border-left: 3px solid rgb(var(--v-theme-info));
 }
 
 .no-data {
-  border-left: 3px solid #FF9800;
+  border-left: 3px solid rgb(var(--v-theme-warning));
 }
 
 .has-error {
-  border-left: 3px solid #FF0000;
+  border-left: 3px solid rgb(var(--v-theme-error));
 }

--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1066,3 +1066,15 @@ ul ul ul {
 .center-self-flex {
   justify-self: center;
 }
+
+.has-answers {
+  border-left: 3px solid #2196F3;
+}
+
+.no-data {
+  border-left: 3px solid #FF9800;
+}
+
+.has-error {
+  border-left: 3px solid #FF0000;
+}

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2754,7 +2754,7 @@ const huntComponent = {
         }, 300);
       }
     },
-    async loadPlaybook(event) {
+    async loadPlaybook(event, index) {
       if ('playbooks' in event || 'playbookLoading' in event || 'playbookErr' in event) return;
       
       const publicId = event?.['rule.uuid'];
@@ -2787,11 +2787,31 @@ const huntComponent = {
       delete event.playbookLoading;
 
       if (playbooks) {
+        // answer the questions and
+        // stable sort them by results
+        let good = []; // has answers
+        let bad = [];  // no answers
+        let ugly = []; // error
         for (let pb of event.playbooks) {
           for (let q of pb.questions) {
             await this.$nextTick();
             await this.askQuestion(q, event);
+
+            if (q.error) {
+              ugly.push(q);
+            } else if (q.answers.length > 0) {
+              good.push(q);
+            } else {
+              bad.push(q);
+            }
           }
+        }
+
+        event.questions = [...good, ...bad, ...ugly];
+
+        this.expandedPlaybookQuestions[index] = [];
+        for (let i = 0; i < good.length; i++) {
+          this.expandedPlaybookQuestions[index].push(i);
         }
       }
     },
@@ -3101,28 +3121,35 @@ const huntComponent = {
 
       event = (event || {}).newest || event;
 
-      if (event.playbookLoading || !('playbooks' in event)) {
+      if (event.playbookLoading || !('questions' in event)) {
         setTimeout(() => {
           this.toggleAllQuestions(event, index, expand);
         }, 100)
         return;
       }
 
-      if (event.playbooks) {
-        let count = 0;
+      if (event.questions) {
         if (!Array.isArray(this.expandedPlaybookQuestions[index]) || !expand) this.expandedPlaybookQuestions[index] = [];
         if (expand) {
-          for (let i = 0; i < event.playbooks.length; i++) {
-            for (let j = 0; j < event.playbooks[i].questions.length; j++) {
-              if (!this.expandedPlaybookQuestions[index].includes(count)) {
-                this.expandedPlaybookQuestions[index].push(count);
-              }
-              count++;
+          for (let i = 0; i < event.questions.length; i++) {
+            if (!this.expandedPlaybookQuestions[index].includes(i)) {
+              this.expandedPlaybookQuestions[index].push(i);
             }
           }
         }
       }
     },
+    pickQuestionColor(question) {
+      if (question.error) {
+        return 'has-error';
+      }
+
+      if (question.answers && question.answers.length > 0) {
+        return 'has-answers';
+      }
+
+      return 'no-data';
+    }
   }
 };
 

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -2175,17 +2175,7 @@ test('isComplexQuery', () => {
 
 test('toggleAllQuestions', () => {
   let event = {
-    playbooks: [
-      {
-        questions: [{}, {}, {}],
-      },
-      {
-        questions: [{}],
-      },
-      {
-        questions: [{}, {}],
-      },
-    ],
+    questions: [{}, {}, {}]
   };
   let index = 0;
   let expand = true;
@@ -2193,39 +2183,39 @@ test('toggleAllQuestions', () => {
 
   // expand
   comp.toggleAllQuestions(event, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2, 3, 4, 5] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2] });
 
   // expand a different index
   index = 1;
   comp.toggleAllQuestions(event, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2, 3, 4, 5], 1: [0, 1, 2, 3, 4, 5] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2], 1: [0, 1, 2] });
 
   // collapse non-existing index
   index = 2;
   expand = false;
   comp.toggleAllQuestions(event, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2, 3, 4, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [0, 1, 2], 1: [0, 1, 2], 2: [] });
 
   // collapse existing, expanded index
   index = 0;
   comp.toggleAllQuestions(event, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [], 1: [0, 1, 2], 2: [] });
 
   // expand existing, partially expanded
-  comp.expandedPlaybookQuestions[0] = [2, 4];
+  comp.expandedPlaybookQuestions[0] = [1];
   expand = true;
   comp.toggleAllQuestions(event, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [] });
 
   // no changes when expanding an already expanded group, even if out of order
   comp.toggleAllQuestions(event, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [] });
 
   // no change when collapsing an already collapsed group
   index = 2;
   expand = false;
   comp.toggleAllQuestions(event, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [] });
 
   // handle aggregate event
   let aggEvent = {
@@ -2234,7 +2224,7 @@ test('toggleAllQuestions', () => {
 
   expand = true;
   comp.toggleAllQuestions(aggEvent, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [0, 1, 2] });
 
   // handle event that doesn't have playbooks yet
   const _setTimeout = global.setTimeout;
@@ -2246,7 +2236,7 @@ test('toggleAllQuestions', () => {
   expand = true;
 
   comp.toggleAllQuestions(emptyEvent, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [0, 1, 2] });
   expect(setTimeoutMock).toHaveBeenCalledTimes(1);
 
   // handle agg event that doesn't have playbooks yet
@@ -2254,7 +2244,7 @@ test('toggleAllQuestions', () => {
   setTimeoutMock.mockClear();
   
   comp.toggleAllQuestions(aggEvent, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [0, 1, 2] });
   expect(setTimeoutMock).toHaveBeenCalledTimes(1);
   
   // handle event that's loading playbooks
@@ -2263,7 +2253,7 @@ test('toggleAllQuestions', () => {
   setTimeoutMock.mockClear();
   
   comp.toggleAllQuestions(emptyEvent, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [0, 1, 2] });
   expect(setTimeoutMock).toHaveBeenCalledTimes(1);
 
   // handle agg event that's loading playbooks
@@ -2271,7 +2261,7 @@ test('toggleAllQuestions', () => {
   setTimeoutMock.mockClear();
   
   comp.toggleAllQuestions(aggEvent, index, expand);
-  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [2, 4, 0, 1, 3, 5], 1: [0, 1, 2, 3, 4, 5], 2: [0, 1, 2, 3, 4, 5] });
+  expect(comp.expandedPlaybookQuestions).toStrictEqual({ 0: [1, 0, 2], 1: [0, 1, 2], 2: [0, 1, 2] });
   expect(setTimeoutMock).toHaveBeenCalledTimes(1);
 
   global.setTimeout = _setTimeout;
@@ -2286,7 +2276,7 @@ test('loadPlaybook', async () => {
 
   let papiMock = mockPapi('get', { data: playbooks });
 
-  await comp.loadPlaybook(event);
+  await comp.loadPlaybook(event, 0);
 
   expect(papiMock).toHaveBeenCalledWith('playbook/detection/123');
   expect(event.playbooks).toStrictEqual(playbooks);
@@ -2300,7 +2290,7 @@ test('loadPlaybook', async () => {
     'rule.uuid': '456',
   };
 
-  comp.loadPlaybook(event);
+  comp.loadPlaybook(event, 0);
 
   expect(papiMock).toHaveBeenCalledWith('playbook/detection/456');
   expect(papiMock).toHaveBeenCalledTimes(1);
@@ -2309,7 +2299,7 @@ test('loadPlaybook', async () => {
 
   event = {};
 
-  comp.loadPlaybook(event);
+  comp.loadPlaybook(event, 0);
 
   expect(event.playbookErr).toBe(true);
 
@@ -2317,24 +2307,75 @@ test('loadPlaybook', async () => {
 
   event = { playbooks: '' };
 
-  comp.loadPlaybook(event);
+  comp.loadPlaybook(event, 0);
   expect(event.playbookErr).toBe(undefined);
   expect(event.playbookLoading).toBe(undefined);
   expect(papiMock).toHaveBeenCalledTimes(0);
 
   event = { playbookLoading: '' };
 
-  comp.loadPlaybook(event);
+  comp.loadPlaybook(event, 0);
   expect(event.playbooks).toBe(undefined);
   expect(event.playbookErr).toBe(undefined);
   expect(papiMock).toHaveBeenCalledTimes(0);
 
   event = { playbookErr: true };
 
-  comp.loadPlaybook(event);
+  comp.loadPlaybook(event, 0);
   expect(event.playbooks).toBe(undefined);
   expect(event.playbookLoading).toBe(undefined);
   expect(papiMock).toHaveBeenCalledTimes(0);
 
   resetPapi();
+});
+
+test('pickQuestionColor', () => {
+  let question = {
+    error: true,
+  };
+
+  let c = comp.pickQuestionColor(question);
+  expect(c).toBe('has-error');
+
+  question = {
+    error: false,
+  };
+
+  c = comp.pickQuestionColor(question);
+  expect(c).toBe('no-data');
+
+  question = {}
+
+  c = comp.pickQuestionColor(question);
+  expect(c).toBe('no-data');
+
+  question = {
+    answers: [],
+  };
+
+  c = comp.pickQuestionColor(question);
+  expect(c).toBe('no-data');
+
+  question = {
+    answers: [{}],
+  };
+
+  c = comp.pickQuestionColor(question);
+  expect(c).toBe('has-answers');
+
+  question = {
+    answers: [{}],
+    error: false,
+  };
+
+  c = comp.pickQuestionColor(question);
+  expect(c).toBe('has-answers');
+
+  question = {
+    answers: [{}],
+    error: true,
+  };
+
+  c = comp.pickQuestionColor(question);
+  expect(c).toBe('has-error');
 });

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -334,7 +334,7 @@
 												<tr>
 													<td :colspan="columns.length" class="px-0" :data-aid="'events_fields_' + category">
 														<div>
-															<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[item._index]" @update:model-value="if (activeTabs[item._index] === 'playbook') loadPlaybook(item.newest);">
+															<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[item._index]" @update:model-value="if (activeTabs[item._index] === 'playbook') loadPlaybook(item.newest, item._index);">
 																<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[item._index] === 'alert' }" :style="{ 'width': (eventColumnWidth * 0.5 - 28) + 'px' }" data-aid="alerts_agg_alertDetailsTab">
 																	<v-icon class="tab-icon">fa-bell</v-icon>
 																	<div class="d-none d-lg-block">{{i18n.alertDetails}}</div>
@@ -343,10 +343,10 @@
 																	<v-icon class="tab-icon">fa-book</v-icon>
 																	<div class="d-none d-lg-block">{{i18n.guidedAnalysis}}</div>
 																	<template #append>
-																		<v-btn class="ml-9" variant="text" size="small" icon @click="toggleAllQuestions(item, index, false)" aria-label="collapse all" data-aid="alerts_agg_playbooks_collapseAll">
+																		<v-btn class="ml-9" variant="text" size="small" icon @click="toggleAllQuestions(item, item._index, false)" aria-label="collapse all" data-aid="alerts_agg_playbooks_collapseAll">
 																			<v-icon>fa-window-minimize</v-icon>
 																		</v-btn>
-																		<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item, index, true)" aria-label="expand all" data-aid="alerts_agg_playbooks_expandAll">
+																		<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item, item._index, true)" aria-label="expand all" data-aid="alerts_agg_playbooks_expandAll">
 																			<v-icon>fa-window-maximize</v-icon>
 																		</v-btn>
 																	</template>
@@ -381,96 +381,94 @@
 																			<v-icon class="mr-3" data-aid="playbook_grouped_ai_indicator">fa-flask</v-icon>
 																			<span v-html="i18n.playbooksAi"  data-aid="playbook_grouped_ai_text"></span>
 																		</div>
-																		<v-expansion-panels @update:model-value="expandedPlaybookQuestions[index] = $event" :model-value="expandedPlaybookQuestions[index]" variant="accordion" multiple static="true">
-																			<template v-for="playbook in item.newest.playbooks">
-																				<v-expansion-panel v-for="question in playbook.questions">
-																					<v-expansion-panel-title class="italic ws-normal spacious-lines" #default="{ expanded }">
-																						<v-icon class="theme-icon mx-4" data-aid="playbook_grouped_question_title">
-																							<template v-if="expanded">fa-angle-down</template>
-																							<template v-else>fa-angle-right</template>
-																						</v-icon>
-																						{{question.question}}
-																					</v-expansion-panel-title>
-																					<v-expansion-panel-text class="pl-13 ws-normal">
-																						<div class="font-weight-bold font-italic" data-aid="playbook_grouped_question_context_label">{{i18n.context}}</div>
-																						<div class="italic" data-aid="playbook_grouped_question_context">{{question.context}}</div>
-																						<div class="italic my-4" data-aid="playbook_grouped_question_daterange">{{i18n.dateRange}}: {{question.range || i18n.event}}</div>
-																						<v-row no-gutters class="mb-5">
-																							<v-col cols="auto">
-																								<v-btn id="hunt-question" icon size="small" variant="text" :href="$router.resolve(buildHuntQuestionParams(question, item.newest)).href" target="_blank" class="cursor-pointer" data-aid="playbook_grouped_hunt_question">
-																									<v-icon>fa-crosshairs</v-icon>
-																								</v-btn>
-																							</v-col>
-																							<v-col style="align-content: center;" data-aid="playbook_grouped_question_query">
-																								{{ question.filledOQL }}
-																							</v-col>
-																						</v-row>
-																						<template v-if="question.answers">
-																							<span class="font-weight-bold font-italic">
-																								{{ i18n.instantInsight }}
-																							</span>
-																							<br/>
-																							<span class="italic" data-aid="playbook_grouped_event_timestamp">
-																								{{ i18n.eventOccurredAt }} {{ formatTimestamp(getEventTimestamp(item.newest)) }}
-																							</span>
-																							<table v-if="question.isAggregate" class="simple-table">
-																								<thead>
-																									<tr>
-																										<th data-aid="playbook_grouped_instantinsights_aggregate_header_count">
-																											{{ i18n.count }}
-																										</th>
-																										<th v-for="field in question.fields" :key="field" :data-aid="'playbook_grouped_instantinsights_aggregate_header_' + field">
-																											{{ field }}
-																										</th>
-																									</tr>
-																								</thead>
-																								<tbody>
-																									<tr v-for="agg in question.answers">
-																										<td class="text-right" data-aid="playbook_grouped_instantinsights_aggregate_answer_count">
-																											{{ agg.value }}
-																										</td>
-																										<td v-for="value in agg.keys" data-aid="playbook_grouped_instantinsights_aggregate_answer">
-																											{{ translateValue(value) }}<span class="resolved-host" v-if="$root.pickHostname(value)"> - {{ $root.pickHostname(value) }}</span>
-																										</td>
-																									</tr>
-																									<tr v-if="question.answers && question.answers.length === 0">
-																										<td colspan="100%" class="text-center" data-aid="playbook_grouped_instantinsights_aggregate_nodata">
-																											{{ question.error ? i18n.error : i18n.noData }}
-																										</td>
-																									</tr>
-																								</tbody>
-																							</table>
-																							<table v-else class="simple-table">
-																								<thead>
-																									<tr>
-																										<th data-aid="playbook_grouped_instantinsights_header_timestamp">
-																											{{ i18n.timestamp }}
-																										</th>
-																										<th v-for="field in question.fields" :key="field" :data-aid="'playbook_grouped_instantinsights_header_' + field">
-																											{{ field }}
-																										</th>
-																									</tr>
-																								</thead>
-																								<tbody>
-																									<tr v-for="answer in question.answers" :key="answer.id">
-																										<td class="text-normal" data-aid="playbook_grouped_instantinsights_result_timestamp">
-																											{{ formatTimestamp(getEventTimestamp(answer.payload)) }}
-																										</td>
-																										<td v-for="field in question.fields" :key="field" data-aid="playbook_grouped_instantinsights_result">
-																											{{ translateValue(getEventField(answer.payload, field)) }}<span class="resolved-host" v-if="$root.pickHostname(getEventField(answer.payload, field))"> - {{ $root.pickHostname(getEventField(answer.payload, field)) }}</span>
-																										</td>
-																									</tr>
-																									<tr v-if="question.answers && question.answers.length === 0">
-																										<td colspan="100%" class="text-center" data-aid="playbook_grouped_instantinsights_nodata">
-																											{{ question.error ? i18n.error : i18n.noData }}
-																										</td>
-																									</tr>
-																								</tbody>
-																							</table>
-																						</template>
-																					</v-expansion-panel-text>
-																				</v-expansion-panel>
-																			</template>
+																		<v-expansion-panels @update:model-value="expandedPlaybookQuestions[item._index] = $event" :model-value="expandedPlaybookQuestions[item._index]" variant="accordion" multiple static="true">
+																			<v-expansion-panel v-for="question in item.newest.questions">
+																				<v-expansion-panel-title :class="['italic', 'ws-normal', 'spacious-lines', 'font-weight-bold', pickQuestionColor(question)]" #default="{ expanded }">
+																					<v-icon class="theme-icon mx-4" data-aid="playbook_grouped_question_title">
+																						<template v-if="expanded">fa-angle-down</template>
+																						<template v-else>fa-angle-right</template>
+																					</v-icon>
+																					{{question.question}}
+																				</v-expansion-panel-title>
+																				<v-expansion-panel-text class="pl-13 ws-normal">
+																					<div class="font-weight-bold font-italic" data-aid="playbook_grouped_question_context_label">{{i18n.context}}</div>
+																					<div class="italic" data-aid="playbook_grouped_question_context">{{question.context}}</div>
+																					<div class="italic my-4" data-aid="playbook_grouped_question_daterange">{{i18n.dateRange}}: {{question.range || i18n.event}}</div>
+																					<v-row no-gutters class="mb-5">
+																						<v-col cols="auto">
+																							<v-btn id="hunt-question" icon size="small" variant="text" :href="$router.resolve(buildHuntQuestionParams(question, item.newest)).href" target="_blank" class="cursor-pointer" data-aid="playbook_grouped_hunt_question">
+																								<v-icon>fa-crosshairs</v-icon>
+																							</v-btn>
+																						</v-col>
+																						<v-col style="align-content: center;" data-aid="playbook_grouped_question_query">
+																							{{ question.filledOQL }}
+																						</v-col>
+																					</v-row>
+																					<template v-if="question.answers">
+																						<span class="font-weight-bold font-italic">
+																							{{ i18n.instantInsight }}
+																						</span>
+																						<br/>
+																						<span class="italic" data-aid="playbook_grouped_event_timestamp">
+																							{{ i18n.eventOccurredAt }} {{ formatTimestamp(getEventTimestamp(item.newest)) }}
+																						</span>
+																						<table v-if="question.isAggregate" class="simple-table">
+																							<thead>
+																								<tr>
+																									<th data-aid="playbook_grouped_instantinsights_aggregate_header_count">
+																										{{ i18n.count }}
+																									</th>
+																									<th v-for="field in question.fields" :key="field" :data-aid="'playbook_grouped_instantinsights_aggregate_header_' + field">
+																										{{ field }}
+																									</th>
+																								</tr>
+																							</thead>
+																							<tbody>
+																								<tr v-for="agg in question.answers">
+																									<td class="text-right" data-aid="playbook_grouped_instantinsights_aggregate_answer_count">
+																										{{ agg.value }}
+																									</td>
+																									<td v-for="value in agg.keys" data-aid="playbook_grouped_instantinsights_aggregate_answer">
+																										{{ translateValue(value) }}<span class="resolved-host" v-if="$root.pickHostname(value)"> - {{ $root.pickHostname(value) }}</span>
+																									</td>
+																								</tr>
+																								<tr v-if="question.answers && question.answers.length === 0">
+																									<td colspan="100%" class="text-center" data-aid="playbook_grouped_instantinsights_aggregate_nodata">
+																										{{ question.error ? i18n.error : i18n.noData }}
+																									</td>
+																								</tr>
+																							</tbody>
+																						</table>
+																						<table v-else class="simple-table">
+																							<thead>
+																								<tr>
+																									<th data-aid="playbook_grouped_instantinsights_header_timestamp">
+																										{{ i18n.timestamp }}
+																									</th>
+																									<th v-for="field in question.fields" :key="field" :data-aid="'playbook_grouped_instantinsights_header_' + field">
+																										{{ field }}
+																									</th>
+																								</tr>
+																							</thead>
+																							<tbody>
+																								<tr v-for="answer in question.answers" :key="answer.id">
+																									<td class="text-normal" data-aid="playbook_grouped_instantinsights_result_timestamp">
+																										{{ formatTimestamp(getEventTimestamp(answer.payload)) }}
+																									</td>
+																									<td v-for="field in question.fields" :key="field" data-aid="playbook_grouped_instantinsights_result">
+																										{{ translateValue(getEventField(answer.payload, field)) }}<span class="resolved-host" v-if="$root.pickHostname(getEventField(answer.payload, field))"> - {{ $root.pickHostname(getEventField(answer.payload, field)) }}</span>
+																									</td>
+																								</tr>
+																								<tr v-if="question.answers && question.answers.length === 0">
+																									<td colspan="100%" class="text-center" data-aid="playbook_grouped_instantinsights_nodata">
+																										{{ question.error ? i18n.error : i18n.noData }}
+																									</td>
+																								</tr>
+																							</tbody>
+																						</table>
+																					</template>
+																				</v-expansion-panel-text>
+																			</v-expansion-panel>
 																		</v-expansion-panels>
 																	</template>
 																	<template v-else-if="item.newest.playbookErr">
@@ -640,7 +638,7 @@
 									<tr>
 										<td :colspan="columns.length" class="px-0" :data-aid="'events_fields_' + category">
 											<div>
-												<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[item._index]" @update:model-value="if (activeTabs[item._index] === 'playbook') loadPlaybook(item);">
+												<v-tabs :height="isCategory('alerts') ? undefined : 0" v-model="activeTabs[item._index]" @update:model-value="if (activeTabs[item._index] === 'playbook') loadPlaybook(item, item._index);">
 													<v-tab id="alerts_alertsDetailTab" value="alert" :class="{ 'theme-primary': activeTabs[item._index] === 'alert' }" :style="{ 'width': (this.eventColumnWidth / 2) + 'px' }" data-aid="alerts_alertDetailsTab">
 														<v-icon class="tab-icon">fa-bell</v-icon>
 														<div class="d-none d-lg-block">{{i18n.alertDetails}}</div>
@@ -649,10 +647,10 @@
 														<v-icon class="tab-icon">fa-book</v-icon>
 														<div class="d-none d-lg-block">{{i18n.guidedAnalysis}}</div>
 														<template #append>
-															<v-btn class="ml-9" variant="text" size="small" icon @click="toggleAllQuestions(item, index, false)" aria-label="collapse all" data-aid="alerts_playbooks_collapseAll">
+															<v-btn class="ml-9" variant="text" size="small" icon @click="toggleAllQuestions(item, item._index, false)" aria-label="collapse all" data-aid="alerts_playbooks_collapseAll">
 																<v-icon>fa-window-minimize</v-icon>
 															</v-btn>
-															<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item, index, true)" aria-label="expand all" data-aid="alerts_playbooks_expandAll">
+															<v-btn variant="text" size="small" icon @click="toggleAllQuestions(item, item._index, true)" aria-label="expand all" data-aid="alerts_playbooks_expandAll">
 																<v-icon>fa-window-maximize</v-icon>
 															</v-btn>
 														</template>
@@ -687,96 +685,94 @@
 																<v-icon class="mr-3" data-aid="playbook_ai_indicator">fa-flask</v-icon>
 																<span v-html="i18n.playbooksAi" data-aid="playbook_ai_text"></span>
 															</div>
-															<v-expansion-panels @update:model-value="expandedPlaybookQuestions[index] = $event" :model-value="expandedPlaybookQuestions[index]" variant="accordion" multiple static="true">
-																<template v-for="playbook in item.playbooks">
-																	<v-expansion-panel v-for="question in playbook.questions">
-																		<v-expansion-panel-title class="italic ws-normal spacious-lines" #default="{ expanded }">
-																			<v-icon class="theme-icon mx-4" data-aid="playbook_question_title">
-																				<template v-if="expanded">fa-angle-down</template>
-																				<template v-else>fa-angle-right</template>
-																			</v-icon>
-																			{{question.question}}
-																		</v-expansion-panel-title>
-																		<v-expansion-panel-text class="pl-13 ws-normal">
-																			<div class="font-weight-bold font-italic" data-aid="playbook_question_context_label">{{i18n.context}}</div>
-																			<div class="italic" data-aid="playbook_question_context">{{question.context}}</div>
-																			<div class="italic my-4" data-aid="playbook_question_daterange">{{i18n.dateRange}}: {{question.range || i18n.event}}</div>
-																			<v-row no-gutters class="mb-5">
-																				<v-col cols="auto">
-																					<v-btn id="hunt-question" icon size="small" variant="text" :href="$router.resolve(buildHuntQuestionParams(question, item)).href" target="_blank" class="cursor-pointer" data-aid="playbook_hunt_question">
-																						<v-icon>fa-crosshairs</v-icon>
-																					</v-btn>
-																				</v-col>
-																				<v-col style="align-content: center;" data-aid="playbook_question_query">
-																					{{question.filledOQL}}
-																				</v-col>
-																			</v-row>
-																			<template v-if="question.answers">
-																				<span class="font-weight-bold font-italic">
-																					{{i18n.instantInsight}}
-																				</span>
-																				<br/>
-																				<span class="italic" data-aid="playbook_event_timestamp">
-																					{{i18n.eventOccurredAt}} {{ formatTimestamp(getEventTimestamp(item)) }}
-																				</span>
-																				<table v-if="question.isAggregate" class="simple-table">
-																					<thead>
-																						<tr>
-																							<th data-aid="playbook_instantinsights_aggregate_header_count">
-																								{{ i18n.count }}
-																							</th>
-																							<th v-for="field in question.fields" :key="field" :data-aid="'playbook_instantinsights_aggregate_header_' + field">
-																								{{ field }}
-																							</th>
-																						</tr>
-																					</thead>
-																					<tbody>
-																						<tr v-for="agg in question.answers">
-																							<td class="text-right" data-aid="playbook_instantinsights_aggregate_answer_count">
-																								{{ agg.value }}
-																							</td>
-																							<td v-for="value in agg.keys" data-aid="playbook_instantinsights_aggregate_answer">
-																								{{ translateValue(value) }}<span class="resolved-host" v-if="$root.pickHostname(value)"> - {{ $root.pickHostname(value) }}</span>
-																							</td>
-																						</tr>
-																						<tr v-if="question.answers && question.answers.length === 0">
-																							<td colspan="100%" class="text-center" data-aid="playbook_instantinsights_aggregate_nodata">
-																								{{ question.error ? i18n.error : i18n.noData }}
-																							</td>
-																						</tr>
-																					</tbody>
-																				</table>
-																				<table v-else class="simple-table">
-																					<thead>
-																						<tr>
-																							<th data-aid="playbook_instantinsights_header_timestamp">
-																								{{ i18n.timestamp }}
-																							</th>
-																							<th v-for="field in question.fields" :key="field" :data-aid="'playbook_instantinsights_header_' + field">
-																								{{ field }}
-																							</th>
-																						</tr>
-																					</thead>
-																					<tbody>
-																						<tr v-for="answer in question.answers" :key="answer.id">
-																							<td class="text-normal" data-aid="playbook_instantinsights_result_timestamp">
-																								{{ formatTimestamp(getEventTimestamp(answer.payload)) }}
-																							</td>
-																							<td v-for="field in question.fields" :key="field" data-aid="playbook_instantinsights_result">
-																								{{ translateValue(getEventField(answer.payload, field)) }}<span class="resolved-host" v-if="$root.pickHostname(getEventField(answer.payload, field))"> - {{ $root.pickHostname(getEventField(answer.payload, field)) }}</span>
-																							</td>
-																						</tr>
-																						<tr v-if="question.answers && question.answers.length === 0">
-																							<td colspan="100%" class="text-center" data-aid="playbook_instantinsights_nodata">
-																								{{ question.error ? i18n.error : i18n.noData }}
-																							</td>
-																						</tr>
-																					</tbody>
-																				</table>
-																			</template>
-																		</v-expansion-panel-text>
-																	</v-expansion-panel>
-																</template>
+															<v-expansion-panels @update:model-value="expandedPlaybookQuestions[item._index] = $event" :model-value="expandedPlaybookQuestions[item._index]" variant="accordion" multiple static="true">
+																<v-expansion-panel v-for="question in item.questions">
+																	<v-expansion-panel-title :class="['italic', 'ws-normal', 'spacious-lines', 'font-weight-bold', pickQuestionColor(question)]" #default="{ expanded }">
+																		<v-icon class="theme-icon mx-4" data-aid="playbook_question_title">
+																			<template v-if="expanded">fa-angle-down</template>
+																			<template v-else>fa-angle-right</template>
+																		</v-icon>
+																		{{question.question}}
+																	</v-expansion-panel-title>
+																	<v-expansion-panel-text class="pl-13 ws-normal">
+																		<div class="font-weight-bold font-italic" data-aid="playbook_question_context_label">{{i18n.context}}</div>
+																		<div class="italic" data-aid="playbook_question_context">{{question.context}}</div>
+																		<div class="italic my-4" data-aid="playbook_question_daterange">{{i18n.dateRange}}: {{question.range || i18n.event}}</div>
+																		<v-row no-gutters class="mb-5">
+																			<v-col cols="auto">
+																				<v-btn id="hunt-question" icon size="small" variant="text" :href="$router.resolve(buildHuntQuestionParams(question, item)).href" target="_blank" class="cursor-pointer" data-aid="playbook_hunt_question">
+																					<v-icon>fa-crosshairs</v-icon>
+																				</v-btn>
+																			</v-col>
+																			<v-col style="align-content: center;" data-aid="playbook_question_query">
+																				{{question.filledOQL}}
+																			</v-col>
+																		</v-row>
+																		<template v-if="question.answers">
+																			<span class="font-weight-bold font-italic">
+																				{{i18n.instantInsight}}
+																			</span>
+																			<br/>
+																			<span class="italic" data-aid="playbook_event_timestamp">
+																				{{i18n.eventOccurredAt}} {{ formatTimestamp(getEventTimestamp(item)) }}
+																			</span>
+																			<table v-if="question.isAggregate" class="simple-table">
+																				<thead>
+																					<tr>
+																						<th data-aid="playbook_instantinsights_aggregate_header_count">
+																							{{ i18n.count }}
+																						</th>
+																						<th v-for="field in question.fields" :key="field" :data-aid="'playbook_instantinsights_aggregate_header_' + field">
+																							{{ field }}
+																						</th>
+																					</tr>
+																				</thead>
+																				<tbody>
+																					<tr v-for="agg in question.answers">
+																						<td class="text-right" data-aid="playbook_instantinsights_aggregate_answer_count">
+																							{{ agg.value }}
+																						</td>
+																						<td v-for="value in agg.keys" data-aid="playbook_instantinsights_aggregate_answer">
+																							{{ translateValue(value) }}<span class="resolved-host" v-if="$root.pickHostname(value)"> - {{ $root.pickHostname(value) }}</span>
+																						</td>
+																					</tr>
+																					<tr v-if="question.answers && question.answers.length === 0">
+																						<td colspan="100%" class="text-center" data-aid="playbook_instantinsights_aggregate_nodata">
+																							{{ question.error ? i18n.error : i18n.noData }}
+																						</td>
+																					</tr>
+																				</tbody>
+																			</table>
+																			<table v-else class="simple-table">
+																				<thead>
+																					<tr>
+																						<th data-aid="playbook_instantinsights_header_timestamp">
+																							{{ i18n.timestamp }}
+																						</th>
+																						<th v-for="field in question.fields" :key="field" :data-aid="'playbook_instantinsights_header_' + field">
+																							{{ field }}
+																						</th>
+																					</tr>
+																				</thead>
+																				<tbody>
+																					<tr v-for="answer in question.answers" :key="answer.id">
+																						<td class="text-normal" data-aid="playbook_instantinsights_result_timestamp">
+																							{{ formatTimestamp(getEventTimestamp(answer.payload)) }}
+																						</td>
+																						<td v-for="field in question.fields" :key="field" data-aid="playbook_instantinsights_result">
+																							{{ translateValue(getEventField(answer.payload, field)) }}<span class="resolved-host" v-if="$root.pickHostname(getEventField(answer.payload, field))"> - {{ $root.pickHostname(getEventField(answer.payload, field)) }}</span>
+																						</td>
+																					</tr>
+																					<tr v-if="question.answers && question.answers.length === 0">
+																						<td colspan="100%" class="text-center" data-aid="playbook_instantinsights_nodata">
+																							{{ question.error ? i18n.error : i18n.noData }}
+																						</td>
+																					</tr>
+																				</tbody>
+																			</table>
+																		</template>
+																	</v-expansion-panel-text>
+																</v-expansion-panel>
 															</v-expansion-panels>
 														</template>
 														<template v-else-if="item.playbookErr">


### PR DESCRIPTION
Sort questions by the results after running all their queries. First questions that retrieved data (marked in blue, #2196F3), then questions with no data (marked in orange, #FF9800), then questions with errors (marked in red, #FF0000). The sort is stable but will not respect playbook boundaries.