### PR TITLE
escalate_alerts

### DIFF
--- a/server/modules/assistant/escalate_alerts.go
+++ b/server/modules/assistant/escalate_alerts.go
@@ -1,0 +1,221 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/util"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/apex/log"
+)
+
+func init() {
+	t := &EscalateAlertsTool{}
+	knownTools[t.GetName()] = t
+}
+
+type EscalateAlertsTool struct{}
+
+func (t *EscalateAlertsTool) GetName() string {
+	return "escalate_alerts"
+}
+
+func (t *EscalateAlertsTool) GetDescription() string {
+	return "Escalate an alert in Security Onion to a new case using its unique identifier (soc_id)."
+}
+
+func (t *EscalateAlertsTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"search_filter": {
+					Type:        "string",
+					Description: `OQL search filter to find matching events (e.g., "tags:alert AND rule.uuid:xyz")`,
+				},
+				"case_title": {
+					Type:        "string",
+					Description: `Title for the new case, usually named after the rule name of the alert(s) being escalated (e.g., "ET SCAN Potential SSH Scan")`,
+				},
+				"date_range": {
+					Type:        "string",
+					Description: `Date range for searching events (e.g., "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM"). The range must contain two dates. Do not specify a timezone or any offsets in this field. If this field is specified, a date_range_format is required.`,
+				},
+				"date_range_format": {
+					Type:        "string",
+					Description: `Format of the date range (default: "2006/01/02 3:04:05 PM"). The format must be specified using Go's time package's reference layout format. "Relative" is not an acceptable format. Required when a date_range is provided.`,
+				},
+				"timezone": {
+					Type:        "string",
+					Description: `Timezone for the date range (default: "UTC")`,
+				},
+			},
+			Required: []string{"search_filter"},
+		},
+	}
+}
+
+type escalateAlertArgs struct {
+	SearchFilter    string `json:"search_filter"`
+	CaseTitle       string `json:"case_title"`
+	DateRange       string `json:"date_range,omitempty"`
+	DateRangeFormat string `json:"date_range_format,omitempty"`
+	Timezone        string `json:"timezone,omitempty"`
+}
+
+func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server, params string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &escalateAlertArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	if args.DateRange != "" {
+		if args.DateRangeFormat == "" {
+			return nil, fmt.Errorf("date_range_format is required when date_range is provided")
+		}
+
+		_, _, err = util.ParseDateRange(args.DateRange, args.DateRangeFormat, args.Timezone)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing date_range: %w", err)
+		}
+	}
+
+	result.Parameters = args
+
+	searchCrit := model.NewEventSearchCriteria()
+
+	err = searchCrit.Populate(
+		"(tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true) AND ("+args.SearchFilter+")",
+		args.DateRange,
+		args.DateRangeFormat,
+		args.Timezone,
+		"0",
+		"10000",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	searchCrit.SortFields = []*model.SortCriteria{
+		{
+			Field: "@timestamp",
+			Order: "desc",
+		},
+	}
+
+	// Step 1: Execute Search Filter, Retrieve Alerts
+
+	searchResults, err := server.Eventstore.Search(ctx, searchCrit)
+	if err != nil {
+		logger.WithError(err).Error("error searching for alerts to escalate")
+
+		return nil, err
+	}
+
+	// convert EventRecord to RelatedEvent
+	relatedEvents := make([]*model.RelatedEvent, 0, len(searchResults.Events))
+	for _, event := range searchResults.Events {
+		related := model.NewRelatedEvent()
+		related.Fields = event.Payload
+		related.Fields["soc_id"] = event.Id
+		related.Fields["soc_timestamp"] = event.Payload["@timestamp"]
+
+		relatedEvents = append(relatedEvents, related)
+	}
+
+	if len(relatedEvents) == 0 {
+		result.Result = "No alerts found with that query. No case was created."
+
+		return result, nil
+	}
+
+	// Step 2: Create Case
+
+	newCase := model.NewCase()
+	newCase.Title = args.CaseTitle
+	newCase.Description = "Review escalated event details in the Events tab below. Click here to update this description."
+
+	savedCase, err := server.Casestore.Create(ctx, newCase)
+	if err != nil {
+		logger.WithError(err).Error("error creating case for escalated alert")
+
+		return nil, err
+	}
+
+	for _, ev := range relatedEvents {
+		ev.CaseId = savedCase.Id
+	}
+
+	// Step 3: Link Alerts to Case
+
+	created, errMap, err := server.Casestore.CreateRelatedEvents(ctx, relatedEvents)
+	if err != nil {
+		logger.WithError(err).Error("error linking alerts to new case")
+
+		return nil, err
+	}
+
+	logger.WithFields(log.Fields{
+		"relatedEventsCreated": created,
+		"errMap":               util.TruncateMap(errMap, 20),
+	}).Info("linked alerts to new case")
+
+	// Step 4: Mark Alerts as Escalated
+
+	ackCrit := model.NewEventAckCriteria()
+	ackCrit.Acknowledge = true
+	ackCrit.Escalate = true
+	ackCrit.SearchFilter = searchCrit.ParsedQuery.String()
+	ackCrit.EventFilter = map[string]any{
+		"tags": "alert",
+	}
+
+	ackResults, err := server.Eventstore.Acknowledge(ctx, ackCrit)
+	if err != nil {
+		logger.WithError(err).Error("error escalating alert to new case")
+
+		return nil, err
+	}
+
+	if ackResults.UpdatedCount == 0 {
+		result.Result = "No case was created"
+	} else {
+		plural := ""
+		if ackResults.UpdatedCount != 1 {
+			plural = "s"
+		}
+
+		result.Result = fmt.Sprintf(`Successfully added %d alert%s to new case "%s" (Id: %s)`, created, plural, savedCase.Title, savedCase.Id)
+	}
+
+	return result, nil
+}

