### PR TITLE
ack_alert tool

### DIFF
--- a/server/modules/assistant/ack_alert.go
+++ b/server/modules/assistant/ack_alert.go
@@ -1,0 +1,102 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/apex/log"
+)
+
+func init() {
+	t := &AckAlertTool{}
+	knownTools[t.GetName()] = t
+}
+
+type AckAlertTool struct{}
+
+func (t *AckAlertTool) GetName() string {
+	return "ack_alert"
+}
+
+func (t *AckAlertTool) GetDescription() string {
+	return "Acknowledge (A.K.A. ack) an alert in Security Onion using its unique identifier (soc_id)."
+}
+
+func (t *AckAlertTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"alert_id": {
+					Type:        "string",
+					Description: "The unique identifier of the alert to acknowledge. This is the `soc_id` field of the alert.",
+				},
+			},
+			Required: []string{"alert_id"},
+		},
+	}
+}
+
+type ackAlertArgs struct {
+	AlertId string `json:"alert_id"`
+}
+
+func (t *AckAlertTool) Execute(ctx context.Context, server *server.Server, params string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &ackAlertArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Parameters = args
+
+	crit := model.NewEventAckCriteria()
+	crit.Acknowledge = true
+	crit.SearchFilter = "tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true"
+	crit.EventFilter = map[string]any{
+		"soc_id": args.AlertId,
+	}
+
+	results, err := server.Eventstore.Acknowledge(ctx, crit)
+	if err != nil {
+		logger.WithError(err).Error("error acknowledging alert")
+
+		return nil, err
+	}
+
+	if results.UpdatedCount == 0 {
+		result.Result = "No alert was modified"
+	} else {
+		result.Result = "Success"
+	}
+
+	return result, nil
+}

--- a/server/modules/assistant/ack_alert_test.go
+++ b/server/modules/assistant/ack_alert_test.go
@@ -1,0 +1,231 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAckAlertTool_GetName(t *testing.T) {
+	tool := &AckAlertTool{}
+	assert.Equal(t, "ack_alert", tool.GetName())
+}
+
+func TestAckAlertTool_GetDescription(t *testing.T) {
+	desc := (&AckAlertTool{}).GetDescription()
+	assert.NotEmpty(t, desc)
+}
+
+func TestAckAlertTool_GetSchema(t *testing.T) {
+	schema := (&AckAlertTool{}).GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+	assert.Contains(t, schema.Json.Properties, "alert_id")
+	assert.Equal(t, "string", schema.Json.Properties["alert_id"].Type)
+	assert.Contains(t, schema.Json.Required, "alert_id")
+}
+
+func TestAckAlertTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name           string
+		params         string
+		mockResults    *model.EventUpdateResults
+		mockError      error
+		expectedResult string
+		expectedError  bool
+	}{
+		{
+			name:   "successful acknowledgment",
+			params: `{"alert_id": "alert-123"}`,
+			mockResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			expectedResult: "Success",
+		},
+		{
+			name:   "no alert modified",
+			params: `{"alert_id": "nonexistent-alert"}`,
+			mockResults: &model.EventUpdateResults{
+				UpdatedCount: 0,
+			},
+			expectedResult: "No alert was modified",
+		},
+		{
+			name:   "multiple alerts acknowledged",
+			params: `{"alert_id": "alert-456"}`,
+			mockResults: &model.EventUpdateResults{
+				UpdatedCount: 5,
+			},
+			expectedResult: "Success",
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"alert_id": "missing closing brace"`,
+			expectedError: true,
+		},
+		{
+			name:   "missing required alert_id field",
+			params: `{}`,
+			mockResults: &model.EventUpdateResults{
+				UpdatedCount: 0,
+			},
+			expectedResult: "No alert was modified",
+		},
+		{
+			name:          "eventstore error",
+			params:        `{"alert_id": "alert-789"}`,
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
+		{
+			name:   "alert with special characters in ID",
+			params: `{"alert_id": "alert-with-special-chars-!@#$%"}`,
+			mockResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			expectedResult: "Success",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock eventstore
+			mockEventstore := server.NewFakeEventstore()
+			if tc.mockResults != nil {
+				mockEventstore.UpdateResults = []*model.EventUpdateResults{tc.mockResults}
+			}
+			if tc.mockError != nil {
+				mockEventstore.Err = tc.mockError
+			}
+
+			// Create mock server
+			mockServer := &server.Server{
+				Eventstore: mockEventstore,
+			}
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create tool and execute
+			tool := &AckAlertTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params)
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "ack_alert", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+			assert.NotZero(t, result.TimeToExecute)
+
+			// Verify acknowledge criteria was populated correctly
+			if !tc.expectedError && tc.mockError == nil {
+				assert.Len(t, mockEventstore.InputAckCriterias, 1)
+				criteria := mockEventstore.InputAckCriterias[0]
+				assert.NotNil(t, criteria)
+				assert.True(t, criteria.Acknowledge)
+				assert.Equal(t, "tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true", criteria.SearchFilter)
+				assert.NotNil(t, criteria.EventFilter)
+
+				// Verify the alert_id was passed correctly in the event filter
+				if tc.params != `{}` { // Skip for missing alert_id test case
+					expectedAlertId := ""
+					switch tc.name {
+					case "successful acknowledgment":
+						expectedAlertId = "alert-123"
+					case "no alert modified":
+						expectedAlertId = "nonexistent-alert"
+					case "multiple alerts acknowledged":
+						expectedAlertId = "alert-456"
+					case "alert with special characters in ID":
+						expectedAlertId = "alert-with-special-chars-!@#$%"
+					}
+					if expectedAlertId != "" {
+						assert.Equal(t, expectedAlertId, criteria.EventFilter["soc_id"])
+					}
+				}
+			}
+
+			// Assert result content
+			if tc.expectedResult != "" {
+				assert.Equal(t, tc.expectedResult, result.Result)
+			}
+
+			// Verify parameters were captured
+			if !tc.expectedError {
+				assert.NotNil(t, result.Parameters)
+				args, ok := result.Parameters.(*ackAlertArgs)
+				assert.True(t, ok)
+				assert.NotNil(t, args)
+			}
+		})
+	}
+}
+
+func TestAckAlertTool_Execute_VerifyContextPropagation(t *testing.T) {
+	// This test verifies that the context is properly passed to the eventstore
+	mockEventstore := server.NewFakeEventstore()
+	mockEventstore.UpdateResults = []*model.EventUpdateResults{
+		{
+			UpdatedCount: 1,
+		},
+	}
+
+	mockServer := &server.Server{
+		Eventstore: mockEventstore,
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-123")
+
+	tool := &AckAlertTool{}
+	_, err := tool.Execute(ctx, mockServer, `{"alert_id": "test-alert"}`)
+
+	assert.NoError(t, err)
+	assert.Len(t, mockEventstore.InputContexts, 1)
+
+	// Verify the context contains the user ID
+	contextUserId := mockEventstore.InputContexts[0].Value(web.ContextKeyRequestorId)
+	assert.Equal(t, "test-user-123", contextUserId)
+}
+
+func TestAckAlertTool_Execute_EmptyAlertId(t *testing.T) {
+	// Test with empty string alert_id
+	mockEventstore := server.NewFakeEventstore()
+	mockEventstore.UpdateResults = []*model.EventUpdateResults{
+		{
+			UpdatedCount: 0,
+		},
+	}
+
+	mockServer := &server.Server{
+		Eventstore: mockEventstore,
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+	tool := &AckAlertTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"alert_id": ""}`)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "No alert was modified", result.Result)
+
+	// Verify empty string was still passed to eventstore
+	assert.Len(t, mockEventstore.InputAckCriterias, 1)
+	criteria := mockEventstore.InputAckCriterias[0]
+	assert.Equal(t, "", criteria.EventFilter["soc_id"])
+}

