### PR TITLE
Improve FetchNewestEvent

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -3037,6 +3037,13 @@ const huntComponent = {
 
       let parts = [];
 
+      if (this.queryBaseFilter) parts.push(this.queryBaseFilter);
+
+      this.obtainQueryDetails();
+      if (this.querySearch) {
+        parts.push(`(${this.querySearch})`);
+      }
+
       for (let field in item) {
         let label = field;
         if (field.startsWith('_')) continue;

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -2108,6 +2108,7 @@ test('fetchNewestEvent', async () => {
       enabled: false,
     },
   ];
+  comp.queryBaseFilter = 'tags:alert';
   comp.dateRange = 'x - y';
   comp.zone = 'zone';
 
@@ -2125,7 +2126,7 @@ test('fetchNewestEvent', async () => {
   expect(eventSearch).toHaveBeenCalledTimes(1);
   expect(eventSearch).toHaveBeenCalledWith('events/', {
     params: {
-      query: 'a:"1" AND b:"2" AND c:"true" AND NOT event.acknowledged:true AND NOT event.escalated:true | sortby @timestamp',
+      query: 'tags:alert AND a:"1" AND b:"2" AND c:"true" AND NOT event.acknowledged:true AND NOT event.escalated:true | sortby @timestamp',
       range: 'x - y',
       format: comp.i18n.timePickerSample,
       zone: 'zone',
@@ -2136,6 +2137,8 @@ test('fetchNewestEvent', async () => {
 
   comp.filterToggles[0].enabled = true;
   comp.filterToggles[1].enabled = true;
+  comp.queryBaseFilter = '';
+  comp.query = '* AND source.ip:10.67.100.14 | groupby rule.name';
   delete item.newest;
   resetPapi();
   const eventSearch2 = mockPapi('get', { data: { events: [{ id: '100', payload: { a: 1, b: "2", c: true } }] } });
@@ -2147,7 +2150,7 @@ test('fetchNewestEvent', async () => {
   expect(eventSearch2).toHaveBeenCalledTimes(1);
   expect(eventSearch2).toHaveBeenCalledWith('events/', {
     params: {
-      query: 'a:"1" AND b:"2" AND c:"true" AND event.acknowledged:true AND event.escalated:true | sortby @timestamp',
+      query: '(* AND source.ip:10.67.100.14) AND a:"1" AND b:"2" AND c:"true" AND event.acknowledged:true AND event.escalated:true | sortby @timestamp',
       range: 'x - y',
       format: comp.i18n.timePickerSample,
       zone: 'zone',


### PR DESCRIPTION
Include the queryBaseFilter (i.e. `tags:alert`) so that the events returned are all alerts. Include the custom query specified by the user but don't include any groupbys. Update tests.