### PR TITLE
Unify Tools Approach to Date Ranges

### DIFF
--- a/server/modules/assistant/ack_alerts.go
+++ b/server/modules/assistant/ack_alerts.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
-	"github.com/security-onion-solutions/securityonion-soc/util"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 
 	"github.com/apex/log"
@@ -53,17 +52,17 @@ func (t *AckAlertsTool) GetSchema() model.JSONSchema {
 					Type:        "object",
 					Description: "Optional dict of field:value pairs to further filter events",
 				},
-				"date_range": {
+				"range_start": {
 					Type:        "string",
-					Description: `Date range for searching events (e.g., "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM"). The range must contain two dates. Do not specify a timezone or any offsets in this field. If this field is specified, a date_range_format is required.`,
+					Description: "Optional start time for the query range (e.g., \"-1h\", \"2023/10/26 10:00:00 AM\"). Default is 24 hours ago (\"-24h\")",
 				},
-				"date_range_format": {
+				"range_end": {
 					Type:        "string",
-					Description: `Format of the date range (default: "2006/01/02 3:04:05 PM"). The format must be specified using Go's time package's reference layout format. "Relative" is not an acceptable format. Required when a date_range is provided.`,
+					Description: "Optional end time for the query range (e.g., \"now\", \"2023/10/26 12:00:00 PM\"). Default is now.",
 				},
-				"timezone": {
+				"range_format": {
 					Type:        "string",
-					Description: `Timezone for the date range (default: "UTC")`,
+					Description: "Format of the date range (default: \"2006/01/02 3:04:05 PM\"). The format must be specified using Go's time package's reference layout format. Required if either range_start or range_end is provided.",
 				},
 			},
 			Required: []string{"search_filter"},
@@ -72,11 +71,11 @@ func (t *AckAlertsTool) GetSchema() model.JSONSchema {
 }
 
 type ackAlertArgs struct {
-	SearchFilter    string         `json:"search_filter"`
-	EventFilter     map[string]any `json:"event_filter,omitempty"`
-	DateRange       string         `json:"date_range,omitempty"`
-	DateRangeFormat string         `json:"date_range_format,omitempty"`
-	Timezone        string         `json:"timezone,omitempty"`
+	SearchFilter string         `json:"search_filter"`
+	EventFilter  map[string]any `json:"event_filter,omitempty"`
+	RangeStart   string         `json:"range_start,omitempty"`
+	RangeEnd     string         `json:"range_end,omitempty"`
+	RangeFormat  string         `json:"range_format,omitempty"`
 }
 
 func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, params string) (result *model.ToolResponse, err error) {
@@ -104,15 +103,10 @@ func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, para
 		return nil, err
 	}
 
-	if args.DateRange != "" {
-		if args.DateRangeFormat == "" {
-			return nil, fmt.Errorf("date_range_format is required when date_range is provided")
-		}
+	var timeRange string
 
-		_, _, err = util.ParseDateRange(args.DateRange, args.DateRangeFormat, args.Timezone)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing date_range: %w", err)
-		}
+	if args.RangeStart != "" || args.RangeEnd != "" {
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
 	}
 
 	result.Parameters = args
@@ -121,9 +115,9 @@ func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, para
 	crit.Acknowledge = true
 	crit.SearchFilter = "(tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true) AND (" + args.SearchFilter + ")"
 	crit.EventFilter = args.EventFilter
-	crit.DateRange = args.DateRange
-	crit.DateRangeFormat = args.DateRangeFormat
-	crit.Timezone = args.Timezone
+	crit.DateRange = timeRange
+	crit.DateRangeFormat = "2006/01/02 3:04:05 PM"
+	crit.Timezone = "UTC"
 
 	if len(crit.EventFilter) == 0 {
 		crit.EventFilter = map[string]any{

--- a/server/modules/assistant/ack_alerts.go
+++ b/server/modules/assistant/ack_alerts.go
@@ -31,9 +31,9 @@ func (t *AckAlertsTool) GetName() string {
 
 func (t *AckAlertsTool) GetDescription() string {
 	return `Acknowledge (A.K.A. ack) alerts in Security Onion by querying them with an OQL query.
-If date_range is specified, then date_range_format is required. If multiple alerts are difficult
-to gather in one query, try OR'ing all the Ids together in the search_filter. When querying by id,
-use _id instead of soc_id as the field. For this tool, all dates are absolute.\n` +
+If range_start or range_end is specified, then date_range_format is required. If multiple alerts are
+difficult to gather in one query, try OR'ing all the Ids together in the search_filter. When querying
+by id, use _id instead of soc_id as the field.\n` +
 		"- Examples for wild cards:\n" +
 		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
 		"  - If you use wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `rule.name:(A B*)` is valid, but `rule.name:\"A B*\"` will not work as expected)"

--- a/server/modules/assistant/ack_alerts_test.go
+++ b/server/modules/assistant/ack_alerts_test.go
@@ -35,9 +35,12 @@ func TestAckAlertsTool_GetSchema(t *testing.T) {
 	assert.Equal(t, "string", schema.Json.Properties["search_filter"].Type)
 	assert.Contains(t, schema.Json.Properties, "event_filter")
 	assert.Equal(t, "object", schema.Json.Properties["event_filter"].Type)
-	assert.Contains(t, schema.Json.Properties, "date_range")
-	assert.Contains(t, schema.Json.Properties, "date_range_format")
-	assert.Contains(t, schema.Json.Properties, "timezone")
+	assert.Contains(t, schema.Json.Properties, "range_start")
+	assert.Equal(t, "string", schema.Json.Properties["range_start"].Type)
+	assert.Contains(t, schema.Json.Properties, "range_end")
+	assert.Equal(t, "string", schema.Json.Properties["range_end"].Type)
+	assert.Contains(t, schema.Json.Properties, "range_format")
+	assert.Equal(t, "string", schema.Json.Properties["range_format"].Type)
 	assert.Contains(t, schema.Json.Required, "search_filter")
 }
 
@@ -48,11 +51,9 @@ func TestAckAlertsTool_Execute(t *testing.T) {
 		mockResults             *model.EventUpdateResults
 		mockError               error
 		expectedResult          string
-		expectedError           bool
-		expectedEventFilter     map[string]any
-		expectedDateRange       string
-		expectedDateRangeFormat string
-		expectedTimezone        string
+		expectedError       bool
+		expectedEventFilter map[string]any
+		expectDateRange     bool
 	}{
 		{
 			name:   "successful acknowledgment with search filter",
@@ -107,28 +108,31 @@ func TestAckAlertsTool_Execute(t *testing.T) {
 			expectedEventFilter: map[string]any{"rule.uuid": "test-uuid"},
 		},
 		{
-			name:          "with date range but no date_range_format",
-			params:        `{"search_filter": "soc_id:alert-123", "date_range": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM"}`,
-			expectedError: true,
-		},
-		{
-			name:   "with date range and date_range_format",
-			params: `{"search_filter": "soc_id:alert-123", "date_range": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "date_range_format": "2006/01/02 3:04:05 PM"}`,
-			mockResults: &model.EventUpdateResults{
-				UpdatedCount: 2,
-			},
-			expectedResult:          "2 eligible alerts were successfully acknowledged",
-			expectedDateRange:       "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM",
-			expectedDateRangeFormat: "2006/01/02 3:04:05 PM",
-		},
-		{
-			name:   "with timezone",
-			params: `{"search_filter": "soc_id:alert-123", "timezone": "America/New_York"}`,
+			name:   "with range_start only (treated as relative)",
+			params: `{"search_filter": "soc_id:alert-123", "range_start": "-2h"}`,
 			mockResults: &model.EventUpdateResults{
 				UpdatedCount: 1,
 			},
-			expectedResult:   "1 eligible alert were successfully acknowledged",
-			expectedTimezone: "America/New_York",
+			expectedResult:  "1 eligible alert were successfully acknowledged",
+			expectDateRange: true,
+		},
+		{
+			name:   "with range_start, range_end and range_format",
+			params: `{"search_filter": "soc_id:alert-123", "range_start": "2024/12/03 02:31:35 PM", "range_end": "2024/12/04 02:31:35 PM", "range_format": "2006/01/02 3:04:05 PM"}`,
+			mockResults: &model.EventUpdateResults{
+				UpdatedCount: 2,
+			},
+			expectedResult:  "2 eligible alerts were successfully acknowledged",
+			expectDateRange: true,
+		},
+		{
+			name:   "with relative date range",
+			params: `{"search_filter": "soc_id:alert-123", "range_start": "-1h", "range_end": "now"}`,
+			mockResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			expectedResult:  "1 eligible alert were successfully acknowledged",
+			expectDateRange: true,
 		},
 	}
 
@@ -191,16 +195,10 @@ func TestAckAlertsTool_Execute(t *testing.T) {
 				}
 
 				// Verify date range fields if specified
-				if tc.expectedDateRange != "" {
-					assert.Equal(t, tc.expectedDateRange, criteria.DateRange)
-				}
-
-				if tc.expectedDateRangeFormat != "" {
-					assert.Equal(t, tc.expectedDateRangeFormat, criteria.DateRangeFormat)
-				}
-
-				if tc.expectedTimezone != "" {
-					assert.Equal(t, tc.expectedTimezone, criteria.Timezone)
+				if tc.expectDateRange {
+					assert.NotEmpty(t, criteria.DateRange)
+					assert.Equal(t, "2006/01/02 3:04:05 PM", criteria.DateRangeFormat)
+					assert.Equal(t, "UTC", criteria.Timezone)
 				}
 			}
 
@@ -293,9 +291,9 @@ func TestAckAlertsTool_Execute_ComplexQuery(t *testing.T) {
 	params := `{
 		"search_filter": "rule.name:*phishing* AND event.severity:high",
 		"event_filter": {"source.ip": "192.168.1.1", "destination.port": 443},
-		"date_range": "2024/12/01 12:00:00 PM - 2024/12/07 12:00:00 PM",
-		"date_range_format": "2006/01/02 3:04:05 PM",
-		"timezone": "America/New_York"
+		"range_start": "2024/12/01 12:00:00 PM",
+		"range_end": "2024/12/07 12:00:00 PM",
+		"range_format": "2006/01/02 3:04:05 PM"
 	}`
 	result, err := tool.Execute(ctx, mockServer, params)
 
@@ -310,7 +308,7 @@ func TestAckAlertsTool_Execute_ComplexQuery(t *testing.T) {
 	assert.Equal(t, "(tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true) AND (rule.name:*phishing* AND event.severity:high)", criteria.SearchFilter)
 	assert.Equal(t, "192.168.1.1", criteria.EventFilter["source.ip"])
 	assert.Equal(t, float64(443), criteria.EventFilter["destination.port"])
-	assert.Equal(t, "2024/12/01 12:00:00 PM - 2024/12/07 12:00:00 PM", criteria.DateRange)
+	assert.NotEmpty(t, criteria.DateRange)
 	assert.Equal(t, "2006/01/02 3:04:05 PM", criteria.DateRangeFormat)
-	assert.Equal(t, "America/New_York", criteria.Timezone)
+	assert.Equal(t, "UTC", criteria.Timezone)
 }

--- a/server/modules/assistant/common.go
+++ b/server/modules/assistant/common.go
@@ -1,0 +1,39 @@
+package assistant
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/util"
+)
+
+func parseRangeAllowRelative(rangeStart string, rangeEnd string, format string) string {
+	start := "-24h"
+	end := "now"
+
+	if rangeStart != "" {
+		start = rangeStart
+	}
+	if rangeEnd != "" {
+		end = rangeEnd
+	}
+
+	var startFormatted, endFormatted string
+
+	// Parse and format times
+	startParsed, err := time.Parse(format, start)
+	if err != nil {
+		startFormatted = util.ParseRelativeTimeString(start)
+	} else {
+		startFormatted = util.FormatSOTime(startParsed)
+	}
+
+	endParsed, err := time.Parse(format, end)
+	if err != nil {
+		endFormatted = util.ParseRelativeTimeString(end)
+	} else {
+		endFormatted = util.FormatSOTime(endParsed)
+	}
+
+	return fmt.Sprintf("%s - %s", startFormatted, endFormatted)
+}

--- a/server/modules/assistant/common_test.go
+++ b/server/modules/assistant/common_test.go
@@ -1,0 +1,255 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRangeAllowRelative(t *testing.T) {
+	testCases := []struct {
+		name             string
+		rangeStart       string
+		rangeEnd         string
+		format           string
+		expectStart      string        // Exact string match (if non-empty)
+		expectEnd        string        // Exact string match (if non-empty)
+		expectDelta      time.Duration // Expected time difference between start and end
+		deltaTolerance   time.Duration // Tolerance for time difference (defaults to 5 seconds)
+		checkMidnight    bool          // Verify start time is at midnight (for "today")
+		checkSeparator   bool          // Verify " - " separator (default true)
+		checkNonEmpty    bool          // Verify result is not empty (default true)
+		expectParseable  bool          // Verify both parts are parseable as dates (default false)
+		expectStartOrder bool          // Verify start is before end (default false)
+	}{
+		{
+			name:             "default empty values",
+			rangeStart:       "",
+			rangeEnd:         "",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      24 * time.Hour,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: -1h to now",
+			rangeStart:       "-1h",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      1 * time.Hour,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: -24h to now",
+			rangeStart:       "-24h",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      24 * time.Hour,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: -7d to now",
+			rangeStart:       "-7d",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      7 * 24 * time.Hour,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: -30m to now",
+			rangeStart:       "-30m",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      30 * time.Minute,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: -5h to now",
+			rangeStart:       "-5h",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      5 * time.Hour,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: -3d to now",
+			rangeStart:       "-3d",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      3 * 24 * time.Hour,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: -2h to now (ordering test)",
+			rangeStart:       "-2h",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			expectDelta:      2 * time.Hour,
+			deltaTolerance:   5 * time.Second,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:             "relative time: today to now",
+			rangeStart:       "today",
+			rangeEnd:         "now",
+			format:           "2006/01/02 3:04:05 PM",
+			checkMidnight:    true,
+			checkSeparator:   true,
+			checkNonEmpty:    true,
+			expectParseable:  true,
+			expectStartOrder: true,
+		},
+		{
+			name:           "absolute times with correct format",
+			rangeStart:     "2025/01/15 10:00:00 AM",
+			rangeEnd:       "2025/01/15 11:00:00 AM",
+			format:         "2006/01/02 3:04:05 PM",
+			expectStart:    "2025/01/15 10:00:00 AM",
+			expectEnd:      "2025/01/15 11:00:00 AM",
+			checkSeparator: true,
+			checkNonEmpty:  true,
+		},
+		{
+			name:           "mixed: relative start, absolute end",
+			rangeStart:     "-1h",
+			rangeEnd:       "2025/01/15 11:00:00 AM",
+			format:         "2006/01/02 3:04:05 PM",
+			expectEnd:      "2025/01/15 11:00:00 AM",
+			checkSeparator: true,
+			checkNonEmpty:  true,
+		},
+		{
+			name:           "mixed: absolute start, relative end",
+			rangeStart:     "2025/01/15 10:00:00 AM",
+			rangeEnd:       "now",
+			format:         "2006/01/02 3:04:05 PM",
+			expectStart:    "2025/01/15 10:00:00 AM",
+			checkSeparator: true,
+			checkNonEmpty:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				result := parseRangeAllowRelative(tc.rangeStart, tc.rangeEnd, tc.format)
+
+				// Basic validations
+				if tc.checkNonEmpty {
+					assert.NotEmpty(t, result, "Result should not be empty")
+				}
+
+				if tc.checkSeparator {
+					assert.Contains(t, result, " - ", "Result should contain ' - ' separator")
+				}
+
+				// Split the result
+				parts := splitRange(result)
+				if tc.checkSeparator {
+					assert.Len(t, parts, 2, "Result should have exactly 2 parts")
+				}
+
+				// Check exact matches
+				if tc.expectStart != "" {
+					assert.Contains(t, result, tc.expectStart, "Result should contain expected start time")
+				}
+				if tc.expectEnd != "" {
+					assert.Contains(t, result, tc.expectEnd, "Result should contain expected end time")
+				}
+
+				// Parse times if needed for further validation
+				if tc.expectParseable || tc.expectDelta > 0 || tc.checkMidnight || tc.expectStartOrder {
+					if len(parts) != 2 {
+						t.Fatal("Cannot proceed with time parsing - invalid parts count")
+					}
+
+					startTime, err := time.Parse("2006/01/02 3:04:05 PM", parts[0])
+					assert.NoError(t, err, "Start time should be parseable")
+
+					endTime, err := time.Parse("2006/01/02 3:04:05 PM", parts[1])
+					assert.NoError(t, err, "End time should be parseable")
+
+					// Check time ordering
+					if tc.expectStartOrder {
+						assert.True(t, startTime.Before(endTime), "Start time should be before end time")
+					}
+
+					// Check time delta
+					if tc.expectDelta > 0 {
+						tolerance := tc.deltaTolerance
+						if tolerance == 0 {
+							tolerance = 5 * time.Second
+						}
+						duration := endTime.Sub(startTime)
+						assert.InDelta(t, tc.expectDelta, duration, float64(tolerance),
+							"Duration should be approximately %v", tc.expectDelta)
+					}
+
+					// Check midnight for "today"
+					if tc.checkMidnight {
+						assert.Equal(t, 0, startTime.Hour(), "Today should start at hour 0")
+						assert.Equal(t, 0, startTime.Minute(), "Today should start at minute 0")
+						assert.Equal(t, 0, startTime.Second(), "Today should start at second 0")
+
+						// Verify it's today's date
+						now := time.Now()
+						assert.Equal(t, now.Year(), startTime.Year(), "Year should match today")
+						assert.Equal(t, now.Month(), startTime.Month(), "Month should match today")
+						assert.Equal(t, now.Day(), startTime.Day(), "Day should match today")
+					}
+				}
+			})
+		})
+	}
+}
+
+// Helper function to split range result
+func splitRange(rangeStr string) []string {
+	// Split on " - " and trim spaces
+	var parts []string
+	for i := 0; i < len(rangeStr); i++ {
+		if i+3 <= len(rangeStr) && rangeStr[i:i+3] == " - " {
+			parts = append(parts, rangeStr[:i])
+			parts = append(parts, rangeStr[i+3:])
+			break
+		}
+	}
+	return parts
+}

--- a/server/modules/assistant/escalate_alerts.go
+++ b/server/modules/assistant/escalate_alerts.go
@@ -50,17 +50,17 @@ func (t *EscalateAlertsTool) GetSchema() model.JSONSchema {
 					Type:        "string",
 					Description: `Title for the new case, usually named after the rule name of the alert(s) being escalated (e.g., "ET SCAN Potential SSH Scan")`,
 				},
-				"date_range": {
+				"range_start": {
 					Type:        "string",
-					Description: `Date range for searching events (e.g., "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM"). The range must contain two dates. Do not specify a timezone or any offsets in this field. If this field is specified, a date_range_format is required.`,
+					Description: "Optional start time for the query range (e.g., \"-1h\", \"2023/10/26 10:00:00 AM\"). Default is 24 hours ago (\"-24h\")",
 				},
-				"date_range_format": {
+				"range_end": {
 					Type:        "string",
-					Description: `Format of the date range (default: "2006/01/02 3:04:05 PM"). The format must be specified using Go's time package's reference layout format. "Relative" is not an acceptable format. Required when a date_range is provided.`,
+					Description: "Optional end time for the query range (e.g., \"now\", \"2023/10/26 12:00:00 PM\"). Default is now.",
 				},
-				"timezone": {
+				"range_format": {
 					Type:        "string",
-					Description: `Timezone for the date range (default: "UTC")`,
+					Description: "Format of the date range (default: \"2006/01/02 3:04:05 PM\"). The format must be specified using Go's time package's reference layout format. Required if either range_start or range_end is provided.",
 				},
 			},
 			Required: []string{"search_filter"},
@@ -69,11 +69,11 @@ func (t *EscalateAlertsTool) GetSchema() model.JSONSchema {
 }
 
 type escalateAlertArgs struct {
-	SearchFilter    string `json:"search_filter"`
-	CaseTitle       string `json:"case_title"`
-	DateRange       string `json:"date_range,omitempty"`
-	DateRangeFormat string `json:"date_range_format,omitempty"`
-	Timezone        string `json:"timezone,omitempty"`
+	SearchFilter string `json:"search_filter"`
+	CaseTitle    string `json:"case_title"`
+	RangeStart   string `json:"range_start,omitempty"`
+	RangeEnd     string `json:"range_end,omitempty"`
+	RangeFormat  string `json:"range_format,omitempty"`
 }
 
 func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server, params string) (result *model.ToolResponse, err error) {
@@ -101,15 +101,10 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 		return nil, err
 	}
 
-	if args.DateRange != "" {
-		if args.DateRangeFormat == "" {
-			return nil, fmt.Errorf("date_range_format is required when date_range is provided")
-		}
+	var timeRange string
 
-		_, _, err = util.ParseDateRange(args.DateRange, args.DateRangeFormat, args.Timezone)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing date_range: %w", err)
-		}
+	if args.RangeStart != "" || args.RangeEnd != "" {
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
 	}
 
 	result.Parameters = args
@@ -118,9 +113,9 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 
 	err = searchCrit.Populate(
 		"(tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true) AND ("+args.SearchFilter+")",
-		args.DateRange,
-		args.DateRangeFormat,
-		args.Timezone,
+		timeRange,
+		"2006/01/02 3:04:05 PM",
+		"UTC",
 		"0",
 		"10000",
 	)

--- a/server/modules/assistant/escalate_alerts_test.go
+++ b/server/modules/assistant/escalate_alerts_test.go
@@ -37,9 +37,12 @@ func TestEscalateAlertsTool_GetSchema(t *testing.T) {
 	assert.Equal(t, "string", schema.Json.Properties["search_filter"].Type)
 	assert.Contains(t, schema.Json.Properties, "case_title")
 	assert.Equal(t, "string", schema.Json.Properties["case_title"].Type)
-	assert.Contains(t, schema.Json.Properties, "date_range")
-	assert.Contains(t, schema.Json.Properties, "date_range_format")
-	assert.Contains(t, schema.Json.Properties, "timezone")
+	assert.Contains(t, schema.Json.Properties, "range_start")
+	assert.Equal(t, "string", schema.Json.Properties["range_start"].Type)
+	assert.Contains(t, schema.Json.Properties, "range_end")
+	assert.Equal(t, "string", schema.Json.Properties["range_end"].Type)
+	assert.Contains(t, schema.Json.Properties, "range_format")
+	assert.Equal(t, "string", schema.Json.Properties["range_format"].Type)
 	assert.Contains(t, schema.Json.Required, "search_filter")
 }
 
@@ -47,15 +50,13 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		params                  string
-		mockSearchResults       *model.EventSearchResults
-		mockUpdateResults       *model.EventUpdateResults
-		mockCase                *model.Case
-		mockError               error
-		expectedResult          string
-		expectedError           bool
-		expectedDateRange       string
-		expectedDateRangeFormat string
-		expectedTimezone        string
+		mockSearchResults *model.EventSearchResults
+		mockUpdateResults *model.EventUpdateResults
+		mockCase          *model.Case
+		mockError         error
+		expectedResult    string
+		expectedError     bool
+		expectDateRange   bool
 	}{
 		{
 			name:   "successful escalation with search filter",
@@ -148,13 +149,33 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:          "with date range but no date_range_format",
-			params:        `{"search_filter": "soc_id:alert-123", "case_title": "Test Case", "date_range": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM"}`,
-			expectedError: true,
+			name:   "with range_start only (treated as relative)",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Test Case", "range_start": "-2h"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-123",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "case-123",
+				},
+				Title: "Test Case",
+			},
+			expectedResult:  `Successfully added 1 alert to new case "Test Case" (Id: case-123)`,
+			expectDateRange: true,
 		},
 		{
-			name:   "with date range and date_range_format",
-			params: `{"search_filter": "soc_id:alert-123", "case_title": "Date Range Case", "date_range": "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM", "date_range_format": "2006/01/02 3:04:05 PM"}`,
+			name:   "with range_start, range_end and range_format",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Date Range Case", "range_start": "2024/12/03 02:31:35 PM", "range_end": "2024/12/04 02:31:35 PM", "range_format": "2006/01/02 3:04:05 PM"}`,
 			mockSearchResults: &model.EventSearchResults{
 				Events: []*model.EventRecord{
 					{
@@ -180,13 +201,12 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				},
 				Title: "Date Range Case",
 			},
-			expectedResult:          `Successfully added 2 alerts to new case "Date Range Case" (Id: case-789)`,
-			expectedDateRange:       "2024/12/03 02:31:35 PM - 2024/12/04 02:31:35 PM",
-			expectedDateRangeFormat: "2006/01/02 3:04:05 PM",
+			expectedResult:  `Successfully added 2 alerts to new case "Date Range Case" (Id: case-789)`,
+			expectDateRange: true,
 		},
 		{
-			name:   "with timezone",
-			params: `{"search_filter": "soc_id:alert-123", "case_title": "Timezone Case", "timezone": "America/New_York"}`,
+			name:   "with relative date range",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Relative Date Case", "range_start": "-1h", "range_end": "now"}`,
 			mockSearchResults: &model.EventSearchResults{
 				Events: []*model.EventRecord{
 					{
@@ -204,10 +224,10 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				Auditable: model.Auditable{
 					Id: "case-999",
 				},
-				Title: "Timezone Case",
+				Title: "Relative Date Case",
 			},
-			expectedResult:   `Successfully added 1 alert to new case "Timezone Case" (Id: case-999)`,
-			expectedTimezone: "America/New_York",
+			expectedResult:  `Successfully added 1 alert to new case "Relative Date Case" (Id: case-999)`,
+			expectDateRange: true,
 		},
 	}
 
@@ -294,8 +314,8 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				}
 
 				// Verify date range fields were parsed correctly if specified
-				// Note: The date range/format/timezone parameters are used to set BeginTime and EndTime
-				if tc.expectedDateRange != "" {
+				// Note: The date range parameters are used to set BeginTime and EndTime
+				if tc.expectDateRange {
 					// Just verify that BeginTime and EndTime were set (not zero)
 					assert.False(t, searchCrit.BeginTime.IsZero())
 					assert.False(t, searchCrit.EndTime.IsZero())
@@ -452,9 +472,9 @@ func TestEscalateAlertsTool_Execute_ComplexQuery(t *testing.T) {
 	params := `{
 		"search_filter": "rule.name:*phishing* AND event.severity:high",
 		"case_title": "Complex Phishing Case",
-		"date_range": "2024/12/01 12:00:00 PM - 2024/12/07 12:00:00 PM",
-		"date_range_format": "2006/01/02 3:04:05 PM",
-		"timezone": "America/New_York"
+		"range_start": "2024/12/01 12:00:00 PM",
+		"range_end": "2024/12/07 12:00:00 PM",
+		"range_format": "2006/01/02 3:04:05 PM"
 	}`
 	result, err := tool.Execute(ctx, mockServer, params)
 

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -16,7 +16,6 @@ import (
 	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
-	"github.com/security-onion-solutions/securityonion-soc/util"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 )
 
@@ -59,13 +58,17 @@ func (t *QueryEventsTool) GetSchema() model.JSONSchema {
 					Type:        "string",
 					Description: "The OQL query string to execute",
 				},
-				"start_time": {
+				"range_start": {
 					Type:        "string",
-					Description: "Optional start time for the query range (e.g., \"-1h\", \"2023/10/26 10:00:00 AM\")",
+					Description: "Optional start time for the query range (e.g., \"-1h\", \"2023/10/26 10:00:00 AM\"). Default is 24 hours ago (\"-24h\")",
 				},
-				"end_time": {
+				"range_end": {
 					Type:        "string",
-					Description: "Optional end time for the query range (e.g., \"now\", \"2023/10/26 12:00:00 PM\")",
+					Description: "Optional end time for the query range (e.g., \"now\", \"2023/10/26 12:00:00 PM\"). Default is now.",
+				},
+				"range_format": {
+					Type:        "string",
+					Description: "Format of the date range (default: \"2006/01/02 3:04:05 PM\"). The format must be specified using Go's time package's reference layout format. Required if either range_start or range_end is provided.",
 				},
 				"limit": {
 					Type:        "integer",
@@ -85,8 +88,9 @@ func (t *QueryEventsTool) GetSchema() model.JSONSchema {
 type queryEventsArgs struct {
 	OQLQuery     string  `json:"oql_query"`
 	Query        string  `json:"query"` // Support both query and oql_query
-	StartTime    *string `json:"start_time,omitempty"`
-	EndTime      *string `json:"end_time,omitempty"`
+	RangeStart   string  `json:"range_start,omitempty"`
+	RangeEnd     string  `json:"range_end,omitempty"`
+	RangeFormat  string  `json:"range_format,omitempty"`
 	Limit        int     `json:"limit"`
 	GroupByField *string `json:"groupby_field,omitempty"`
 }
@@ -151,40 +155,8 @@ func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, pa
 
 	var timeRange string
 
-	if args.StartTime != nil || args.EndTime != nil {
-		start := "-24h"
-		end := "now"
-
-		if args.StartTime != nil {
-			start = *args.StartTime
-		}
-		if args.EndTime != nil {
-			end = *args.EndTime
-		}
-
-		var startFormatted, endFormatted string
-
-		formats := []string{
-			"2006-01-02 3:04:05 PM", "2006/01/02 3:04:05 PM", "2006_01_02 3:04:05 PM",
-			"2006-01-02 15:04:05", "2006/01/02 15:04:05", "2006_01_02 15:04:05",
-		}
-
-		// Parse and format times
-		startParsed, err := util.ParseDate(start, formats)
-		if err != nil {
-			startFormatted = util.ParseRelativeTimeString(start)
-		} else {
-			startFormatted = util.FormatSOTime(startParsed)
-		}
-
-		endParsed, err := util.ParseDate(end, formats)
-		if err != nil {
-			endFormatted = util.ParseRelativeTimeString(end)
-		} else {
-			endFormatted = util.FormatSOTime(endParsed)
-		}
-
-		timeRange = fmt.Sprintf("%s - %s", startFormatted, endFormatted)
+	if args.RangeStart != "" || args.RangeEnd != "" {
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
 	}
 
 	criteria := model.NewEventSearchCriteria()


### PR DESCRIPTION
Every tool that receives date ranges now accepts relative ("now", "today", "-7d") and absolute dates. They're all processed the same way. Tests updated.