### PR TITLE
Assistant: auto-scroll escape functionality, visual bug fixes, i18n/css/html updates

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1305,6 +1305,13 @@ ul ul ul {
   word-break: break-all;
 }
 
+.disclaimer-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 75%;
+}
+
 .disclaimer-card {
   display: flex;
   flex-direction: column;

--- a/html/index.html
+++ b/html/index.html
@@ -187,7 +187,7 @@
             <div v-html="tipMessage" class="tip-message"></div>
           </v-snackbar>
           <template v-if="disclaimer">
-            <v-container id="disclaimer" class="disclaimer-container pa-0 fill-height" fluid data-aid="banner_disclaimer">
+            <v-container id="disclaimer" class="disclaimer-container pa-0" fluid data-aid="banner_disclaimer">
               <v-card class="disclaimer-card h-100">
                 <v-card-title id="disclaimer-header">
                   <div class="disclaimer-title" v-html="disclaimerTitle"></div>

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -156,6 +156,8 @@ const i18n = {
       artifactValueHelp: 'Specify the observed value',
       assistantAdvertisement: `<v-card-text>This feature requires Security Onion Pro and credits for the OnionAI API. Visit <a target="sos" href="https://securityonionsolutions.com/pro?utm_source=ainotice&utm_medium=app&utm_id=ai">Security Onion</a>.</v-card-text>`,
       assistantBalanceCheckUnhealthy: 'The AI model could not be reached. Support for local AI models is coming soon.',
+      assistantContextLimitPt1: 'Context length limit reached',
+      assistantContextLimitPt2: 'Please start a new chat to continue.',
       assistantDisabled: 'This feature is not enabled on this grid. Contact your Security Onion administrator.',
       assistantDisclaimerMessage: `Use of this feature requires AI requests which can contain event data and will be sent to the OnionAI API in the US.<br><br>No Query Logging: OnionAI API does not record or store input prompts, queries, or generated outputs. No context is stored on the API.<br><br>Token Tracking: The API tracks usage metrics limited to token counts for billing and operational purposes.<br><br>Local Retention: Prompts and responses are stored in the local grid's Elasticsearch data store.`,
       assistantDisclaimerTitle: 'Data Privacy Notice',

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -154,38 +154,11 @@ const i18n = {
       artifactTypeHelp: 'Select a type for classification purposes (Note: choose "file" type to upload a file)',
       artifactValue: 'Value (hash, filename, etc.)',
       artifactValueHelp: 'Specify the observed value',
-      assistantAdvertisement: 'Purchase Security Onion Pro to get access to Onion AI.',
-      assistantBalanceCheckUnhealthy: 'Health check in balance request came back unhealthy.',
-      assistantDisabled: 'Onion AI is disabled. Contact your administrator to enable it.',
-      assistantDisclaimerMessage: `Effective Date: [Insert Date]<br>
- Last Updated: [Insert Date]<br><br>
-1. INTRODUCTION<br><br>
-This Agreement governs data handling when accessing the Security Onion Solutions OnionAI API (“Service”). By using the Service, you (“User”) agree to these terms.<br><br>
-2. PARTIES AND SCOPE<br><br>
-OnionAI API: Security Onion Solutions service that proxies requests to AWS.<br><br>
-User: Individual or entity utilizing the Service.<br><br>
-This Agreement applies to all interactions with the OnionAI API.<br><br>
-3. DATA HANDLING<br><br>
-No Query Logging: OnionAI API does not record or store input prompts, queries, or generated outputs.<br><br>
-Token Usage Only: The API tracks usage metrics limited to token counts for billing and operational purposes.<br><br>
-Stateless Processing: Each request is processed independently without persistence of content.<br><br>
-4. DATA SECURITY<br><br>
-Encryption: All traffic is encrypted in transit (TLS 1.2+).<br><br>
-Content Retention: Prompts and responses are stored in the local Elastic Search data store.<br><br>
-User Ownership: Users retain ownership of all inputs and outputs.<br><br>
-5. USER RIGHTS<br><br>
-Users may:<br><br>
-Access usage records (token counts).<br><br>
-Request clarification of data handling.<br><br>
-Terminate use at any time without retention of past queries.<br><br>
-6. COMPLIANCE<br><br>
-The Service supports alignment with GDPR, CCPA, and other applicable regulations by ensuring no retention of query content and limiting processing to ephemeral token usage.<br><br>
-7. TERMINATION<br><br>
-Standard Termination: Upon termination of the Service, data processing ceases immediately. No user content remains stored. Token usage data may be retained for billing and compliance records only.<br><br>
-Abuse-Related Termination: Security Onion Solutions reserves the right to suspend or terminate access immediately if the User is found to be misusing, abusing, or attempting to compromise the Service (including but not limited to security violations, excessive or malicious usage, or attempts to circumvent system protections).<br><br>
-8. GOVERNING LAW<br><br>
-This Agreement is governed by [Insert Jurisdiction] law.`,
-      assistantDisclaimerTitle: 'Data Privacy End User Agreement',
+      assistantAdvertisement: `<v-card-text>This feature requires Security Onion Pro and credits for the OnionAI API. Visit <a target="sos" href="https://securityonionsolutions.com/pro?utm_source=ainotice&utm_medium=app&utm_id=ai">Security Onion</a>.</v-card-text>`,
+      assistantBalanceCheckUnhealthy: 'The AI model could not be reached. Support for local AI models is coming soon.',
+      assistantDisabled: 'This feature is not enabled on this grid. Contact your Security Onion administrator.',
+      assistantDisclaimerMessage: `Use of this feature requires AI requests which can contain event data and will be sent to the OnionAI API in the US.<br><br>No Query Logging: OnionAI API does not record or store input prompts, queries, or generated outputs. No context is stored on the API.<br><br>Token Tracking: The API tracks usage metrics limited to token counts for billing and operational purposes.<br><br>Local Retention: Prompts and responses are stored in the local grid's Elasticsearch data store.`,
+      assistantDisclaimerTitle: 'Data Privacy Notice',
       assistantErrorMessage: 'I apologize, but I\'m having trouble connecting to the AI service right now. Please try again in a moment.',
       assistantHistoryCollapse: 'Hide Chat History',
       assistantHistoryExpand: 'Show Chat History',

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -32,6 +32,8 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     thresholdColorRatioMax: 1,
     lowBalanceColorAlert: 500000,
     activeStreamingSessionId: null, // Track which session is actively streaming
+    autoScrollOnNextRender: false, // gate for programmatic scrolls
+    isPinnedToBottom: true, // user is at (or near) bottom?
   }},
   async created() {
     this.loadLocalSettings();
@@ -241,24 +243,23 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       return 'chat_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
     },
     async loadChat(chat) {
-      await this.saveCurrentChat(); // Save current chat before switching
-      
-      // Clear active streaming session and UI state when switching chats
+      await this.saveCurrentChat();
       this.clearStreamingStates();
-      
+
       this.$root.startLoading();
       try {
         if (this.currentChatId === chat.sessionId) {
           await this.loadChatFromBackend(chat.sessionId);
         }
         this.updateUrlWithSessionId(chat.sessionId);
-        this.scrollToBottom();
+
       } catch (error) {
         this.$root.showError(this.i18n.assistantUnableToLoadChat + ': ' + error.message);
       } finally {
         this.$root.stopLoading();
       }
     },
+
     async deleteChat(chatId) {
       try {
         // Call the backend DELETE endpoint to remove the session
@@ -460,7 +461,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       }
 
       this.messages.push(assistantMessage);
-      this.scrollToBottom();
+      this.scrollIfPinned();
       
       return { assistantMessage, messageUsage };
     },
@@ -492,7 +493,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         // Only update UI if this is for the current session and we have an assistant message
         if (assistantMessage && targetSessionId === this.currentChatId) {
           assistantMessage.toolUses.value.push(toolUse);
-          this.scrollToBottom();
+          this.scrollIfPinned();
         }
       }
     },
