### PR TITLE
Assistant page - Proper background handling for leaving current session

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -155,6 +155,7 @@ const i18n = {
       artifactValue: 'Value (hash, filename, etc.)',
       artifactValueHelp: 'Specify the observed value',
       assistantAdvertisement: 'Purchase Security Onion Pro to get access to Onion AI.',
+      assistantBalanceCheckUnhealthy: 'Health check in balance request came back unhealthy.',
       assistantDisabled: 'Onion AI is disabled. Contact your administrator to enable it.',
       assistantDisclaimerMessage: `Effective Date: [Insert Date]<br>
  Last Updated: [Insert Date]<br><br>

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -35,7 +35,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
   }},
   async created() {
     this.loadLocalSettings();
-    this.loadChatHistory();
+    this.loadNewChatScreen();
   },
   beforeUnmount() {
     // Backend automatically saves chats, just save current chat ID
@@ -97,7 +97,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       }
     },
     
-    async loadChatHistory() {
+    async loadNewChatScreen() {
       try {
         // Initialize with a welcome message from the AI Assistant
         this.messages = [
@@ -181,7 +181,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
             }
             
           } else if (this.messages.length > 1) {
-            this.loadChatHistory();
+            this.loadNewChatScreen();
           }
         } finally {
           this.$root.stopLoading();
@@ -271,7 +271,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         if (this.currentChatId === chatId) {
           this.currentChatId = null;
           this.saveCurrentChatId(); // Clear the saved current chat ID
-          this.loadChatHistory(); // Reset to welcome message
+          this.loadNewChatScreen(); // Reset to welcome message
           // Navigate to chat without session ID
           this.$router.push({ name: 'assistant' });
         }
@@ -288,7 +288,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       
       this.currentChatId = null;
       this.saveCurrentChatId(); // Clear the saved current chat ID
-      this.loadChatHistory(); // Reset to welcome message (also resets context length)
+      this.loadNewChatScreen(); // Reset to welcome message (also resets context length)
       // Navigate to chat without session ID
       this.$router.push({ name: 'assistant' });
     },
@@ -1233,7 +1233,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       } catch (error) {
         // If session doesn't exist, start with welcome message
         if (error.response && error.response.status === 404) {
-          this.loadChatHistory(); // Reset to welcome message
+          this.loadNewChatScreen(); // Reset to welcome message
           this.currentChatId = sessionId;
           this.saveCurrentChatId();
         } else {

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -1111,6 +1111,8 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         // Always update tool status with error, but only update UI if current session
         toolUse.status = 'error';
         toolUse.error = error.message;
+
+        const isCurrentSession = this.currentChatId === toolStreamingSessionId;
         
         if (isCurrentSession) {
           this.isStreaming = false;

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -462,9 +462,10 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     },
     
     // Helper method to handle content_block_start event
-    handleContentBlockStart(c, assistantMessage) {
+    handleContentBlockStart(c, assistantMessage, sessionId = null) {
       // Handle tool use blocks
       if (c.content_block && c.content_block.type === 'tool_use') {
+        const targetSessionId = sessionId || this.currentChatId;
         const toolUse = {
           id: c.content_block.id,
           name: c.content_block.name,
@@ -476,42 +477,51 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           rawResult: null, // Will store the raw tool result
           timestamp: new Date().toISOString(),
           blockIndex: c.index, // Store the block index for tracking
-          approved: null // null = pending, true = approved, false = rejected
+          approved: null, // null = pending, true = approved, false = rejected
+          sessionId: targetSessionId // Track which session this belongs to
         };
         
-        if (assistantMessage) {
+        // Always track the tool use
+        this.executingTools.set(toolUse.id, toolUse);
+        this.executingTools.set(`block_${c.index}_${targetSessionId}`, toolUse);
+        
+        // Only update UI if this is for the current session and we have an assistant message
+        if (assistantMessage && targetSessionId === this.currentChatId) {
           assistantMessage.toolUses.value.push(toolUse);
-          this.executingTools.set(toolUse.id, toolUse);
-          // Also track by block index for delta updates
-          this.executingTools.set(`block_${c.index}`, toolUse);
           this.scrollToBottom();
         }
       }
     },
     
     // Helper method to handle content_block_delta event
-    handleContentBlockDelta(c, assistantMessage) {
-      if (assistantMessage && c.delta.type === 'text_delta') {
-        // update the ref's value
+    handleContentBlockDelta(c, assistantMessage, sessionId = null) {
+      const targetSessionId = sessionId || this.currentChatId;
+      
+      if (assistantMessage && c.delta.type === 'text_delta' && targetSessionId === this.currentChatId) {
+        // Only update UI if this is for the current session
         assistantMessage.content.value += c.delta.text;
         this.scrollToBottom();
       } else if (c.delta.type === 'input_json_delta') {
-        // Handle tool input updates - accumulate the JSON
-        const toolUse = this.executingTools.get(`block_${c.index}`);
+        // Handle tool input updates - accumulate the JSON (always process, regardless of session)
+        const toolUse = this.executingTools.get(`block_${c.index}_${targetSessionId}`);
         if (toolUse) {
           toolUse.inputJson += c.delta.partial_json;
           toolUse.status = 'preparing';
-          this.scrollToBottom();
+          // Only update UI if this is for the current session
+          if (targetSessionId === this.currentChatId) {
+            this.scrollToBottom();
+          }
         }
       }
     },
     
     // Helper method to handle content_block_stop event
-    handleContentBlockStop(c) {
+    handleContentBlockStop(c, sessionId = null) {
       let messageUsage = null;
+      const targetSessionId = sessionId || this.currentChatId;
       
       // Handle tool input completion - wait for user approval
-      const toolUse = this.executingTools.get(`block_${c.index}`);
+      const toolUse = this.executingTools.get(`block_${c.index}_${targetSessionId}`);
       if (toolUse && toolUse.status === 'preparing') {
         try {
           // Parse the accumulated JSON input
@@ -524,7 +534,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
             // Auto-approve the tool
             toolUse.status = 'executing';
             toolUse.approved = true;
-            // Execute the tool immediately
+            // Execute the tool immediately (use background execution if not current session)
             this.$nextTick(() => {
               this.executeTool(toolUse);
             });
@@ -537,7 +547,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           toolUse.status = 'error';
           toolUse.error = this.i18n.assistantToolParseInputError + ': ' + error.message;
         }
-        this.scrollToBottom();
+        
+        // Only update UI if this is for the current session
+        if (targetSessionId === this.currentChatId) {
+          this.scrollToBottom();
+        }
       }
       
       // Sometimes usage comes here
@@ -595,7 +609,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           const { done, value } = await reader.read();
           if (done) break;
           
-          // Check if we're still in the same session - if not, continue processing but don't update UI
+          // Check if we're still in the same session for UI updates
           const isCurrentSession = this.activeStreamingSessionId === streamingSessionId && this.currentChatId === streamingSessionId;
           
           // Process streaming chunks using helper method
@@ -638,53 +652,54 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
 
             const c = parseResult.data;
 
-            // Only update UI if we're still in the same session
-            if (isCurrentSession) {
-              // handle chunk by type using helper methods
-              switch (c.type) {
-                case 'message_start':
+            // Always process chunks for tool execution logic, but only update UI if current session
+            switch (c.type) {
+              case 'message_start':
+                if (isCurrentSession) {
                   const startResult = this.handleMessageStart(c, assistantMessage);
                   assistantMessage = startResult.assistantMessage;
                   if (startResult.messageUsage) {
                     messageUsage = startResult.messageUsage;
                   }
-                  break;
-                  
-                case 'content_block_start':
-                  this.handleContentBlockStart(c, assistantMessage);
-                  break;
-                  
-                case 'content_block_delta':
-                  this.handleContentBlockDelta(c, assistantMessage);
-                  break;
-                  
-                case 'content_block_stop':
-                  const stopUsage = this.handleContentBlockStop(c);
-                  if (stopUsage) {
-                    messageUsage = stopUsage;
-                  }
-                  break;
-                  
-                case 'message_stop':
+                }
+                break;
+                
+              case 'content_block_start':
+                this.handleContentBlockStart(c, isCurrentSession ? assistantMessage : null, streamingSessionId);
+                break;
+                
+              case 'content_block_delta':
+                this.handleContentBlockDelta(c, isCurrentSession ? assistantMessage : null, streamingSessionId);
+                break;
+                
+              case 'content_block_stop':
+                const stopUsage = this.handleContentBlockStop(c, streamingSessionId);
+                if (stopUsage && isCurrentSession) {
+                  messageUsage = stopUsage;
+                }
+                break;
+                
+              case 'message_stop':
+                if (isCurrentSession) {
                   const stopResult = this.handleMessageStop(assistantMessage, messageUsage);
                   assistantMessage = stopResult.assistantMessage;
                   messageUsage = stopResult.messageUsage;
-                  break;
-                  
-                case 'message_delta':
-                  // Handle usage information if present
-                  if (c.usage) {
-                    messageUsage = c.usage;
-                  }
-                  break;
-                  
-                default:
-                  // Log any unhandled event types that might contain usage
-                  if (c.usage) {
-                    messageUsage = c.usage;
-                  }
-                  break;
-              }
+                }
+                break;
+                
+              case 'message_delta':
+                // Handle usage information if present
+                if (c.usage && isCurrentSession) {
+                  messageUsage = c.usage;
+                }
+                break;
+                
+              default:
+                // Log any unhandled event types that might contain usage
+                if (c.usage && isCurrentSession) {
+                  messageUsage = c.usage;
+                }
+                break;
             }
           }
 
@@ -758,9 +773,10 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     },
     
     // Helper method to handle content_block_start event for tool execution (chained tools)
-    handleToolExecutionContentBlockStart(c, assistantMessage) {
+    handleToolExecutionContentBlockStart(c, assistantMessage, sessionId = null) {
       // Handle tool use blocks in the response after tool execution
       if (c.content_block && c.content_block.type === 'tool_use') {
+        const targetSessionId = sessionId || this.currentChatId;
         const newToolUse = {
           id: c.content_block.id,
           name: c.content_block.name,
@@ -772,40 +788,51 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           rawResult: null, // Will store the raw tool result
           timestamp: new Date().toISOString(),
           blockIndex: c.index,
-          approved: null
+          approved: null,
+          sessionId: targetSessionId // Track which session this belongs to
         };
         
-        if (assistantMessage) {
+        // Always track the tool use
+        this.executingTools.set(newToolUse.id, newToolUse);
+        this.executingTools.set(`block_${c.index}_${targetSessionId}`, newToolUse);
+        
+        // Only update UI if this is for the current session and we have an assistant message
+        if (assistantMessage && targetSessionId === this.currentChatId) {
           assistantMessage.toolUses.value.push(newToolUse);
-          this.executingTools.set(newToolUse.id, newToolUse);
-          this.executingTools.set(`block_${c.index}`, newToolUse);
           this.scrollToBottom();
         }
       }
     },
     
     // Helper method to handle content_block_delta event for tool execution
-    handleToolExecutionContentBlockDelta(c, assistantMessage) {
-      if (assistantMessage && c.delta.type === 'text_delta') {
+    handleToolExecutionContentBlockDelta(c, assistantMessage, sessionId = null) {
+      const targetSessionId = sessionId || this.currentChatId;
+      
+      if (assistantMessage && c.delta.type === 'text_delta' && targetSessionId === this.currentChatId) {
+        // Only update UI if this is for the current session
         assistantMessage.content.value += c.delta.text;
         this.scrollToBottom();
       } else if (c.delta.type === 'input_json_delta') {
-        // Handle tool input updates for chained tools
-        const chainedToolUse = this.executingTools.get(`block_${c.index}`);
+        // Handle tool input updates for chained tools (always process, regardless of session)
+        const chainedToolUse = this.executingTools.get(`block_${c.index}_${targetSessionId}`);
         if (chainedToolUse) {
           chainedToolUse.inputJson += c.delta.partial_json;
           chainedToolUse.status = 'preparing';
-          this.scrollToBottom();
+          // Only update UI if this is for the current session
+          if (targetSessionId === this.currentChatId) {
+            this.scrollToBottom();
+          }
         }
       }
     },
     
     // Helper method to handle content_block_stop event for tool execution (chained tools)
-    handleToolExecutionContentBlockStop(c) {
+    handleToolExecutionContentBlockStop(c, sessionId = null) {
       let messageUsage = null;
+      const targetSessionId = sessionId || this.currentChatId;
       
       // Handle tool input completion for chained tools
-      const chainedToolUse = this.executingTools.get(`block_${c.index}`);
+      const chainedToolUse = this.executingTools.get(`block_${c.index}_${targetSessionId}`);
       if (chainedToolUse && chainedToolUse.status === 'preparing') {
         try {
           // Parse the accumulated JSON input
@@ -818,7 +845,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
             // Auto-approve the chained tool
             chainedToolUse.status = 'executing';
             chainedToolUse.approved = true;
-            // Execute the tool immediately
+            // Execute the tool immediately (use background execution if not current session)
             this.$nextTick(() => {
               this.executeTool(chainedToolUse);
             });
@@ -831,7 +858,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           chainedToolUse.status = 'error';
           chainedToolUse.error = this.i18n.assistantToolParseInputError + ': ' + error.message;
         }
-        this.scrollToBottom();
+        
+        // Only update UI if this is for the current session
+        if (targetSessionId === this.currentChatId) {
+          this.scrollToBottom();
+        }
       }
       
       // Sometimes usage comes here
@@ -928,12 +959,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       return this.$root.formatCount(count);
     },
     async executeTool(toolUse) {
-      // Capture the session ID at the start of the tool execution
-      const toolStreamingSessionId = this.currentChatId;
+      // Use the tool's session ID if available, otherwise use current session
+      const toolStreamingSessionId = toolUse.sessionId || this.currentChatId;
       
       try {
         // Create ToolRequest object with history and params
-        // Session ID should already be set by sendMessage()
         const toolRequest = {
           sessionId: toolStreamingSessionId,
           toolUseId: toolUse.id,
@@ -949,8 +979,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           adapter: 'fetch',
         });
 
+        // Check if we should update UI (current session)
+        const isCurrentSession = this.currentChatId === toolStreamingSessionId;
+
         // Update tool status to executing only if still in same session
-        if (this.currentChatId === toolStreamingSessionId) {
+        if (isCurrentSession) {
           toolUse.status = 'executing';
         }
 
@@ -958,7 +991,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         const stream = response.data;
         const reader = stream.pipeThrough(new TextDecoderStream()).getReader();
 
-        if (this.currentChatId === toolStreamingSessionId) {
+        if (isCurrentSession) {
           this.isStreaming = true;
         }
         let assistantMessage = null;
@@ -969,9 +1002,6 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          
-          // Check if we're still in the same session
-          const isCurrentSession = this.currentChatId === toolStreamingSessionId;
           
           // Process streaming chunks using helper method
           const chunkResult = this.processStreamingChunks(value, chunks, partial);
@@ -1012,11 +1042,10 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
 
             const c = parseResult.data;
 
-            // Only update UI if we're still in the same session
-            if (isCurrentSession) {
-              // Handle streaming chunks for tool result response using helper methods
-              switch (c.type) {
-                case 'message_start':
+            // Always process chunks for tool execution logic, but only update UI if current session
+            switch (c.type) {
+              case 'message_start':
+                if (isCurrentSession) {
                   // Capture raw tool result using helper method
                   this.captureRawToolResult(toolUse);
                   
@@ -1025,41 +1054,43 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
                   if (startResult.messageUsage) {
                     messageUsage = startResult.messageUsage;
                   }
-                  break;
+                }
+                break;
 
-                case 'content_block_start':
-                  this.handleToolExecutionContentBlockStart(c, assistantMessage);
-                  break;
+              case 'content_block_start':
+                this.handleToolExecutionContentBlockStart(c, isCurrentSession ? assistantMessage : null, toolStreamingSessionId);
+                break;
 
-                case 'content_block_delta':
-                  this.handleToolExecutionContentBlockDelta(c, assistantMessage);
-                  break;
+              case 'content_block_delta':
+                this.handleToolExecutionContentBlockDelta(c, isCurrentSession ? assistantMessage : null, toolStreamingSessionId);
+                break;
 
-                case 'content_block_stop':
-                  const stopUsage = this.handleToolExecutionContentBlockStop(c);
-                  if (stopUsage) {
-                    messageUsage = stopUsage;
-                  }
-                  break;
+              case 'content_block_stop':
+                const stopUsage = this.handleToolExecutionContentBlockStop(c, toolStreamingSessionId);
+                if (stopUsage && isCurrentSession) {
+                  messageUsage = stopUsage;
+                }
+                break;
 
-                case 'message_stop':
+              case 'message_stop':
+                if (isCurrentSession) {
                   const stopResult = this.handleToolExecutionMessageStop(assistantMessage, messageUsage);
                   assistantMessage = stopResult.assistantMessage;
                   messageUsage = stopResult.messageUsage;
-                  break;
+                }
+                break;
 
-                case 'message_delta':
-                  if (c.usage) {
-                    messageUsage = c.usage;
-                  }
-                  break;
+              case 'message_delta':
+                if (c.usage && isCurrentSession) {
+                  messageUsage = c.usage;
+                }
+                break;
 
-                default:
-                  if (c.usage) {
-                    messageUsage = c.usage;
-                  }
-                  break;
-              }
+              default:
+                if (c.usage && isCurrentSession) {
+                  messageUsage = c.usage;
+                }
+                break;
             }
           }
 
@@ -1070,20 +1101,19 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         }
         
         // Only update UI state if we're still in the same session
-        if (this.currentChatId === toolStreamingSessionId) {
+        if (isCurrentSession) {
           this.isStreaming = false;
           // Update credits after tool execution
           await this.loadCredits();
         }
         
       } catch (error) {
-        // Only update UI state if we're still in the same session
-        if (this.currentChatId === toolStreamingSessionId) {
+        // Always update tool status with error, but only update UI if current session
+        toolUse.status = 'error';
+        toolUse.error = error.message;
+        
+        if (isCurrentSession) {
           this.isStreaming = false;
-
-          // Update tool use status with error
-          toolUse.status = 'error';
-          toolUse.error = error.message;
           
           // Add error message to chat
           const errorMessage = {

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -1218,8 +1218,8 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         const response = await this.$root.papi.get(`/assistant/sessions/${sessionId}`);
         if (response.data && Array.isArray(response.data) && response.data.length > 0) {
           // Convert backend messages to frontend format
-          this.messages = this.convertBackendMessagesToFrontend(response.data);
           this.currentChatId = sessionId;
+          this.messages = this.convertBackendMessagesToFrontend(response.data);
           this.saveCurrentChatId();
         } else {
           throw new Error(this.i18n.assistantNoHistoryFound + ' ' + sessionId);
@@ -1347,6 +1347,20 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
             rawResult: null, // Will be populated by subsequent tool result message
             timestamp: msg.createTime || new Date().toISOString(),
             approved: true
+          })));
+        // Allows tool use blocks at the end of a session to persist even when the user clicks away
+        } else {
+          frontendMsg.toolUses = Vue.ref(toolBlocks.map(block => ({
+            id: block.id || 'unknown',
+            name: block.name || 'unknown',
+            input: block.input || {}, // Ensure input is always an object, never null/undefined
+            status: 'pending_approval',
+            result: null,
+            error: null,
+            rawResult: null, // Will be populated by subsequent tool result message
+            timestamp: msg.createTime || new Date().toISOString(),
+            approved: null,
+            sessionId: this.currentChatId
           })));
         }
       }

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -214,7 +214,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       try {
         const response = await this.$root.papi.get('/assistant/balance');
         if (response.data) {
-          this.creditsRemaining = response.data.credit_balance || 0;
+          if (response.data.health_status === 'healthy') {
+            this.creditsRemaining = response.data.credit_balance || 0;
+          } else {
+            throw new Error(this.i18n.assistantBalanceCheckUnhealthy);
+          }
         }
       } catch (error) {
         this.$root.showError(this.i18n.assistantUnableToLoadCredits + ': ' + error.message);

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -70,6 +70,7 @@ const fakeToolUse = {
   approved: null
 };
 const fakeCreditsResponse = {
+  health_status: 'healthy',
   credit_balance: 100
 };
 const fakeInvestigationData = {
@@ -196,21 +197,21 @@ test('component data initialization', () => {
   expect(comp.executingTools).toBeInstanceOf(Map);
 });
 
-test('loadChatHistory initializes with welcome message', async () => {
-  await comp.loadChatHistory();
+test('loadNewChatScreen initializes with welcome message', async () => {
+  await comp.loadNewChatScreen();
   
   expect(comp.messages).toHaveLength(1);
   expect(comp.messages[0].role).toBe('assistant');
   expect(comp.messages[0].content).toContain('Hello! I\'m your AI Assistant');
 });
 
-test('loadChatHistory handles error', async () => {
+test('loadNewChatScreen handles error', async () => {
   const showErrorMock = mockShowError();
   comp.$root.showError = jest.fn(() => {
     throw new Error('Test error');
   });
   
-  await comp.loadChatHistory();
+  await comp.loadNewChatScreen();
   
   expect(comp.messages).toHaveLength(1); // Should still have welcome message
 });
@@ -318,6 +319,20 @@ test('loadCredits handles error', async () => {
   expect(comp.creditsRemaining).toBe(0);
 });
 
+test('loadCredits handles unhealthy status', async () => {
+  const showErrorMock = mockShowError();
+  const unhealthyResponse = {
+    health_status: 'unhealthy',
+    credit_balance: 50
+  };
+  mockPapi("get", { data: unhealthyResponse });
+  
+  await comp.loadCredits();
+  
+  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: Health check in balance request came back unhealthy.');
+  expect(comp.creditsRemaining).toBe(0); // Should remain 0 when unhealthy
+});
+
 // Chat operations tests
 test('loadChat switches to existing chat', async () => {
   const chat = fakeChatHistory[0];
@@ -355,7 +370,7 @@ test('deleteChat success', async () => {
   comp.chatHistory = [...fakeChatHistory];
   comp.currentChatId = chatId;
   comp.saveCurrentChatId = jest.fn();
-  comp.loadChatHistory = jest.fn();
+  comp.loadNewChatScreen = jest.fn();
   
   await comp.deleteChat(chatId);
   
@@ -363,7 +378,7 @@ test('deleteChat success', async () => {
   expect(comp.chatHistory).toHaveLength(0);
   expect(comp.currentChatId).toBe(null);
   expect(comp.saveCurrentChatId).toHaveBeenCalled();
-  expect(comp.loadChatHistory).toHaveBeenCalled();
+  expect(comp.loadNewChatScreen).toHaveBeenCalled();
   expect(comp.$router.push).toHaveBeenCalledWith({ name: 'assistant' });
 });
 
@@ -380,7 +395,7 @@ test('deleteChat handles error', async () => {
 test('startNewChat', async () => {
   comp.saveCurrentChat = jest.fn().mockResolvedValue();
   comp.saveCurrentChatId = jest.fn();
-  comp.loadChatHistory = jest.fn();
+  comp.loadNewChatScreen = jest.fn();
   comp.currentChatId = fakeSessionId;
   
   await comp.startNewChat();
@@ -388,7 +403,7 @@ test('startNewChat', async () => {
   expect(comp.saveCurrentChat).toHaveBeenCalled();
   expect(comp.currentChatId).toBe(null);
   expect(comp.saveCurrentChatId).toHaveBeenCalled();
-  expect(comp.loadChatHistory).toHaveBeenCalled();
+  expect(comp.loadNewChatScreen).toHaveBeenCalled();
   expect(comp.$router.push).toHaveBeenCalledWith({ name: 'assistant' });
 });
 
@@ -1479,7 +1494,7 @@ test('handleRouteSessionId handles non-investigation session with existing messa
   comp.$route.params.sessionId = fakeSessionId;
   comp.$route.query.investigation = 'false'; // Not an investigation
   comp.loadChatFromBackend = jest.fn().mockRejectedValue(new Error('Session not found'));
-  comp.loadChatHistory = jest.fn();
+  comp.loadNewChatScreen = jest.fn();
   comp.saveCurrentChatId = jest.fn();
   comp.messages = [fakeMessage, fakeAssistantMessage]; // More than 1 message
   
@@ -1487,7 +1502,7 @@ test('handleRouteSessionId handles non-investigation session with existing messa
   
   expect(comp.currentChatId).toBe(fakeSessionId);
   expect(comp.saveCurrentChatId).toHaveBeenCalled();
-  expect(comp.loadChatHistory).toHaveBeenCalled();
+  expect(comp.loadNewChatScreen).toHaveBeenCalled();
 });
 
 test('startInvestigationSession clears messages and sets up investigation prompt', async () => {
@@ -2285,11 +2300,11 @@ test('loadChatFromBackend handles 404 error', async () => {
   const error = new Error('Not found');
   error.response = { status: 404 };
   mockPapi("get", null, error);
-  comp.loadChatHistory = jest.fn();
+  comp.loadNewChatScreen = jest.fn();
   
   await comp.loadChatFromBackend(fakeSessionId);
   
-  expect(comp.loadChatHistory).toHaveBeenCalled();
+  expect(comp.loadNewChatScreen).toHaveBeenCalled();
   expect(comp.currentChatId).toBe(fakeSessionId);
 });
 

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -766,7 +766,7 @@ test('executeTool handles chained tool use in response', async () => {
   expect(comp.messages[0].toolUses.value[0].name).toBe('analyze_data');
   expect(comp.messages[0].toolUses.value[0].status).toBe('preparing');
   expect(comp.executingTools.get('chained_tool_456')).toBeDefined();
-  expect(comp.executingTools.get('block_0')).toBeDefined();
+  expect(comp.executingTools.get(`block_0_${fakeSessionId}`)).toBeDefined();
 });
 
 test('executeTool captures raw tool result from backend', async () => {
@@ -1064,7 +1064,7 @@ test('callAIAPI processes content_block_start with tool_use', async () => {
   expect(comp.messages[0].toolUses.value[0].input).toEqual({ query: 'test query' });
   expect(comp.messages[0].toolUses.value[0].status).toBe('preparing');
   expect(comp.executingTools.get('tool_456')).toBeDefined();
-  expect(comp.executingTools.get('block_0')).toBeDefined();
+  expect(comp.executingTools.get(`block_0_${fakeSessionId}`)).toBeDefined();
 });
 
 test('callAIAPI processes content_block_delta with text_delta', async () => {
@@ -1149,7 +1149,7 @@ test('callAIAPI processes content_block_delta with input_json_delta', async () =
   
   await comp.callAIAPI('Test message');
   
-  const toolUse = comp.executingTools.get('block_0');
+  const toolUse = comp.executingTools.get(`block_0_${fakeSessionId}`);
   expect(toolUse).toBeDefined();
   expect(toolUse.inputJson).toBe('{"param": "value"}');
   expect(toolUse.status).toBe('preparing');
@@ -1198,7 +1198,7 @@ test('callAIAPI processes content_block_stop event', async () => {
   
   await comp.callAIAPI('Test message');
   
-  const toolUse = comp.executingTools.get('block_0');
+  const toolUse = comp.executingTools.get(`block_0_${fakeSessionId}`);
   expect(toolUse).toBeDefined();
   expect(toolUse.input).toEqual({ test: 'data' });
   expect(toolUse.status).toBe('pending_approval');
@@ -1247,7 +1247,7 @@ test('callAIAPI handles content_block_stop with invalid JSON', async () => {
   
   await comp.callAIAPI('Test message');
   
-  const toolUse = comp.executingTools.get('block_0');
+  const toolUse = comp.executingTools.get(`block_0_${fakeSessionId}`);
   expect(toolUse).toBeDefined();
   expect(toolUse.status).toBe('error');
   expect(toolUse.error).toContain('Failed to parse tool input');

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -152,6 +152,8 @@
 															icon
 															variant="text"
 															size="x-small"
+															height="auto"
+															width="auto"
 															@click="openOptionsMenu"
 															data-aid="assistant_tool_use_options"
 															style="min-width: auto;"


### PR DESCRIPTION
- Tool use execution (when set to auto-approve) now happens in the background if the user switches sessions mid-request. [#333](https://github.com/Security-Onion-Solutions/sos/issues/333)
- Tool use prompt blocks that haven't yet been interacted with will return to the screen if the user leaves the current session and comes back.
- Added health check handling for balance request.
- Centered gear button on the tool request prompt block.
- Modified and added unit tests to reflect these changes.