--- a/server/modules/assistant/escalate_alerts_test.go
+++ b/server/modules/assistant/escalate_alerts_test.go
@@ -1,0 +1,529 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/mock"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestEscalateAlertsTool_GetName(t *testing.T) {
+	tool := &EscalateAlertsTool{}
+	assert.Equal(t, "escalate_alerts", tool.GetName())
+}
+
+func TestEscalateAlertsTool_GetDescription(t *testing.T) {
+	desc := (&EscalateAlertsTool{}).GetDescription()
+	assert.NotEmpty(t, desc)
+}
+
+func TestEscalateAlertsTool_GetSchema(t *testing.T) {
+	schema := (&EscalateAlertsTool{}).GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+	assert.Contains(t, schema.Json.Properties, "search_filter")
+	assert.Equal(t, "string", schema.Json.Properties["search_filter"].Type)
+	assert.Contains(t, schema.Json.Properties, "case_title")
+	assert.Equal(t, "string", schema.Json.Properties["case_title"].Type)
+	assert.Contains(t, schema.Json.Properties, "date_range")
+	assert.Contains(t, schema.Json.Properties, "date_range_format")
+	assert.Contains(t, schema.Json.Properties, "timezone")
+	assert.Contains(t, schema.Json.Required, "search_filter")
+}
+
+func TestEscalateAlertsTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		params                  string
+		mockSearchResults       *model.EventSearchResults
+		mockUpdateResults       *model.EventUpdateResults
+		mockCase                *model.Case
+		mockError               error
+		expectedResult          string
+		expectedError           bool
+		expectedDateRange       string
+		expectedDateRangeFormat string
+		expectedTimezone        string
+	}{
+		{
+			name:   "successful escalation with search filter",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Test Alert Case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-123",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+							"rule.name":  "Test Rule",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "case-123",
+				},
+				Title: "Test Alert Case",
+			},
+			expectedResult: `Successfully added 1 alert to new case "Test Alert Case" (Id: case-123)`,
+		},
+		{
+			name:   "no alerts found",
+			params: `{"search_filter": "soc_id:nonexistent-alert", "case_title": "Empty Case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{},
+			},
+			expectedResult: "No alerts found with that query. No case was created.",
+		},
+		{
+			name:   "multiple alerts escalated",
+			params: `{"search_filter": "rule.uuid:xyz", "case_title": "Multiple Alerts Case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-1",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+					{
+						Id: "alert-2",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:01:00Z",
+						},
+					},
+					{
+						Id: "alert-3",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:02:00Z",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 3,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "case-456",
+				},
+				Title: "Multiple Alerts Case",
+			},
+			expectedResult: `Successfully added 3 alerts to new case "Multiple Alerts Case" (Id: case-456)`,
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"search_filter": "missing closing brace"`,
+			expectedError: true,
+		},
+		{
+			name:   "eventstore error",
+			params: `{"search_filter": "soc_id:alert-789", "case_title": "Error Case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-789",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+				},
+			},
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
+		{
+			name:          "with date range but no date_range_format",
+			params:        `{"search_filter": "soc_id:alert-123", "case_title": "Test Case", "date_range": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM"}`,
+			expectedError: true,
+		},
+		{
+			name:   "with date range and date_range_format",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Date Range Case", "date_range": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "date_range_format": "2006/01/02 3:04:05 PM"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-123",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+					{
+						Id: "alert-124",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:01:00Z",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 2,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "case-789",
+				},
+				Title: "Date Range Case",
+			},
+			expectedResult:          `Successfully added 2 alerts to new case "Date Range Case" (Id: case-789)`,
+			expectedDateRange:       "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM",
+			expectedDateRangeFormat: "2006/01/02 3:04:05 PM",
+		},
+		{
+			name:   "with timezone",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Timezone Case", "timezone": "America/New_York"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-123",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "case-999",
+				},
+				Title: "Timezone Case",
+			},
+			expectedResult:   `Successfully added 1 alert to new case "Timezone Case" (Id: case-999)`,
+			expectedTimezone: "America/New_York",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create mock eventstore
+			mockEventstore := server.NewFakeEventstore()
+			if tc.mockSearchResults != nil {
+				mockEventstore.SearchResults = []*model.EventSearchResults{tc.mockSearchResults}
+			}
+			if tc.mockUpdateResults != nil {
+				mockEventstore.UpdateResults = []*model.EventUpdateResults{tc.mockUpdateResults}
+			}
+			if tc.mockError != nil {
+				mockEventstore.Err = tc.mockError
+			}
+
+			// Create mock casestore
+			mockCasestore := mock.NewMockCasestore(ctrl)
+
+			// Only set up casestore expectations if we expect to create a case
+			if !tc.expectedError && tc.mockSearchResults != nil && len(tc.mockSearchResults.Events) > 0 {
+				// Expect Create call
+				mockCasestore.EXPECT().
+					Create(gomock.Any(), gomock.Any()).
+					Return(tc.mockCase, nil).
+					Times(1)
+
+				// Expect CreateRelatedEvents call
+				mockCasestore.EXPECT().
+					CreateRelatedEvents(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, events []*model.RelatedEvent) (int, map[string]error, error) {
+						return len(events), nil, nil
+					}).
+					Times(1)
+			}
+
+			// Create mock server
+			mockServer := &server.Server{
+				Eventstore: mockEventstore,
+				Casestore:  mockCasestore,
+			}
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create tool and execute
+			tool := &EscalateAlertsTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params)
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "escalate_alerts", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+			assert.NotZero(t, result.TimeToExecute)
+
+			// Verify search criteria was populated correctly
+			if !tc.expectedError && tc.mockError == nil {
+				assert.Len(t, mockEventstore.InputSearchCriterias, 1)
+				searchCrit := mockEventstore.InputSearchCriterias[0]
+				assert.NotNil(t, searchCrit)
+
+				// Verify the search filter wraps the user's filter with base criteria
+				assert.Contains(t, searchCrit.ParsedQuery.String(), "tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true")
+
+				// Verify acknowledge criteria was populated correctly if alerts were found
+				if tc.mockSearchResults != nil && len(tc.mockSearchResults.Events) > 0 {
+					assert.Len(t, mockEventstore.InputAckCriterias, 1)
+					ackCrit := mockEventstore.InputAckCriterias[0]
+					assert.NotNil(t, ackCrit)
+					assert.True(t, ackCrit.Acknowledge)
+					assert.True(t, ackCrit.Escalate)
+					assert.NotNil(t, ackCrit.EventFilter)
+					assert.Equal(t, "alert", ackCrit.EventFilter["tags"])
+				}
+
+				// Verify date range fields were parsed correctly if specified
+				// Note: The date range/format/timezone parameters are used to set BeginTime and EndTime
+				if tc.expectedDateRange != "" {
+					// Just verify that BeginTime and EndTime were set (not zero)
+					assert.False(t, searchCrit.BeginTime.IsZero())
+					assert.False(t, searchCrit.EndTime.IsZero())
+				}
+			}
+
+			// Assert result content
+			if tc.expectedResult != "" {
+				assert.Equal(t, tc.expectedResult, result.Result)
+			}
+
+			// Verify parameters were captured
+			if !tc.expectedError {
+				assert.NotNil(t, result.Parameters)
+				args, ok := result.Parameters.(*escalateAlertArgs)
+				assert.True(t, ok)
+				assert.NotNil(t, args)
+			}
+		})
+	}
+}
+
+func TestEscalateAlertsTool_Execute_VerifyContextPropagation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// This test verifies that the context is properly passed to the eventstore and casestore
+	mockEventstore := server.NewFakeEventstore()
+	mockEventstore.SearchResults = []*model.EventSearchResults{
+		{
+			Events: []*model.EventRecord{
+				{
+					Id: "test-alert",
+					Payload: map[string]interface{}{
+						"@timestamp": "2024-12-04T10:00:00Z",
+					},
+				},
+			},
+		},
+	}
+	mockEventstore.UpdateResults = []*model.EventUpdateResults{
+		{
+			UpdatedCount: 1,
+		},
+	}
+
+	mockCasestore := mock.NewMockCasestore(ctrl)
+	mockCasestore.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(&model.Case{Auditable: model.Auditable{Id: "case-123"}, Title: "Test Case"}, nil).
+		Times(1)
+	mockCasestore.EXPECT().
+		CreateRelatedEvents(gomock.Any(), gomock.Any()).
+		Return(1, nil, nil).
+		Times(1)
+
+	mockServer := &server.Server{
+		Eventstore: mockEventstore,
+		Casestore:  mockCasestore,
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-123")
+
+	tool := &EscalateAlertsTool{}
+	_, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:test-alert", "case_title": "Test Case"}`)
+
+	assert.NoError(t, err)
+	assert.Len(t, mockEventstore.InputContexts, 2) // Once for Search, once for Acknowledge
+
+	// Verify the context contains the user ID
+	contextUserId := mockEventstore.InputContexts[0].Value(web.ContextKeyRequestorId)
+	assert.Equal(t, "test-user-123", contextUserId)
+}
+
+func TestEscalateAlertsTool_Execute_EmptySearchFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Test with empty string search_filter - this should result in an error
+	// because the empty filter creates an invalid query during Populate
+	mockEventstore := server.NewFakeEventstore()
+	mockEventstore.SearchResults = []*model.EventSearchResults{
+		{
+			Events: []*model.EventRecord{},
+		},
+	}
+
+	mockCasestore := mock.NewMockCasestore(ctrl)
+
+	mockServer := &server.Server{
+		Eventstore: mockEventstore,
+		Casestore:  mockCasestore,
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+	tool := &EscalateAlertsTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"search_filter": "", "case_title": "Empty Filter Case"}`)
+
+	// Empty search filter results in an error during query parsing
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestEscalateAlertsTool_Execute_ComplexQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Test with a complex search filter and multiple parameters
+	mockEventstore := server.NewFakeEventstore()
+	mockEventstore.SearchResults = []*model.EventSearchResults{
+		{
+			Events: []*model.EventRecord{
+				{Id: "alert-1", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:00:00Z"}},
+				{Id: "alert-2", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:01:00Z"}},
+				{Id: "alert-3", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:02:00Z"}},
+				{Id: "alert-4", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:03:00Z"}},
+				{Id: "alert-5", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:04:00Z"}},
+				{Id: "alert-6", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:05:00Z"}},
+				{Id: "alert-7", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:06:00Z"}},
+				{Id: "alert-8", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:07:00Z"}},
+				{Id: "alert-9", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:08:00Z"}},
+				{Id: "alert-10", Payload: map[string]interface{}{"@timestamp": "2024-12-04T10:09:00Z"}},
+			},
+		},
+	}
+	mockEventstore.UpdateResults = []*model.EventUpdateResults{
+		{
+			UpdatedCount: 10,
+		},
+	}
+
+	mockCasestore := mock.NewMockCasestore(ctrl)
+	mockCasestore.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(&model.Case{Auditable: model.Auditable{Id: "case-complex"}, Title: "Complex Phishing Case"}, nil).
+		Times(1)
+	mockCasestore.EXPECT().
+		CreateRelatedEvents(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, events []*model.RelatedEvent) (int, map[string]error, error) {
+			assert.Len(t, events, 10)
+			return 10, nil, nil
+		}).
+		Times(1)
+
+	mockServer := &server.Server{
+		Eventstore: mockEventstore,
+		Casestore:  mockCasestore,
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+	tool := &EscalateAlertsTool{}
+	params := `{
+		"search_filter": "rule.name:*phishing* AND event.severity:high",
+		"case_title": "Complex Phishing Case",
+		"date_range": "2024/12/01 12:00:00 PM - 2024/12/07 12:00:00 PM",
+		"date_range_format": "2006/01/02 3:04:05 PM",
+		"timezone": "America/New_York"
+	}`
+	result, err := tool.Execute(ctx, mockServer, params)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, `Successfully added 10 alerts to new case "Complex Phishing Case" (Id: case-complex)`, result.Result)
+
+	// Verify all search criteria fields were populated correctly
+	assert.Len(t, mockEventstore.InputSearchCriterias, 1)
+	searchCrit := mockEventstore.InputSearchCriterias[0]
+	assert.Contains(t, searchCrit.ParsedQuery.String(), "tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true")
+	assert.Contains(t, searchCrit.ParsedQuery.String(), "rule.name:*phishing* AND event.severity:high")
+	// Verify date range was parsed correctly
+	assert.False(t, searchCrit.BeginTime.IsZero())
+	assert.False(t, searchCrit.EndTime.IsZero())
+
+	// Verify acknowledge criteria
+	assert.Len(t, mockEventstore.InputAckCriterias, 1)
+	ackCrit := mockEventstore.InputAckCriterias[0]
+	assert.True(t, ackCrit.Acknowledge)
+	assert.True(t, ackCrit.Escalate)
+	assert.Equal(t, "alert", ackCrit.EventFilter["tags"])
+}
+
+func TestEscalateAlertsTool_Execute_NoAlertsEscalated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Test when alerts are found but none get escalated (UpdatedCount = 0)
+	mockEventstore := server.NewFakeEventstore()
+	mockEventstore.SearchResults = []*model.EventSearchResults{
+		{
+			Events: []*model.EventRecord{
+				{
+					Id: "alert-123",
+					Payload: map[string]interface{}{
+						"@timestamp": "2024-12-04T10:00:00Z",
+					},
+				},
+			},
+		},
+	}
+	mockEventstore.UpdateResults = []*model.EventUpdateResults{
+		{
+			UpdatedCount: 0,
+		},
+	}
+
+	mockCasestore := mock.NewMockCasestore(ctrl)
+	mockCasestore.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(&model.Case{Auditable: model.Auditable{Id: "case-123"}, Title: "Test Case"}, nil).
+		Times(1)
+	mockCasestore.EXPECT().
+		CreateRelatedEvents(gomock.Any(), gomock.Any()).
+		Return(1, nil, nil).
+		Times(1)
+
+	mockServer := &server.Server{
+		Eventstore: mockEventstore,
+		Casestore:  mockCasestore,
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+	tool := &EscalateAlertsTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:alert-123", "case_title": "Test Case"}`)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "No case was created", result.Result)
+}