@@ -504,7 +505,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       if (assistantMessage && c.delta.type === 'text_delta' && targetSessionId === this.currentChatId) {
         // Only update UI if this is for the current session
         assistantMessage.content.value += c.delta.text;
-        this.scrollToBottom();
+        this.scrollIfPinned();
       } else if (c.delta.type === 'input_json_delta') {
         // Handle tool input updates - accumulate the JSON (always process, regardless of session)
         const toolUse = this.executingTools.get(`block_${c.index}_${targetSessionId}`);
@@ -513,7 +514,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           toolUse.status = 'preparing';
           // Only update UI if this is for the current session
           if (targetSessionId === this.currentChatId) {
-            this.scrollToBottom();
+            this.scrollIfPinned();
           }
         }
       }
@@ -554,7 +555,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         
         // Only update UI if this is for the current session
         if (targetSessionId === this.currentChatId) {
-          this.scrollToBottom();
+          this.scrollIfPinned();
         }
       }
       
@@ -739,7 +740,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
             timestamp: new Date().toISOString()
           };
           this.messages.push(errorMessage);
-          this.scrollToBottom();
+          this.scrollIfPinned();
           
           // Show error to user
           this.$root.showError(this.i18n.assistantNoResponse + ': ' + (error.response?.data?.error || error.message));
@@ -771,7 +772,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       }
 
       this.messages.push(assistantMessage);
-      this.scrollToBottom();
+      this.scrollIfPinned();
       
       return { assistantMessage, messageUsage };
     },
@@ -803,7 +804,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         // Only update UI if this is for the current session and we have an assistant message
         if (assistantMessage && targetSessionId === this.currentChatId) {
           assistantMessage.toolUses.value.push(newToolUse);
-          this.scrollToBottom();
+          this.scrollIfPinned();
         }
       }
     },
