### PR TITLE
Health check during Balance

### DIFF
--- a/model/assistant.go
+++ b/model/assistant.go
@@ -243,7 +243,13 @@ type BalanceResponse struct {
 	// The status of the key used.
 	Status string `json:"status" example:"active"`
 	// The remaining credit balance.
-	Balance float64 `json:"credit_balance" example:"123000"`
+	Balance int64 `json:"credit_balance" example:"123000"`
+	// The health status of the service.
+	HealthStatus string `json:"health_status" example:"healthy"`
+}
+
+type HealthResponse struct {
+	Status string `json:"status"`
 }
 
 type ChatOpt func(*ChatConfig)

--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -376,6 +376,21 @@ func (h *AssistantHandler) GetBalance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	health, err := h.server.AssistantManager.Health(ctx)
+	if err != nil {
+		logger.WithError(err).Error("unable to get assistant health")
+		web.Respond(w, r, http.StatusInternalServerError, err)
+
+		return
+	}
+
+	if health == nil || health.Status == "" {
+		logger.WithField("healthResponse", health).Warn("assistant health response is nil or missing status")
+		web.Respond(w, r, http.StatusInternalServerError, nil)
+
+		return
+	}
+
 	response, err := h.server.AssistantManager.Balance(ctx)
 	if err != nil {
 		logger.WithError(err).Error("unable to chat with assistant")
@@ -383,6 +398,8 @@ func (h *AssistantHandler) GetBalance(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	response.HealthStatus = health.Status
 
 	web.Respond(w, r, http.StatusOK, response)
 }

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -403,6 +404,7 @@ func TestGetBalance(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// Set up mock expectations
+	mockManager.EXPECT().Health(gomock.Any()).Return(&model.HealthResponse{Status: "healthy"}, nil)
 	mockManager.EXPECT().Balance(gomock.Any()).Return(&model.BalanceResponse{Balance: 10000}, nil)
 
 	// Execute the handler
@@ -410,6 +412,48 @@ func TestGetBalance(t *testing.T) {
 
 	// Verify response
 	assert.Equal(t, http.StatusOK, w.Code)
+
+	// assert response value
+	var response model.BalanceResponse
+
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, int64(10000), response.Balance)
+	assert.Equal(t, "healthy", response.HealthStatus)
+}
+
+func TestGetBalanceUnhealthy(t *testing.T) {
+	// Create mock server
+	srv := &Server{
+		Authorizer: &rbac.FakeAuthorizer{Authorized: true},
+	}
+	ctrl := gomock.NewController(t)
+	mockManager := mock.NewMockAssistantManager(ctrl)
+	defer ctrl.Finish()
+
+	srv.AssistantManager = mockManager
+
+	handler := NewAssistantHandler(srv)
+
+	req := httptest.NewRequest("GET", "/assistant/balance", nil)
+
+	// Add required context values
+	ctx := context.WithValue(req.Context(), web.ContextKeyRequestorId, "test-user-123")
+	ctx = context.WithValue(ctx, web.ContextKeyRequestStart, time.Now())
+	ctx = context.WithValue(ctx, web.ContextKeyRequestId, "test-request-123")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// Set up mock expectations
+	mockManager.EXPECT().Health(gomock.Any()).Return(nil, errors.New("service unreachable"))
+
+	// Execute the handler
+	handler.GetBalance(w, req)
+
+	// Verify response
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestGetUsage(t *testing.T) {

--- a/server/assistantmanager.go
+++ b/server/assistantmanager.go
@@ -17,6 +17,7 @@ type AssistantManager interface {
 	ChatStream(ctx context.Context, messages []*model.Message) (*http.Response, error)
 	ExecuteTool(ctx context.Context, toolName string, params string) (*model.ToolResponse, error)
 	Balance(context.Context) (*model.BalanceResponse, error)
+	Health(context.Context) (*model.HealthResponse, error)
 }
 
 //go:generate mockgen -destination mock/mock_assistantmanager.go -package mock . AssistantManager

--- a/server/mock/mock_assistantmanager.go
+++ b/server/mock/mock_assistantmanager.go
@@ -106,3 +106,18 @@ func (mr *MockAssistantManagerMockRecorder) ExecuteTool(ctx, toolName, params an
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteTool", reflect.TypeOf((*MockAssistantManager)(nil).ExecuteTool), ctx, toolName, params)
 }
+
+// Health mocks base method.
+func (m *MockAssistantManager) Health(arg0 context.Context) (*model.HealthResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Health", arg0)
+	ret0, _ := ret[0].(*model.HealthResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Health indicates an expected call of Health.
+func (mr *MockAssistantManagerMockRecorder) Health(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockAssistantManager)(nil).Health), arg0)
+}

--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"path"
 	"sort"
+	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/licensing"
 	"github.com/security-onion-solutions/securityonion-soc/model"
@@ -32,7 +33,8 @@ import (
 )
 
 const (
-	DEFAULT_APIURL = "https://onionai.securityonion.net/"
+	DEFAULT_APIURL                 = "https://onionai.securityonion.net/"
+	DEFAULT_HEALTH_TIMEOUT_SECONDS = 3
 )
 
 var (
@@ -40,10 +42,11 @@ var (
 )
 
 type AssistantCoordinator struct {
-	srv       *server.Server
-	apiKey    string
-	apiUrl    string
-	isRunning bool
+	srv                  *server.Server
+	apiKey               string
+	apiUrl               string
+	healthTimeoutSeconds int
+	isRunning            bool
 
 	FunctionLibrary map[string]Tool
 	toolConfig      json.RawMessage
@@ -67,6 +70,7 @@ func (ac *AssistantCoordinator) Init(config module.ModuleConfig) (err error) {
 	ac.FunctionLibrary = knownTools
 
 	ac.apiUrl = module.GetStringDefault(config, "apiUrl", DEFAULT_APIURL)
+	ac.healthTimeoutSeconds = module.GetIntDefault(config, "healthTimeoutSeconds", DEFAULT_HEALTH_TIMEOUT_SECONDS)
 
 	ac.toolConfig, err = buildToolConfig(ac.FunctionLibrary)
 
@@ -400,6 +404,58 @@ func (ac *AssistantCoordinator) Balance(ctx context.Context) (*model.BalanceResp
 	err = json.Unmarshal(resBody, response)
 	if err != nil {
 		logger.WithError(err).WithField("rawBalanceResponseBody", string(resBody)).Error("unable to unmarhsal JSON response")
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (ac *AssistantCoordinator) Health(ctx context.Context) (*model.HealthResponse, error) {
+	logger := log.FromContext(ctx)
+
+	u, err := url.Parse(ac.apiUrl)
+	if err != nil {
+		logger.WithError(err).WithField("apiUrl", ac.apiUrl).Error("unable to parse apiUrl")
+
+		return nil, err
+	}
+
+	u.Path = path.Join(u.Path, "/health")
+	endpoint := u.String()
+
+	shortLived, cancel := context.WithTimeout(ctx, time.Second*time.Duration(ac.healthTimeoutSeconds))
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(shortLived, http.MethodGet, endpoint, nil)
+	if err != nil {
+		logger.WithError(err).Error("unable to make request object")
+
+		return nil, err
+	}
+
+	ac.prepareRequestHeaders(httpReq)
+
+	res, err := ac.MakeRequest(httpReq, false)
+	if err != nil {
+		logger.WithError(err).WithField("apiEndpoint", endpoint).Error("unable to execute request")
+
+		return nil, err
+	}
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		logger.WithError(err).Error("unable to read response body")
+
+		return nil, err
+	}
+
+	logger.WithField("rawHealthResponseBody", string(resBody)).Debug("health response received")
+
+	response := &model.HealthResponse{}
+
+	err = json.Unmarshal(resBody, response)
+	if err != nil {
+		logger.WithError(err).WithField("rawHealthResponseBody", string(resBody)).Error("unable to unmarhsal JSON response")
 		return nil, err
 	}
 

--- a/server/modules/assistant/assistant_test.go
+++ b/server/modules/assistant/assistant_test.go
@@ -228,14 +228,14 @@ func TestAssistantCoordinator_Balance(t *testing.T) {
 			name:   "successful balance request",
 			apiUrl: "https://api.example.com",
 			setupMocks: func(mockIO *detectionsmock.MockIOManager) {
-				responseBody := `{"credit_balance": 100.50, "api_key": "key", "api_key_prefix": "id", "company_id": "company", "status": "status"}`
+				responseBody := `{"credit_balance": 100, "api_key": "key", "api_key_prefix": "id", "company_id": "company", "status": "status"}`
 				mockIO.EXPECT().MakeRequest(gomock.Any(), false).Return(&http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader(responseBody)),
 				}, nil)
 			},
 			expectedResult: &model.BalanceResponse{
-				Balance:   100.50,
+				Balance:   100,
 				KeyId:     "id",
 				CompanyId: "company",
 				Status:    "status",


### PR DESCRIPTION
Do a health check before requesting the balance. Return the health status in the same response. Includes new config value for the timeout that defaults to 3 seconds. Update tests.

Also changed Balance's Credits to be an int64. Confirmed with Mike that it's never fractional and can grow quite large. Refactored tests.

Regenerated mocks.