### PR TITLE
Fix Issues Found During Testing

### DIFF
--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -160,7 +160,16 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response, err := h.server.AssistantManager.ChatStream(ctx, messages)
+	noTimeOutCtx := context.Background()
+	val := ctx.Value(web.ContextKeyRunAsUsername)
+	if val != nil {
+		if username, ok := val.(string); ok {
+			noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRunAsUsername, username)
+		}
+	}
+	noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRequestorId, ctx.Value(web.ContextKeyRequestorId).(string))
+
+	response, err := h.server.AssistantManager.ChatStream(noTimeOutCtx, messages)
 	if err != nil {
 		logger.WithError(err).Error("unable to chat (stream) with assistant")
 		web.Respond(w, r, http.StatusInternalServerError, err)
@@ -175,15 +184,6 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-
-	noTimeOutCtx := context.Background()
-	val := ctx.Value(web.ContextKeyRunAsUsername)
-	if val != nil {
-		if username, ok := val.(string); ok {
-			noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRunAsUsername, username)
-		}
-	}
-	noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRequestorId, ctx.Value(web.ContextKeyRequestorId).(string))
 
 	go func() {
 		msg, err := unstreamResponse(string(entireResponse))
@@ -272,6 +272,8 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 	err = h.server.Assistantstore.SaveChat(ctx, toolMsg.PrepareForStorage(toolReq.SessionId, []string{"tool_result"}))
 	if err != nil {
 		logger.WithError(err).Error("unable to save tool result message")
+		web.Respond(w, r, http.StatusInternalServerError, err)
+
 		return
 	}
 

--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -411,6 +411,19 @@ func cleanupMessages(messages []*model.Message) []*model.Message {
 		m.StopReason = nil
 		m.StopSequence = nil
 		m.Usage = nil
+
+		// ToolUse-only messages, while given out by the AI, are not accepted by the AI
+		// add text to the ToolUse body to placate the AI's validation.
+		if m.Role == "assistant" && len(m.ContentBlocks) == 1 && m.ContentBlocks[0].Type == "tool_use" {
+			m.ContentBlocks[0].Text = "ToolUse"
+			m.ContentBlocks = append([]model.ContentBlock{
+				{
+					Type: "text",
+					Text: "ToolUse",
+				},
+			}, m.ContentBlocks...)
+		}
+
 		msgs = append(msgs, &m)
 	}
 

--- a/server/modules/assistant/assistant_test.go
+++ b/server/modules/assistant/assistant_test.go
@@ -618,6 +618,48 @@ func TestCleanupMessages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ToolUse w/out text",
+			inputMessages: []*model.Message{
+				{
+					Id:           "msg1",
+					Role:         "user",
+					StopReason:   stringPtr("stop"),
+					StopSequence: stringPtr("seq"),
+					Usage: &model.Usage{
+						InputTokens:  10,
+						OutputTokens: 20,
+					},
+					ContentBlocks: []model.ContentBlock{
+						{Type: "tool_use", Input: []byte(`{"param1": "value1"}`)},
+					},
+				},
+				{
+					Id:         "msg2",
+					Role:       "assistant",
+					StopReason: stringPtr("length"),
+					ContentBlocks: []model.ContentBlock{
+						{Type: "tool_use", Input: []byte(`{"param1": "value1"}`)},
+					},
+				},
+			},
+			expectedResults: []*model.Message{
+				{
+					Id:   "msg1",
+					Role: "user",
+					ContentBlocks: []model.ContentBlock{
+						{Type: "tool_use", Input: []byte(`{"param1": "value1"}`)},
+					},
+				},
+				{
+					Id:   "msg2",
+					Role: "assistant",
+					ContentBlocks: []model.ContentBlock{
+						{Type: "tool_use", Input: []byte(`{"param1": "value1"}`), Text: "ToolUse"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -209,9 +209,15 @@ func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, pa
 		for _, g := range groupbyResults {
 			var key any
 			for _, k := range g.Keys {
-				keys := k.([]any)
-				if len(keys) > 0 {
-					key = keys[0]
+				keys, ok := k.([]any)
+				if ok {
+					if len(keys) > 0 {
+						key = keys[0]
+						break
+					}
+				} else {
+					key = k
+					break
 				}
 			}
 

--- a/server/modules/elastic/elasticassistantstore.go
+++ b/server/modules/elastic/elasticassistantstore.go
@@ -161,6 +161,12 @@ func (store *ElasticAssistantstore) validateChat(chat *model.StoredMessage) erro
 			for _, cb := range chat.Message.ContentBlocks {
 				if cb.Type == "text" && cb.Text == "" {
 					err = fmt.Errorf("content block of type 'text' must have non-empty text")
+					break
+				}
+
+				if cb.Type == "" {
+					err = fmt.Errorf("every content block must have a type")
+					break
 				}
 			}
 		}
@@ -169,7 +175,7 @@ func (store *ElasticAssistantstore) validateChat(chat *model.StoredMessage) erro
 			contentCount++
 		}
 
-		if contentCount != 1 {
+		if contentCount != 1 && err == nil {
 			err = fmt.Errorf("message must have exactly one content type: either ContentBlocks or ContentStr")
 		}
 	}


### PR DESCRIPTION
Fix context usage when streaming response to ensure we receive entire response even if client disconnects.

Sometimes the AI sends ToolUse messages without text. When the conversation continues, the AI will complain that the message does not contain text. Refactored cleanupMessages to give those messages the text "ToolUse" so the conversation can continue. Updated tests.

Fix for query_events tool returning a 502.

New validation rule won't save a message if any contentblocks are missing a type.