### PR TITLE
Remove empty/corrupted files

### DIFF
--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -575,7 +575,13 @@ func (e *ElastAlertEngine) SyncLocalDetections(ctx context.Context, detections [
 
 			err = e.WriteFile(path, []byte(wrapped), 0644)
 			if err != nil {
-				errMap[det.PublicID] = fmt.Sprintf("unable to write enabled detection file: %s", err)
+				// Attempt to clean up the potentially corrupted file
+				deleteErr := e.DeleteFile(path)
+				if deleteErr != nil && !os.IsNotExist(deleteErr) {
+					errMap[det.PublicID] = fmt.Sprintf("unable to write enabled detection file (%s) and cleanup failed (%s)", err, deleteErr)
+				} else {
+					errMap[det.PublicID] = fmt.Sprintf("unable to write enabled detection file: %s", err)
+				}
 				continue
 			}
 		} else {
@@ -1354,7 +1360,13 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 
 			err = e.WriteFile(path, []byte(rule), 0644)
 			if err != nil {
-				errMap[detect.PublicID] = fmt.Errorf("unable to write enabled detection file: %s", err)
+				// Attempt to clean up the potentially corrupted file
+				deleteErr := e.DeleteFile(path)
+				if deleteErr != nil && !os.IsNotExist(deleteErr) {
+					errMap[detect.PublicID] = fmt.Errorf("unable to write enabled detection file (%s) and cleanup failed (%s)", err, deleteErr)
+				} else {
+					errMap[detect.PublicID] = fmt.Errorf("unable to write enabled detection file: %s", err)
+				}
 				continue
 			}
 		} else if path != "" {

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -573,15 +573,9 @@ func (e *ElastAlertEngine) SyncLocalDetections(ctx context.Context, detections [
 				continue
 			}
 
-			err = e.WriteFile(path, []byte(wrapped), 0644)
+			err = e.writeFileWithCleanup(path, []byte(wrapped), 0644)
 			if err != nil {
-				// Attempt to clean up the potentially corrupted file
-				deleteErr := e.DeleteFile(path)
-				if deleteErr != nil && !os.IsNotExist(deleteErr) {
-					errMap[det.PublicID] = fmt.Sprintf("unable to write enabled detection file (%s) and cleanup failed (%s)", err, deleteErr)
-				} else {
-					errMap[det.PublicID] = fmt.Sprintf("unable to write enabled detection file: %s", err)
-				}
+				errMap[det.PublicID] = err.Error()
 				continue
 			}
 		} else {
@@ -1358,15 +1352,9 @@ func (e *ElastAlertEngine) syncCommunityDetections(ctx context.Context, logger *
 				path = filepath.Join(e.elastAlertRulesFolder, fmt.Sprintf("%s.yml", name))
 			}
 
-			err = e.WriteFile(path, []byte(rule), 0644)
+			err = e.writeFileWithCleanup(path, []byte(rule), 0644)
 			if err != nil {
-				// Attempt to clean up the potentially corrupted file
-				deleteErr := e.DeleteFile(path)
-				if deleteErr != nil && !os.IsNotExist(deleteErr) {
-					errMap[detect.PublicID] = fmt.Errorf("unable to write enabled detection file (%s) and cleanup failed (%s)", err, deleteErr)
-				} else {
-					errMap[detect.PublicID] = fmt.Errorf("unable to write enabled detection file: %s", err)
-				}
+				errMap[detect.PublicID] = err
 				continue
 			}
 		} else if path != "" {
@@ -2177,4 +2165,18 @@ func (e *ElastAlertEngine) getDeployedPublicIds() (publicIds []string, err error
 	}
 
 	return publicIds, nil
+}
+
+// writeFileWithCleanup attempts to write a file and cleans up on failure
+func (e *ElastAlertEngine) writeFileWithCleanup(path string, data []byte, perm fs.FileMode) error {
+	err := e.WriteFile(path, data, perm)
+	if err != nil {
+		// Attempt to clean up the potentially corrupted file
+		deleteErr := e.DeleteFile(path)
+		if deleteErr != nil && !os.IsNotExist(deleteErr) {
+			return fmt.Errorf("unable to write enabled detection file (%s) and cleanup failed (%s)", err, deleteErr)
+		}
+		return fmt.Errorf("unable to write enabled detection file: %s", err)
+	}
+	return nil
 }

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -2557,3 +2557,72 @@ func TestSyncLocalExisting(t *testing.T) {
 
 	assert.Len(t, workItems, 0)
 }
+
+func TestWriteFileWithCleanup(t *testing.T) {
+	tests := []struct {
+		name          string
+		writeErr      error
+		deleteErr     error
+		expectedError string
+	}{
+		{
+			name:          "successful write",
+			writeErr:      nil,
+			deleteErr:     nil,
+			expectedError: "",
+		},
+		{
+			name:          "write fails, cleanup succeeds",
+			writeErr:      errors.New("disk full"),
+			deleteErr:     nil,
+			expectedError: "unable to write enabled detection file: disk full",
+		},
+		{
+			name:          "write fails, file doesn't exist for cleanup",
+			writeErr:      errors.New("permission denied"),
+			deleteErr:     os.ErrNotExist,
+			expectedError: "unable to write enabled detection file: permission denied",
+		},
+		{
+			name:          "write fails, cleanup also fails",
+			writeErr:      errors.New("disk full"),
+			deleteErr:     errors.New("permission denied"),
+			expectedError: "unable to write enabled detection file (disk full) and cleanup failed (permission denied)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockIOManager := mock.NewMockIOManager(ctrl)
+			
+			engine := &ElastAlertEngine{
+				IOManager: mockIOManager,
+			}
+
+			path := "/test/path.yml"
+			data := []byte("test data")
+			perm := fs.FileMode(0644)
+
+			// Setup expectations
+			mockIOManager.EXPECT().WriteFile(path, data, perm).Return(tt.writeErr)
+			
+			if tt.writeErr != nil {
+				mockIOManager.EXPECT().DeleteFile(path).Return(tt.deleteErr)
+			}
+
+			// Execute
+			err := engine.writeFileWithCleanup(path, data, perm)
+
+			// Verify
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Elastalert chokes on empty files. This PR attempts to remove any files that were created but for some reason failed to be written to. 