### PR TITLE
Wait for questions

### DIFF
--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -376,7 +376,7 @@
 																	</v-data-table>
 																</v-tabs-window-item>
 																<v-tabs-window-item value="playbook">
-																	<template v-if="item.newest.playbooks">
+																	<template v-if="item.newest.questions">
 																		<div class="playbook-ai-warning">
 																			<v-icon class="mr-3" data-aid="playbook_grouped_ai_indicator">fa-flask</v-icon>
 																			<span v-html="i18n.playbooksAi"  data-aid="playbook_grouped_ai_text"></span>

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -680,7 +680,7 @@
 														</v-data-table>
 													</v-tabs-window-item>
 													<v-tabs-window-item value="playbook">
-														<template v-if="item.playbooks">
+														<template v-if="item.questions">
 															<div class="playbook-ai-warning theme-background-lighten-1">
 																<v-icon class="mr-3" data-aid="playbook_ai_indicator">fa-flask</v-icon>
 																<span v-html="i18n.playbooksAi" data-aid="playbook_ai_text"></span>


### PR DESCRIPTION
After updating to sort playbook questions, the UI was looking at the wrong field to know when they'll be available to show. Now the loading circle stays visible until the questions are completely ready.