### PR TITLE
Changes to Reverse Lookup

### DIFF
--- a/config/serverconfig.go
+++ b/config/serverconfig.go
@@ -47,6 +47,7 @@ type ServerConfig struct {
 	SrvExpSeconds           int                    `json:"srvExpSeconds"`
 	Subgrids                []*model.Subgrid       `json:"subgrids"`
 	CustomReportsPath       string                 `json:"customReportsPath"`
+	EnableReverseLookup     bool                   `json:"enableReverseLookup"`
 	SrvKeyBytes             []byte
 }
 

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -183,7 +183,6 @@ $(document).ready(function () {
           maximizedCancelFn: null,
           licenseKey: null,
           licenseStatus: null,
-          enableReverseLookup: false,
           ip2host: {},
           securitySettingsAlreadyChecked: false,
           forceUserOtp: false,
@@ -469,7 +468,6 @@ $(document).ready(function () {
                   this.parameters = response.data.parameters;
                   this.elasticVersion = response.data.elasticVersion;
                   this.timezones = response.data.timezones;
-                  this.enableReverseLookup = response.data.parameters.enableReverseLookup;
                   this.subgrids = response.data.subgrids;
                   this.exportNodeId = response.data.parameters.exportNodeId;
                   this.customReports = response.data.customReports;
@@ -1477,12 +1475,9 @@ $(document).ready(function () {
           }
         },
         batchLookup(ips, comp) {
-          if (!this.enableReverseLookup) {
-            return;
-          }
-
           ips = ips.filter(ip => (this.isIPv4(ip) || this.isIPv6(ip)) && !this.ip2host[ip]);
           if (ips.length) {
+            ips = [...new Set(ips)];
             ips.forEach(ip => this.ip2host[ip] = []);
             const route = this;
 
@@ -1526,10 +1521,6 @@ $(document).ready(function () {
           return b === true || ("" + b).toLowerCase() == "true";
         },
         pickHostname(ip) {
-          if (!this.enableReverseLookup) {
-            return '';
-          }
-
           const arr = this.ip2host[ip];
           if (arr && arr.length) {
             const names = this.ip2host[ip].filter(host => host != ip);

--- a/model/clientparameters.go
+++ b/model/clientparameters.go
@@ -16,28 +16,27 @@ const DEFAULT_CHART_LABEL_OTHER_LIMIT = 10
 const DEFAULT_CHART_LABEL_FIELD_SEPARATOR = ", "
 
 type ClientParameters struct {
-	HuntingParams       HuntingParameters    `json:"hunt"`
-	AlertingParams      AlertingParameters   `json:"alerts"`
-	CasesParams         HuntingParameters    `json:"cases"`
-	CaseParams          CaseParameters       `json:"case"`
-	DashboardsParams    HuntingParameters    `json:"dashboards"`
-	JobParams           HuntingParameters    `json:"job"`
-	DetectionsParams    DetectionsParameters `json:"detections"`
-	DetectionParams     DetectionParameters  `json:"detection"`
-	DocsUrl             string               `json:"docsUrl"`
-	CheatsheetUrl       string               `json:"cheatsheetUrl"`
-	ReleaseNotesUrl     string               `json:"releaseNotesUrl"`
-	GridParams          GridParameters       `json:"grid"`
-	WebSocketTimeoutMs  int                  `json:"webSocketTimeoutMs"`
-	TipTimeoutMs        int                  `json:"tipTimeoutMs"`
-	ApiTimeoutMs        int                  `json:"apiTimeoutMs"`
-	CacheExpirationMs   int                  `json:"cacheExpirationMs"`
-	InactiveTools       []string             `json:"inactiveTools"`
-	Tools               []ClientTool         `json:"tools"`
-	CasesEnabled        bool                 `json:"casesEnabled"`
-	EnableReverseLookup bool                 `json:"enableReverseLookup"`
-	DetectionsEnabled   bool                 `json:"detectionsEnabled"`
-	ExportNodeId        string               `json:"exportNodeId"`
+	HuntingParams      HuntingParameters    `json:"hunt"`
+	AlertingParams     AlertingParameters   `json:"alerts"`
+	CasesParams        HuntingParameters    `json:"cases"`
+	CaseParams         CaseParameters       `json:"case"`
+	DashboardsParams   HuntingParameters    `json:"dashboards"`
+	JobParams          HuntingParameters    `json:"job"`
+	DetectionsParams   DetectionsParameters `json:"detections"`
+	DetectionParams    DetectionParameters  `json:"detection"`
+	DocsUrl            string               `json:"docsUrl"`
+	CheatsheetUrl      string               `json:"cheatsheetUrl"`
+	ReleaseNotesUrl    string               `json:"releaseNotesUrl"`
+	GridParams         GridParameters       `json:"grid"`
+	WebSocketTimeoutMs int                  `json:"webSocketTimeoutMs"`
+	TipTimeoutMs       int                  `json:"tipTimeoutMs"`
+	ApiTimeoutMs       int                  `json:"apiTimeoutMs"`
+	CacheExpirationMs  int                  `json:"cacheExpirationMs"`
+	InactiveTools      []string             `json:"inactiveTools"`
+	Tools              []ClientTool         `json:"tools"`
+	CasesEnabled       bool                 `json:"casesEnabled"`
+	DetectionsEnabled  bool                 `json:"detectionsEnabled"`
+	ExportNodeId       string               `json:"exportNodeId"`
 }
 
 func (config *ClientParameters) Verify() error {

--- a/server/utilhandler.go
+++ b/server/utilhandler.go
@@ -133,63 +133,67 @@ func (h *UtilHandler) PutReverseLookup(w http.ResponseWriter, r *http.Request) {
 		"esSearchTimeInMS": result.ElapsedMs,
 	}).Info("completed ES lookup")
 
-	// build list of IPs to lookup with DNS
-	ips := make([]string, 0, len(dedup))
-	for ip := range dedup {
-		ips = append(ips, ip)
-	}
+	if h.server.Config.EnableReverseLookup {
+		// build list of IPs to lookup with DNS
+		ips := make([]string, 0, len(dedup))
+		for ip := range dedup {
+			ips = append(ips, ip)
+		}
 
-	if len(ips) != 0 {
-		logger.WithField("ipsToLookup", len(ips)).Info("starting DNS lookup")
+		if len(ips) != 0 {
+			logger.WithField("ipsToLookup", len(ips)).Info("starting DNS lookup")
 
-		var resolver *net.Resolver
+			var resolver *net.Resolver
 
-		if h.server.Config.Dns != "" {
-			dnsServer := h.server.Config.Dns
+			if h.server.Config.Dns != "" {
+				dnsServer := h.server.Config.Dns
 
-			_, _, err = net.SplitHostPort(dnsServer)
-			if err != nil && err.Error() == "missing port in address" {
-				dnsServer = net.JoinHostPort(dnsServer, "53")
-				err = nil
-			}
+				_, _, err = net.SplitHostPort(dnsServer)
+				if err != nil && err.Error() == "missing port in address" {
+					dnsServer = net.JoinHostPort(dnsServer, "53")
+					err = nil
+				}
 
-			if err == nil {
-				resolver = &net.Resolver{
-					PreferGo: true,
-					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-						d := net.Dialer{
-							Timeout: time.Millisecond * time.Duration(3000),
-						}
-						return d.DialContext(ctx, network, dnsServer)
-					},
+				if err == nil {
+					resolver = &net.Resolver{
+						PreferGo: true,
+						Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+							d := net.Dialer{
+								Timeout: time.Millisecond * time.Duration(3000),
+							}
+							return d.DialContext(ctx, network, dnsServer)
+						},
+					}
 				}
 			}
-		}
 
-		if resolver == nil {
-			resolver = net.DefaultResolver
-		}
-
-		mapLock := sync.Mutex{}
-		resolved := int32(0)
-
-		lop.ForEach(ips, func(ip string, _ int) {
-			addrs, err := resolver.LookupAddr(ctx, ip)
-			if err != nil && !strings.Contains(err.Error(), "Name or service not known") {
-				logger.WithField("ip", ip).WithError(err).Warn("Failed to lookup address")
-			}
-			if len(addrs) == 0 {
-				addrs = []string{ip}
-			} else {
-				atomic.AddInt32(&resolved, 1)
+			if resolver == nil {
+				resolver = net.DefaultResolver
 			}
 
-			mapLock.Lock()
-			results[ip] = addrs
-			mapLock.Unlock()
-		})
+			mapLock := sync.Mutex{}
+			resolved := int32(0)
 
-		logger.WithField("ipsResolvedByDNS", resolved).Info("completed DNS lookup")
+			lop.ForEach(ips, func(ip string, _ int) {
+				addrs, err := resolver.LookupAddr(ctx, ip)
+				if err != nil && !strings.Contains(err.Error(), "Name or service not known") {
+					logger.WithField("ip", ip).WithError(err).Warn("Failed to lookup address")
+				}
+				if len(addrs) == 0 {
+					addrs = []string{ip}
+				} else {
+					atomic.AddInt32(&resolved, 1)
+				}
+
+				mapLock.Lock()
+				results[ip] = addrs
+				mapLock.Unlock()
+			})
+
+			logger.WithField("ipsResolvedByDNS", resolved).Info("completed DNS lookup")
+		}
+	} else {
+		logger.Info("skipping DNS lookup, reverse lookup is disabled")
 	}
 
 	web.Respond(w, r, http.StatusOK, results)

--- a/server/utilhandler_test.go
+++ b/server/utilhandler_test.go
@@ -23,58 +23,77 @@ import (
 )
 
 func TestReverseLookupHandler(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	cfg := &config.ServerConfig{
-		Dns: "",
+	tests := []struct {
+		Name                string
+		EnableReverseLookup bool
+		ExpectedResults     int
+	}{
+		{
+			Name:                "No DNS",
+			EnableReverseLookup: false,
+			ExpectedResults:     1,
+		},
+		{
+			Name:                "With DNS",
+			EnableReverseLookup: true,
+			ExpectedResults:     4,
+		},
 	}
 
-	srv := NewMockServer(t, ctrl, cfg)
+	for _, test := range tests {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	h := NewUtilHandler(srv)
+		cfg := &config.ServerConfig{
+			EnableReverseLookup: test.EnableReverseLookup,
+		}
 
-	fakeEventStore := srv.Eventstore.(*FakeEventstore)
+		srv := NewMockServer(t, ctrl, cfg)
 
-	fakeEventStore.MSearchResults = append(fakeEventStore.MSearchResults, &model.EventMSearchResults{
-		Responses: []*model.EventSearchResults{
-			{},
-			{},
-			{},
-			{
-				Events: []*model.EventRecord{
-					{
-						Payload: map[string]interface{}{
-							"so.ip_address":  "4.0.0.4",
-							"so.description": "host4",
+		h := NewUtilHandler(srv)
+
+		fakeEventStore := srv.Eventstore.(*FakeEventstore)
+
+		fakeEventStore.MSearchResults = append(fakeEventStore.MSearchResults, &model.EventMSearchResults{
+			Responses: []*model.EventSearchResults{
+				{},
+				{},
+				{},
+				{
+					Events: []*model.EventRecord{
+						{
+							Payload: map[string]interface{}{
+								"so.ip_address":  "4.0.0.4",
+								"so.description": "host4",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 
-	body := []byte(`["1.0.0.1", "2.0.0.2", "3.0.0.3", "4.0.0.4", "badip"]`)
+		body := []byte(`["1.0.0.1", "2.0.0.2", "3.0.0.3", "4.0.0.4", "badip"]`)
 
-	r := httptest.NewRequest("PUT", "/reverse-lookup", bytes.NewReader(body))
+		r := httptest.NewRequest("PUT", "/reverse-lookup", bytes.NewReader(body))
 
-	ctx := context.WithValue(context.Background(), web.ContextKeyRequestStart, time.Now())
-	r = r.WithContext(ctx)
+		ctx := context.WithValue(context.Background(), web.ContextKeyRequestStart, time.Now())
+		r = r.WithContext(ctx)
 
-	w := httptest.NewRecorder()
+		w := httptest.NewRecorder()
 
-	h.PutReverseLookup(w, r)
+		h.PutReverseLookup(w, r)
 
-	raw := w.Body.Bytes()
-	results := map[string][]string{}
+		raw := w.Body.Bytes()
+		results := map[string][]string{}
 
-	err := json.Unmarshal(raw, &results)
-	assert.NoError(t, err)
+		err := json.Unmarshal(raw, &results)
+		assert.NoError(t, err)
 
-	assert.Equal(t, 4, len(results))
-	for _, names := range results {
-		assert.NotEmpty(t, names)
+		assert.Equal(t, test.ExpectedResults, len(results))
+		for _, names := range results {
+			assert.NotEmpty(t, names)
+		}
+
+		assert.Equal(t, []string{"host4"}, results["4.0.0.4"])
 	}
-
-	assert.Equal(t, []string{"host4"}, results["4.0.0.4"])
 }


### PR DESCRIPTION
UI will now always do reverse lookup. The UI also now dedupe IPs before sending. In one observed instance, it reduced duplicates from ~1700 to 42.

Moved EnableReverseLookup from ClientParams to ServerConfig.

The utilhandler has been updated to always check against ES, but to only hit DNS when the setting is enabled.