### PR TITLE
Fix Light Mode Assistant Icon

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -3388,7 +3388,7 @@ const huntComponent = {
     getAIInvestigationButtonColor(item) {
       // Grouped alerts
       if (item.count) {
-        return 'white';
+        return '';
       }
       // For individual alerts, use soc_id as before
       const socId = item.soc_id;
@@ -3398,7 +3398,7 @@ const huntComponent = {
         return 'secondary';
       }
       // Not investigated
-      return 'white';
+      return '';
     },
 
     getAIInvestigationTooltip(item) {

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -2721,7 +2721,7 @@ test('getAIInvestigationButtonColor - individual alert not investigated', () => 
   comp.aiInvestigations = {};
 
   const color = comp.getAIInvestigationButtonColor(item);
-  expect(color).toBe('white');
+  expect(color).toBe('');
 });
 
 test('getAIInvestigationButtonColor - individual alert investigated', () => {
@@ -2738,7 +2738,7 @@ test('getAIInvestigationButtonColor - grouped alert', () => {
   const item = { count: 5 };
 
   const color = comp.getAIInvestigationButtonColor(item);
-  expect(color).toBe('white');
+  expect(color).toBe('');
 });
 
 test('getAIInvestigationTooltip - individual alert not investigated', () => {


### PR DESCRIPTION
In Alerts, the microchip icon was white-on-white in light mode. Not specifying a color allows the style to fallback to the proper color defined by the theme.