--- a/server/modules/assistant/get_playbook_questions_test.go
+++ b/server/modules/assistant/get_playbook_questions_test.go
@@ -105,7 +105,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":       "alert-123",
+										"_id":          "alert-123",
 										"@timestamp":   "2024-01-01T00:01:00Z",
 										"process.name": "malware.exe",
 									},
@@ -119,7 +119,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":           "alert-123",
+										"_id":              "alert-123",
 										"@timestamp":       "2024-01-01T00:02:00Z",
 										"destination.ip":   "192.168.1.100",
 										"destination.port": 80,
@@ -201,7 +201,7 @@ func TestGetPlaybookQuestionsTool_Execute(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":         "alert-456",
+										"_id":            "alert-456",
 										"@timestamp":     "2024-01-01T00:01:00Z",
 										"destination.ip": "192.168.1.1",
 										"source.ip":      "10.0.0.1",
@@ -552,7 +552,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":       "alert-1",
+										"_id":          "alert-1",
 										"@timestamp":   "2024-01-01T00:01:00Z",
 										"process.name": "malware.exe",
 									},
@@ -566,7 +566,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":           "alert-2",
+										"_id":              "alert-2",
 										"@timestamp":       "2024-01-01T00:02:00Z",
 										"destination.ip":   "192.168.1.100",
 										"destination.port": 80,