@@ -815,7 +816,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       if (assistantMessage && c.delta.type === 'text_delta' && targetSessionId === this.currentChatId) {
         // Only update UI if this is for the current session
         assistantMessage.content.value += c.delta.text;
-        this.scrollToBottom();
+        this.scrollIfPinned();
       } else if (c.delta.type === 'input_json_delta') {
         // Handle tool input updates for chained tools (always process, regardless of session)
         const chainedToolUse = this.executingTools.get(`block_${c.index}_${targetSessionId}`);
@@ -824,7 +825,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           chainedToolUse.status = 'preparing';
           // Only update UI if this is for the current session
           if (targetSessionId === this.currentChatId) {
-            this.scrollToBottom();
+            this.scrollIfPinned();
           }
         }
       }
@@ -865,7 +866,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         
         // Only update UI if this is for the current session
         if (targetSessionId === this.currentChatId) {
-          this.scrollToBottom();
+          this.scrollIfPinned();
         }
       }
       
@@ -933,6 +934,14 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       }, 1000); // Wait 1 second for the backend to save the result
     },
     
+    isNearBottom(container, thresholdPx = 48) {
+      return (container.scrollHeight - container.clientHeight - container.scrollTop) <= thresholdPx;
+    },
+
+    forceScrollBottom(container) {
+      container.scrollTop = container.scrollHeight;
+    },
+
     scrollToBottom() {
       this.$nextTick(() => {
         const messagesContainer = this.$el.querySelector('.chat-messages');
@@ -941,6 +950,111 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         }
       });
     },
+
+    async scrollToBottomSettled({ settleDelay = 180, maxWait = 3000 } = {}) {
+      await this.$nextTick(); // wait for Vue's immediate DOM updates
+
+      const container = this.$el && this.$el.querySelector
+        ? this.$el.querySelector('.chat-messages')
+        : null;
+      if (!container) return;
+
+      // Always do an initial snap
+      this.forceScrollBottom(container);
+
+      let resolved = false;
+      let lastHeight = container.scrollHeight;
+      let settleTimer = null;
+
+      const cleanupFns = [];
+
+      const scheduleSettle = () => {
+        if (settleTimer) clearTimeout(settleTimer);
+        settleTimer = setTimeout(() => {
+          // If height hasn't changed for settleDelay, consider layout "settled"
+          const sameHeight = container.scrollHeight === lastHeight;
+          lastHeight = container.scrollHeight;
+          if (sameHeight) {
+            resolved = true;
+            cleanup();
+            // final snap (covers any last-millisecond growth)
+            this.forceScrollBottom(container);
+          } else {
+            // height changed during debounce; snap again and wait again
+            this.forceScrollBottom(container);
+            scheduleSettle();
+          }
+        }, settleDelay);
+      };
+
+      const onMutateOrResize = () => {
+        if (resolved) return;
+        // When DOM mutates or sizes change, snap and restart settle timer
+        this.forceScrollBottom(container);
+        lastHeight = container.scrollHeight;
+        scheduleSettle();
+      };
+
+      // Observe DOM changes under chat messages (mermaid renders, tool cards, etc.)
+      const mo = new MutationObserver(onMutateOrResize);
+      mo.observe(container, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+      cleanupFns.push(() => mo.disconnect());
+
+      // Observe size changes (tables/images causing height growth)
+      if ('ResizeObserver' in window) {
+        const ro = new ResizeObserver(onMutateOrResize);
+        ro.observe(container);
+        cleanupFns.push(() => ro.disconnect());
+      }
+
+      // Listen for image loads inside container (images can change height after decode)
+      const imgs = Array.from(container.querySelectorAll('img'));
+      const pendingImgs = imgs.filter(img => !img.complete);
+      const imgHandlers = [];
+      pendingImgs.forEach(img => {
+        const h = () => onMutateOrResize();
+        img.addEventListener('load', h, { once: true });
+        img.addEventListener('error', h, { once: true });
+        imgHandlers.push(() => {
+          img.removeEventListener('load', h);
+          img.removeEventListener('error', h);
+        });
+      });
+      cleanupFns.push(() => imgHandlers.forEach(fn => fn()));
+
+      // Safety timeout so we don't hang forever if something keeps mutating
+      const safetyTimer = setTimeout(() => {
+        if (!resolved) {
+          cleanup();
+          this.forceScrollBottom(container);
+        }
+      }, maxWait);
+      cleanupFns.push(() => clearTimeout(safetyTimer));
+
+      const cleanup = () => {
+        cleanupFns.forEach(fn => fn());
+        if (settleTimer) clearTimeout(settleTimer);
+      };
+
+      // kick off the initial settle wait
+      scheduleSettle();
+    },
+
+    onChatScroll(evt) {
+      const c = evt.target;
+      const atBottom = this.isNearBottom(c, 4);
+      this.isPinnedToBottom = atBottom;
+    },
+
+    scrollIfPinned() {
+      if (!this.isPinnedToBottom) return;
+      this.scrollToBottom();
+    },
+
     getAvatar(user) {
       return this.$root.getAvatar(user);
     },
@@ -1132,7 +1246,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           };
           
           this.messages.push(errorMessage);
-          this.scrollToBottom();
+          this.scrollIfPinned();
         }
       }
     },