--- a/server/modules/assistant/get_playbook_questions_test.go
+++ b/server/modules/assistant/get_playbook_questions_test.go
@@ -66,6 +66,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							Range:    nil,
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-123",
 									Payload: map[string]any{
 										"@timestamp":   "2024-01-01T00:01:00Z",
 										"process.name": "malware.exe",
@@ -80,6 +81,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							Range:    nil,
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-123",
 									Payload: map[string]any{
 										"@timestamp":       "2024-01-01T00:02:00Z",
 										"destination.ip":   "192.168.1.100",
@@ -103,6 +105,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":       "alert-123",
 										"@timestamp":   "2024-01-01T00:01:00Z",
 										"process.name": "malware.exe",
 									},
@@ -116,6 +119,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":           "alert-123",
 										"@timestamp":       "2024-01-01T00:02:00Z",
 										"destination.ip":   "192.168.1.100",
 										"destination.port": 80,
@@ -161,6 +165,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							Range:    nil,
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-456",
 									Payload: map[string]any{
 										"@timestamp":     "2024-01-01T00:01:00Z",
 										"destination.ip": "192.168.1.1",
@@ -196,6 +201,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":         "alert-456",
 										"@timestamp":     "2024-01-01T00:01:00Z",
 										"destination.ip": "192.168.1.1",
 										"source.ip":      "10.0.0.1",
@@ -507,6 +513,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							Range:    nil,
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-1",
 									Payload: map[string]any{
 										"@timestamp":   "2024-01-01T00:01:00Z",
 										"process.name": "malware.exe",
@@ -521,6 +528,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							Range:    stringPtr("±1h"),
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-2",
 									Payload: map[string]any{
 										"@timestamp":       "2024-01-01T00:02:00Z",
 										"destination.ip":   "192.168.1.100",
@@ -544,6 +552,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":       "alert-1",
 										"@timestamp":   "2024-01-01T00:01:00Z",
 										"process.name": "malware.exe",
 									},
@@ -557,6 +566,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":           "alert-2",
 										"@timestamp":       "2024-01-01T00:02:00Z",
 										"destination.ip":   "192.168.1.100",
 										"destination.port": 80,
@@ -612,6 +622,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							Context:  "Has query results",
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-1",
 									Payload: map[string]any{
 										"@timestamp": "2024-01-01T00:01:00Z",
 										"source.ip":  "10.0.0.1",
@@ -629,6 +640,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							Context:  "Also has query results",
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-1",
 									Payload: map[string]any{
 										"@timestamp":     "2024-01-01T00:02:00Z",
 										"destination.ip": "192.168.1.1",
@@ -650,6 +662,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":     "alert-1",
 										"@timestamp": "2024-01-01T00:01:00Z",
 										"source.ip":  "10.0.0.1",
 									},
@@ -662,6 +675,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":         "alert-1",
 										"@timestamp":     "2024-01-01T00:02:00Z",
 										"destination.ip": "192.168.1.1",
 									},
@@ -685,6 +699,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							Context:  "First context",
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-1",
 									Payload: map[string]any{
 										"@timestamp": "2024-01-01T00:01:00Z",
 										"event.id":   "event-1",
@@ -703,6 +718,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							Context:  "Second context",
 							QueryResults: []*model.EventRecord{
 								{
+									Id: "alert-2",
 									Payload: map[string]any{
 										"@timestamp": "2024-01-01T00:02:00Z",
 										"event.id":   "event-2",
@@ -724,6 +740,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":     "alert-1",
 										"@timestamp": "2024-01-01T00:01:00Z",
 									},
 								},
@@ -741,6 +758,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
+										"soc_id":     "alert-2",
 										"@timestamp": "2024-01-01T00:02:00Z",
 									},
 								},

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -313,38 +313,40 @@ func filterEvents(events []*model.EventRecord) []map[string]any {
 	filtered := make([]map[string]any, 0, len(events))
 
 	for i, event := range events {
-		filteredPayload := make(map[string]any)
+		filteredPayload := map[string]any{
+			"soc_id": event.Id,
+		}
 
 		// Debug: log available fields for first event
 		if i == 0 {
-			fmt.Printf("[QueryEvents] First event payload fields:\n")
+			fmt.Printf("[query_events] First event payload fields:\n")
 			for key := range event.Payload {
 				fmt.Printf("  - %s\n", key)
 			}
 		}
 
-		// Copy only default fields
-		foundFields := 0
+		// Copy only default fields starting with the Id field
+		foundFields := 1
 		for _, field := range defaultFields {
 			// First try the field as-is (for non-nested fields)
 			if val, exists := event.Payload[field]; exists && val != nil {
 				filteredPayload[field] = val
 				foundFields++
 				if i == 0 && foundFields <= 10 {
-					fmt.Printf("[QueryEvents] Found direct field '%s'\n", field)
+					fmt.Printf("[query_events] Found direct field '%s'\n", field)
 				}
 			} else if value := getNestedField(event.Payload, field); value != nil {
 				// Try nested field lookup
 				setNestedField(filteredPayload, field, value)
 				foundFields++
 				if i == 0 && foundFields <= 10 {
-					fmt.Printf("[QueryEvents] Found nested field '%s'\n", field)
+					fmt.Printf("[query_events] Found nested field '%s'\n", field)
 				}
 			}
 		}
 
 		if i == 0 {
-			fmt.Printf("[QueryEvents] Filtered %d fields from first event\n", foundFields)
+			fmt.Printf("[query_events] Filtered %d fields from first event\n", foundFields)
 		}
 
 		filtered = append(filtered, map[string]any{

--- a/server/modules/assistant/query_events_test.go
+++ b/server/modules/assistant/query_events_test.go
@@ -36,8 +36,8 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"@timestamp": "2024-01-01T00:00:00Z", "tags": []string{"alert"}}},
-				{"payload": map[string]any{"@timestamp": "2024-01-01T00:01:00Z", "tags": []string{"alert"}}},
+				{"payload": map[string]any{"soc_id": "alert-1", "@timestamp": "2024-01-01T00:00:00Z", "tags": []string{"alert"}}},
+				{"payload": map[string]any{"soc_id": "alert-2", "@timestamp": "2024-01-01T00:01:00Z", "tags": []string{"alert"}}},
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
+				{"payload": map[string]any{"soc_id": "dns-1", "@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
 			},
 		},
 		{
@@ -83,7 +83,7 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
+				{"payload": map[string]any{"soc_id": "dns-1", "@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"@timestamp": "2024-01-01T00:00:00Z", "source.ip": "192.168.1.1", "destination.ip": "192.168.1.2"}},
+				{"payload": map[string]any{"soc_id": "conn-1", "@timestamp": "2024-01-01T00:00:00Z", "source.ip": "192.168.1.1", "destination.ip": "192.168.1.2"}},
 			},
 		},
 		{


### PR DESCRIPTION
To help make ack_alert as useful as possible, updated query_events to return soc_id for any events it finds. Updates tests as this had a ripple.

New ack_alert tool. The AI can acknowledge an alert by soc_id with this.