@@ -662,7 +662,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":     "alert-1",
+										"_id":        "alert-1",
 										"@timestamp": "2024-01-01T00:01:00Z",
 										"source.ip":  "10.0.0.1",
 									},
@@ -675,7 +675,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":         "alert-1",
+										"_id":            "alert-1",
 										"@timestamp":     "2024-01-01T00:02:00Z",
 										"destination.ip": "192.168.1.1",
 									},
@@ -740,7 +740,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":     "alert-1",
+										"_id":        "alert-1",
 										"@timestamp": "2024-01-01T00:01:00Z",
 									},
 								},
@@ -758,7 +758,7 @@ func TestSimplifyPlaybooks(t *testing.T) {
 							QueryResults: []map[string]any{
 								{
 									"payload": map[string]any{
-										"soc_id":     "alert-2",
+										"_id":        "alert-2",
 										"@timestamp": "2024-01-01T00:02:00Z",
 									},
 								},

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -284,7 +284,6 @@ func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, pa
 func filterEvents(events []*model.EventRecord) []map[string]any {
 	// Default fields from Python implementation
 	defaultFields := []string{
-		"_id",
 		"@timestamp",
 		"client.name",
 		"destination.ip", "destination.port", "destination.geo.country_name",
@@ -314,7 +313,7 @@ func filterEvents(events []*model.EventRecord) []map[string]any {
 
 	for i, event := range events {
 		filteredPayload := map[string]any{
-			"soc_id": event.Id,
+			"_id": event.Id,
 		}
 
 		// Debug: log available fields for first event

--- a/server/modules/assistant/query_events_test.go
+++ b/server/modules/assistant/query_events_test.go
@@ -36,8 +36,8 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"soc_id": "alert-1", "@timestamp": "2024-01-01T00:00:00Z", "tags": []string{"alert"}}},
-				{"payload": map[string]any{"soc_id": "alert-2", "@timestamp": "2024-01-01T00:01:00Z", "tags": []string{"alert"}}},
+				{"payload": map[string]any{"_id": "alert-1", "@timestamp": "2024-01-01T00:00:00Z", "tags": []string{"alert"}}},
+				{"payload": map[string]any{"_id": "alert-2", "@timestamp": "2024-01-01T00:01:00Z", "tags": []string{"alert"}}},
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"soc_id": "dns-1", "@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
+				{"payload": map[string]any{"_id": "dns-1", "@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
 			},
 		},
 		{
@@ -83,7 +83,7 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"soc_id": "dns-1", "@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
+				{"payload": map[string]any{"_id": "dns-1", "@timestamp": "2024-01-01T00:00:00Z", "dns.query.name": "example.com"}},
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 				Metrics:     make(map[string][]*model.EventMetric),
 			},
 			expectedResult: []map[string]any{
-				{"payload": map[string]any{"soc_id": "conn-1", "@timestamp": "2024-01-01T00:00:00Z", "source.ip": "192.168.1.1", "destination.ip": "192.168.1.2"}},
+				{"payload": map[string]any{"_id": "conn-1", "@timestamp": "2024-01-01T00:00:00Z", "source.ip": "192.168.1.1", "destination.ip": "192.168.1.2"}},
 			},
 		},
 		{


### PR DESCRIPTION
Implemented and tested escalate_alerts tool.

query_events now uses _id instead of soc_id to keep consistent with fields used in queries.