@@ -1223,19 +1337,21 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       try {
         const response = await this.$root.papi.get(`/assistant/sessions/${sessionId}`);
         if (response.data && Array.isArray(response.data) && response.data.length > 0) {
-          // Convert backend messages to frontend format
           this.currentChatId = sessionId;
           this.messages = this.convertBackendMessagesToFrontend(response.data);
           this.saveCurrentChatId();
+
+          await this.scrollToBottomSettled({ maxWait: 6000, settleDelay: 200 });
         } else {
           throw new Error(this.i18n.assistantNoHistoryFound + ' ' + sessionId);
         }
       } catch (error) {
-        // If session doesn't exist, start with welcome message
         if (error.response && error.response.status === 404) {
-          this.loadNewChatScreen(); // Reset to welcome message
+          this.loadNewChatScreen();
           this.currentChatId = sessionId;
           this.saveCurrentChatId();
+
+          await this.scrollToBottomSettled();
         } else {
           throw error;
         }

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -103,7 +103,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       const maxContextLength = this.increaseMaxContextThreshold ? this.contextLimitLarge : this.contextLimitSmall;
       if (this.contextLength >= maxContextLength) {
         const formattedLimit = this.formatCount(maxContextLength);
-        this.$root.showError(`Context length limit reached (${formattedLimit}+ tokens). Please start a new chat to continue.`);
+        this.$root.showError(this.i18n.assistantContextLimitPt1 + ` (${formattedLimit}+ tokens). ` + this.i18n.assistantContextLimitPt2);
         return true;
       }
       return false;

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -98,6 +98,16 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         this.contextLength += messageContext;
       }
     },
+
+    checkContextLimitReached() {
+      const maxContextLength = this.increaseMaxContextThreshold ? this.contextLimitLarge : this.contextLimitSmall;
+      if (this.contextLength >= maxContextLength) {
+        const formattedLimit = this.formatCount(maxContextLength);
+        this.$root.showError(`Context length limit reached (${formattedLimit}+ tokens). Please start a new chat to continue.`);
+        return true;
+      }
+      return false;
+    },
     
     async loadNewChatScreen() {
       try {
@@ -308,12 +318,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       }
 
       // Check if context length has reached the limit
-      const maxContextLength = this.increaseMaxContextThreshold ? this.contextLimitLarge : this.contextLimitSmall;
-      if (this.contextLength >= maxContextLength) {
-        const formattedLimit = this.formatCount(maxContextLength);
-        this.$root.showError(`Context length limit reached (${formattedLimit}+ tokens). Please start a new chat to continue.`);
-        return;
-      }
+      if (this.checkContextLimitReached()) return;
       
       // Check if user has credits
       if (this.creditsRemaining <= 0) {
@@ -536,6 +541,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           
           // Check if this tool should be auto-approved
           if (this.shouldAutoApproveTool(toolUse.name)) {
+            if (this.checkContextLimitReached()) return;
             // Auto-approve the tool
             toolUse.status = 'executing';
             toolUse.approved = true;
@@ -847,6 +853,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           
           // Check if this chained tool should be auto-approved
           if (this.shouldAutoApproveTool(chainedToolUse.name)) {
+            if (this.checkContextLimitReached()) return;
             // Auto-approve the chained tool
             chainedToolUse.status = 'executing';
             chainedToolUse.approved = true;
@@ -1274,6 +1281,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     },
     async approveTool(toolUse) {
       try {
+        if (this.checkContextLimitReached()) return;
         toolUse.approved = true;
         toolUse.status = 'executing';
         await this.executeTool(toolUse);
@@ -1284,6 +1292,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       this.scrollToBottom();
     },
     async rejectTool(toolUse) {
+      if (this.checkContextLimitReached()) return;
       toolUse.approved = false;
       toolUse.status = 'rejected';
       toolUse.error = this.i18n.assistantToolUseReject;

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -329,7 +329,7 @@ test('loadCredits handles unhealthy status', async () => {
   
   await comp.loadCredits();
   
-  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: Health check in balance request came back unhealthy.');
+  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: The AI model could not be reached. Support for local AI models is coming soon.');
   expect(comp.creditsRemaining).toBe(0); // Should remain 0 when unhealthy
 });
 
@@ -339,15 +339,15 @@ test('loadChat switches to existing chat', async () => {
   comp.saveCurrentChat = jest.fn().mockResolvedValue();
   comp.loadChatFromBackend = jest.fn().mockResolvedValue();
   comp.updateUrlWithSessionId = jest.fn();
-  comp.scrollToBottom = jest.fn();
+  comp.clearStreamingStates = jest.fn();
   comp.currentChatId = chat.sessionId; // Set current chat ID to match
   
   await comp.loadChat(chat);
   
   expect(comp.saveCurrentChat).toHaveBeenCalled();
+  expect(comp.clearStreamingStates).toHaveBeenCalled();
   expect(comp.loadChatFromBackend).toHaveBeenCalledWith(chat.sessionId);
   expect(comp.updateUrlWithSessionId).toHaveBeenCalledWith(chat.sessionId);
-  expect(comp.scrollToBottom).toHaveBeenCalled();
 });
 
 test('loadChat handles error', async () => {
@@ -2019,6 +2019,166 @@ test('convertBackendMessagesToFrontend handles tool_use blocks with null/undefin
   expect(result[0].toolUses.value[0].input).toEqual({}); // Should default to empty object
 });
 
+test('convertBackendMessagesToFrontend handles tool_use blocks at end of session with pending_approval status', () => {
+  comp.resetContextLength = jest.fn();
+  comp.currentChatId = 'test_session_123';
+  global.Vue = { ref: jest.fn((value) => ({ value })) };
+  
+  // Single message with tool use at the end (no subsequent messages)
+  const backendMessages = [
+    {
+      createTime: '2025-01-01T12:00:00.000Z',
+      message: {
+        role: 'assistant',
+        contentBlocks: [
+          {
+            type: 'tool_use',
+            id: 'tool_end_session',
+            name: 'query_events',
+            input: { query: 'test query at end' }
+          }
+        ]
+      }
+    }
+    // No subsequent messages - this is the end of the session
+  ];
+  
+  const result = comp.convertBackendMessagesToFrontend(backendMessages);
+  
+  expect(result).toHaveLength(1);
+  expect(result[0]).toHaveProperty('toolUses');
+  expect(result[0].toolUses.value).toHaveLength(1);
+  
+  const toolUse = result[0].toolUses.value[0];
+  expect(toolUse.id).toBe('tool_end_session');
+  expect(toolUse.name).toBe('query_events');
+  expect(toolUse.input).toEqual({ query: 'test query at end' });
+  expect(toolUse.status).toBe('pending_approval'); // Key assertion for line 1473
+  expect(toolUse.result).toBe(null);
+  expect(toolUse.error).toBe(null);
+  expect(toolUse.rawResult).toBe(null);
+  expect(toolUse.timestamp).toBe('2025-01-01T12:00:00.000Z');
+  expect(toolUse.approved).toBe(null);
+  expect(toolUse.sessionId).toBe('test_session_123'); // Should include sessionId
+});
+
+test('convertBackendMessagesToFrontend handles multiple tool_use blocks at end of session', () => {
+  comp.resetContextLength = jest.fn();
+  comp.currentChatId = 'multi_tool_session';
+  global.Vue = { ref: jest.fn((value) => ({ value })) };
+  
+  // Message with multiple tool uses at the end of session
+  const backendMessages = [
+    {
+      createTime: '2025-01-01T12:00:00.000Z',
+      message: {
+        role: 'assistant',
+        contentBlocks: [
+          {
+            type: 'tool_use',
+            id: 'tool_1',
+            name: 'query_events',
+            input: { query: 'first query' }
+          },
+          {
+            type: 'tool_use',
+            id: 'tool_2',
+            name: 'get_playbook_questions',
+            input: { alert_id: 'alert_123' }
+          }
+        ]
+      }
+    }
+    // No subsequent messages
+  ];
+  
+  const result = comp.convertBackendMessagesToFrontend(backendMessages);
+  
+  expect(result).toHaveLength(1);
+  expect(result[0]).toHaveProperty('toolUses');
+  expect(result[0].toolUses.value).toHaveLength(2);
+  
+  // Both tools should have pending_approval status
+  result[0].toolUses.value.forEach((toolUse, index) => {
+    expect(toolUse.status).toBe('pending_approval');
+    expect(toolUse.approved).toBe(null);
+    expect(toolUse.sessionId).toBe('multi_tool_session');
+    expect(toolUse.id).toBe(`tool_${index + 1}`);
+  });
+});
+
+test('convertBackendMessagesToFrontend handles tool_use blocks at end with missing input', () => {
+  comp.resetContextLength = jest.fn();
+  comp.currentChatId = 'missing_input_session';
+  global.Vue = { ref: jest.fn((value) => ({ value })) };
+  
+  // Tool use block with missing input at end of session
+  const backendMessages = [
+    {
+      createTime: '2025-01-01T12:00:00.000Z',
+      message: {
+        role: 'assistant',
+        contentBlocks: [
+          {
+            type: 'tool_use',
+            id: 'tool_no_input',
+            name: 'simple_tool'
+            // No input property
+          }
+        ]
+      }
+    }
+  ];
+  
+  const result = comp.convertBackendMessagesToFrontend(backendMessages);
+  
+  expect(result).toHaveLength(1);
+  expect(result[0]).toHaveProperty('toolUses');
+  expect(result[0].toolUses.value).toHaveLength(1);
+  
+  const toolUse = result[0].toolUses.value[0];
+  expect(toolUse.status).toBe('pending_approval');
+  expect(toolUse.input).toEqual({}); // Should default to empty object
+  expect(toolUse.approved).toBe(null);
+  expect(toolUse.sessionId).toBe('missing_input_session');
+});
+
+test('convertBackendMessagesToFrontend handles tool_use blocks at end with missing id/name', () => {
+  comp.resetContextLength = jest.fn();
+  comp.currentChatId = 'missing_props_session';
+  global.Vue = { ref: jest.fn((value) => ({ value })) };
+  
+  // Tool use block with missing id and name at end of session
+  const backendMessages = [
+    {
+      createTime: '2025-01-01T12:00:00.000Z',
+      message: {
+        role: 'assistant',
+        contentBlocks: [
+          {
+            type: 'tool_use'
+            // Missing id and name properties
+          }
+        ]
+      }
+    }
+  ];
+  
+  const result = comp.convertBackendMessagesToFrontend(backendMessages);
+  
+  expect(result).toHaveLength(1);
+  expect(result[0]).toHaveProperty('toolUses');
+  expect(result[0].toolUses.value).toHaveLength(1);
+  
+  const toolUse = result[0].toolUses.value[0];
+  expect(toolUse.status).toBe('pending_approval');
+  expect(toolUse.id).toBe('unknown'); // Should default to 'unknown'
+  expect(toolUse.name).toBe('unknown'); // Should default to 'unknown'
+  expect(toolUse.input).toEqual({});
+  expect(toolUse.approved).toBe(null);
+  expect(toolUse.sessionId).toBe('missing_props_session');
+});
+
 test('convertBackendMessagesToFrontend filters out new format tool result messages', () => {
   comp.resetContextLength = jest.fn();
   global.Vue = { ref: jest.fn((value) => ({ value })) };
@@ -2282,18 +2442,20 @@ test('loadChatFromBackend success', async () => {
       message: {
         role: 'assistant',
         contentBlocks: [
-          { type: '', content: 'I can help you with security analysis and investigations.' }
+          { type: 'text', text: 'I can help you with security analysis and investigations.' }
         ]
       }
     }
   ];
   const mock = mockPapi("get", { data: testMessages });
+  comp.scrollToBottomSettled = jest.fn().mockResolvedValue();
   
   await comp.loadChatFromBackend(fakeSessionId);
   
   expect(mock).toHaveBeenCalledWith(`/assistant/sessions/${fakeSessionId}`);
   expect(comp.messages).toHaveLength(2);
   expect(comp.currentChatId).toBe(fakeSessionId);
+  expect(comp.scrollToBottomSettled).toHaveBeenCalled();
 });
 
 test('loadChatFromBackend handles 404 error', async () => {
@@ -2301,11 +2463,13 @@ test('loadChatFromBackend handles 404 error', async () => {
   error.response = { status: 404 };
   mockPapi("get", null, error);
   comp.loadNewChatScreen = jest.fn();
+  comp.scrollToBottomSettled = jest.fn().mockResolvedValue();
   
   await comp.loadChatFromBackend(fakeSessionId);
   
   expect(comp.loadNewChatScreen).toHaveBeenCalled();
   expect(comp.currentChatId).toBe(fakeSessionId);
+  expect(comp.scrollToBottomSettled).toHaveBeenCalled();
 });
 
 test('loadChatFromBackend handles other errors', async () => {
@@ -2792,4 +2956,569 @@ test('settings watcher integration with saveLocalSettings', () => {
   comp.saveLocalSettings(); // Simulating watcher trigger
   
   expect(comp.saveLocalSettings).toHaveBeenCalledTimes(4);
+});
+
+// scrollToBottomSettled method tests
+test('scrollToBottomSettled waits for nextTick and finds container', async () => {
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  // Mock MutationObserver and ResizeObserver
+  const mockMutationObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  const mockResizeObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  
+  global.MutationObserver = jest.fn().mockImplementation(() => mockMutationObserver);
+  global.ResizeObserver = jest.fn().mockImplementation(() => mockResizeObserver);
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  // Use fake timers to control setTimeout
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled();
+  
+  // Advance timers to trigger the settle timeout
+  jest.advanceTimersByTime(180);
+  
+  await promise;
+  
+  expect(comp.$nextTick).toHaveBeenCalled();
+  expect(comp.$el.querySelector).toHaveBeenCalledWith('.chat-messages');
+  expect(comp.forceScrollBottom).toHaveBeenCalledWith(mockContainer);
+  expect(global.MutationObserver).toHaveBeenCalled();
+  expect(mockMutationObserver.observe).toHaveBeenCalledWith(mockContainer, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+  expect(global.ResizeObserver).toHaveBeenCalled();
+  expect(mockResizeObserver.observe).toHaveBeenCalledWith(mockContainer);
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled returns early when no container found', async () => {
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(null)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  await comp.scrollToBottomSettled();
+  
+  expect(comp.$nextTick).toHaveBeenCalled();
+  expect(comp.$el.querySelector).toHaveBeenCalledWith('.chat-messages');
+  expect(comp.forceScrollBottom).not.toHaveBeenCalled();
+});
+
+test('scrollToBottomSettled returns early when $el is null', async () => {
+  comp.$el = null;
+  comp.forceScrollBottom = jest.fn();
+  
+  await comp.scrollToBottomSettled();
+  
+  expect(comp.$nextTick).toHaveBeenCalled();
+  expect(comp.forceScrollBottom).not.toHaveBeenCalled();
+});
+
+test('scrollToBottomSettled returns early when $el has no querySelector', async () => {
+  comp.$el = {};
+  comp.forceScrollBottom = jest.fn();
+  
+  await comp.scrollToBottomSettled();
+  
+  expect(comp.$nextTick).toHaveBeenCalled();
+  expect(comp.forceScrollBottom).not.toHaveBeenCalled();
+});
+
+test('scrollToBottomSettled uses custom settleDelay and maxWait options', async () => {
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  // Mock observers
+  const mockMutationObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  const mockResizeObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  
+  global.MutationObserver = jest.fn().mockImplementation(() => mockMutationObserver);
+  global.ResizeObserver = jest.fn().mockImplementation(() => mockResizeObserver);
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled({ settleDelay: 300, maxWait: 5000 });
+  
+  // Advance by custom settleDelay
+  jest.advanceTimersByTime(300);
+  
+  await promise;
+  
+  expect(comp.forceScrollBottom).toHaveBeenCalledWith(mockContainer);
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled handles height changes during settle period', async () => {
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  let mutationCallback;
+  const mockMutationObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  
+  global.MutationObserver = jest.fn().mockImplementation((callback) => {
+    mutationCallback = callback;
+    return mockMutationObserver;
+  });
+  
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled({ settleDelay: 200 });
+  
+  // Wait for the MutationObserver to be set up
+  await Promise.resolve();
+  
+  // Simulate height change during settle period
+  if (mutationCallback) {
+    mockContainer.scrollHeight = 600; // Height changed
+    mutationCallback(); // Trigger mutation callback
+  }
+  
+  // Advance timers to complete settling
+  jest.advanceTimersByTime(400);
+  
+  await promise;
+  
+  // Should have been called at least twice (initial + mutation trigger + final)
+  expect(comp.forceScrollBottom).toHaveBeenCalledWith(mockContainer);
+  expect(comp.forceScrollBottom).toHaveBeenCalledTimes(3);
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled handles image loading events', async () => {
+  const mockImg1 = {
+    complete: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  const mockImg2 = {
+    complete: true, // Already loaded
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([mockImg1, mockImg2]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  // Mock observers
+  global.MutationObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled();
+  
+  // Advance timers to complete
+  jest.advanceTimersByTime(180);
+  
+  await promise;
+  
+  expect(mockContainer.querySelectorAll).toHaveBeenCalledWith('img');
+  // Only incomplete image should have event listeners added
+  expect(mockImg1.addEventListener).toHaveBeenCalledWith('load', expect.any(Function), { once: true });
+  expect(mockImg1.addEventListener).toHaveBeenCalledWith('error', expect.any(Function), { once: true });
+  // Complete image should not have listeners added
+  expect(mockImg2.addEventListener).not.toHaveBeenCalled();
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled triggers safety timeout when maxWait exceeded', async () => {
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  let mutationCallback;
+  const mockMutationObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  
+  global.MutationObserver = jest.fn().mockImplementation((callback) => {
+    mutationCallback = callback;
+    return mockMutationObserver;
+  });
+  
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled({ settleDelay: 200, maxWait: 1000 });
+  
+  // Wait for setup
+  await Promise.resolve();
+  
+  // Keep triggering mutations to prevent settling
+  if (mutationCallback) {
+    for (let i = 0; i < 5; i++) {
+      mockContainer.scrollHeight += 10; // Keep changing height
+      mutationCallback();
+    }
+  }
+  
+  // Advance past maxWait time to trigger safety timeout
+  jest.advanceTimersByTime(1100);
+  
+  await promise;
+  
+  // Should have been called due to mutations and safety timeout
+  expect(comp.forceScrollBottom).toHaveBeenCalled();
+  expect(mockMutationObserver.disconnect).toHaveBeenCalled();
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled handles ResizeObserver not available', async () => {
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  // Mock MutationObserver but not ResizeObserver
+  global.MutationObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  
+  // Remove ResizeObserver from window
+  delete global.window.ResizeObserver;
+  delete global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled();
+  
+  jest.advanceTimersByTime(180);
+  
+  await promise;
+  
+  expect(comp.forceScrollBottom).toHaveBeenCalledWith(mockContainer);
+  expect(global.MutationObserver).toHaveBeenCalled();
+  // Should not throw error when ResizeObserver is not available
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled properly cleans up all observers and timers', async () => {
+  const mockImg = {
+    complete: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([mockImg]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  const mockMutationObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  const mockResizeObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  
+  global.MutationObserver = jest.fn().mockImplementation(() => mockMutationObserver);
+  global.ResizeObserver = jest.fn().mockImplementation(() => mockResizeObserver);
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  await comp.scrollToBottomSettled();
+  
+  // Advance timers to ensure cleanup happens
+  jest.advanceTimersByTime(200);
+  
+  // Verify all cleanup functions were called
+  expect(mockMutationObserver.disconnect).toHaveBeenCalled();
+  expect(mockResizeObserver.disconnect).toHaveBeenCalled();
+  // Note: removeEventListener calls depend on the cleanup function execution
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled handles image load event triggering mutation callback', async () => {
+  let imageLoadHandler;
+  const mockImg = {
+    complete: false,
+    addEventListener: jest.fn((event, handler) => {
+      if (event === 'load') {
+        imageLoadHandler = handler;
+      }
+    }),
+    removeEventListener: jest.fn()
+  };
+  
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([mockImg]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  global.MutationObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled();
+  
+  // Simulate image loading after 50ms
+  setTimeout(() => {
+    if (imageLoadHandler) {
+      imageLoadHandler(); // Trigger image load
+    }
+  }, 50);
+  
+  jest.advanceTimersByTime(180);
+  
+  await promise;
+  
+  expect(mockImg.addEventListener).toHaveBeenCalledWith('load', expect.any(Function), { once: true });
+  expect(comp.forceScrollBottom).toHaveBeenCalled();
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled settles immediately when height is stable', async () => {
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  const mockMutationObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  
+  global.MutationObserver = jest.fn().mockImplementation(() => mockMutationObserver);
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  await comp.scrollToBottomSettled({ settleDelay: 100 });
+  
+  // Advance timers to complete settling
+  jest.advanceTimersByTime(200);
+  
+  // Should have done initial scroll plus final scroll when settled
+  expect(comp.forceScrollBottom).toHaveBeenCalledWith(mockContainer);
+  expect(comp.forceScrollBottom).toHaveBeenCalledTimes(2);
+  expect(mockMutationObserver.disconnect).toHaveBeenCalled();
+  
+  jest.useRealTimers();
+});
+
+test('scrollToBottomSettled handles multiple rapid height changes', async () => {
+  const mockContainer = {
+    scrollTop: 0,
+    scrollHeight: 500,
+    clientHeight: 400,
+    querySelectorAll: jest.fn().mockReturnValue([]),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
+  
+  comp.$el = {
+    querySelector: jest.fn().mockReturnValue(mockContainer)
+  };
+  
+  comp.forceScrollBottom = jest.fn();
+  
+  let mutationCallback;
+  const mockMutationObserver = {
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  };
+  
+  global.MutationObserver = jest.fn().mockImplementation((callback) => {
+    mutationCallback = callback;
+    return mockMutationObserver;
+  });
+  
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    disconnect: jest.fn()
+  }));
+  global.window.ResizeObserver = global.ResizeObserver;
+  
+  jest.useFakeTimers();
+  
+  const promise = comp.scrollToBottomSettled({ settleDelay: 200 });
+  
+  // Wait for setup
+  await Promise.resolve();
+  
+  // Simulate rapid height changes
+  if (mutationCallback) {
+    mockContainer.scrollHeight = 600;
+    mutationCallback();
+    
+    mockContainer.scrollHeight = 700;
+    mutationCallback();
+    
+    mockContainer.scrollHeight = 800;
+    mutationCallback();
+  }
+  
+  // Let it settle after the changes
+  jest.advanceTimersByTime(400);
+  
+  await promise;
+  
+  // Should have scrolled multiple times due to height changes
+  expect(comp.forceScrollBottom).toHaveBeenCalledWith(mockContainer);
+  expect(comp.forceScrollBottom).toHaveBeenCalledTimes(5); // Initial + 3 changes + final
+  
+  jest.useRealTimers();
 });

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -84,7 +84,7 @@
 					<div class="text-wrap" style="font-size: 14px;">{{ i18n.contextLength }}: <span :class="getContextColor(contextLength)">{{ formatCount(contextLength) }}</span></div>
 				</v-card-title>
 				<v-divider></v-divider>
-				<v-card-text id="chat-messages" class="chat-messages pa-0">
+				<v-card-text id="chat-messages" class="chat-messages pa-0" @scroll="onChatScroll">
 					<div class="pa-4">
 						<div v-for="(message, index) in messages" :key="index" :id="'message-' + index" class="message-item mb-3">
 							<div class="d-flex align-start">

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -308,11 +308,11 @@
 </v-container>
 
 <v-container v-else fluid data-aid="assistant_advertisment">
-	<div style="
+	<div v-html="i18n.assistantAdvertisement" style="
 		align-items: center;
 		margin: 0;
 		display: flex;
 		min-height: 50vh;
 		justify-content: center;
-	">{{ i18n.assistantAdvertisement }}</div>
+	"></div>
 </v-container>


### PR DESCRIPTION
- Added the ability to scroll up to escape the auto-scroll during AI response streaming.
- Fixed visual bug when switching chat sessions, causing graphs, diagrams, etc. to briefly flash on the screen.
- Fixed unwanted behavior when switching to sessions with graphics, wherein the user was not being taken to the most recent chat messages (at the bottom) due to graphic height being rendered after the scroll-down.
- Updated data retention message to the newest draft. Tweaked CSS/HTML to account for the message shrinkage. Also updated the messages given in the other scenarios.
- Added more checks for context limit reached in order to prevent potential loopholes or unwanted context ballooning/overflow. Also localized this error.
- Modified tests and added additional coverage to account for these changes.