### PR TITLE
Check Response Code in IO Manager

### DIFF
--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -190,12 +190,14 @@ func (ac *AssistantCoordinator) Chat(ctx context.Context, messages []*model.Mess
 	ac.prepareRequestHeaders(httpReq)
 
 	res, err := ac.MakeRequest(httpReq, false)
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		logger.WithError(err).Error("unable to execute request")
 
 		return nil, err
 	}
-	defer res.Body.Close()
 
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -330,6 +332,10 @@ func (ac *AssistantCoordinator) ChatStream(ctx context.Context, messages []*mode
 
 	res, err := ac.MakeRequest(httpReq, true)
 	if err != nil {
+		if res != nil && res.Body != nil {
+			defer res.Body.Close()
+		}
+
 		logger.WithError(err).Error("unable to execute request")
 
 		return nil, err
@@ -395,6 +401,9 @@ func (ac *AssistantCoordinator) Balance(ctx context.Context) (*model.BalanceResp
 	ac.prepareRequestHeaders(httpReq)
 
 	res, err := ac.MakeRequest(httpReq, false)
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		logger.WithError(err).WithField("apiEndpoint", endpoint).Error("unable to execute request")
 
@@ -447,6 +456,9 @@ func (ac *AssistantCoordinator) Health(ctx context.Context) (*model.HealthRespon
 	ac.prepareRequestHeaders(httpReq)
 
 	res, err := ac.MakeRequest(httpReq, false)
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		logger.WithError(err).WithField("apiEndpoint", endpoint).Error("unable to execute request")
 

--- a/server/modules/detections/io_manager.go
+++ b/server/modules/detections/io_manager.go
@@ -11,19 +11,22 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/config"
 
 	"github.com/apex/log"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/security-onion-solutions/securityonion-soc/config"
 )
 
 //go:generate mockgen -destination mock/mock_iomanager.go -package mock . IOManager
@@ -83,7 +86,25 @@ func (resman *ResourceManager) MakeRequest(req *http.Request, streaming bool) (*
 		client = resman._client
 	}
 
-	return client.Do(req)
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		bytes, _ := io.ReadAll(res.Body)
+		body := string(bytes)
+
+		log.WithFields(log.Fields{
+			"body": body,
+		}).Debug("Response")
+
+		err = errors.New("Request did not complete successfully (" + strconv.Itoa(res.StatusCode) + "): " + res.Status)
+
+		return res, err
+	}
+
+	return res, nil
 }
 
 func (resman *ResourceManager) buildHttpClient(disableCompression bool) *http.Client {

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -1555,6 +1555,9 @@ func (e *ElastAlertEngine) downloadSigmaPackages() (zipData map[string][]byte, e
 		}
 
 		resp, err := e.MakeRequest(req, false)
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
 		if err != nil {
 			errMap[pkg] = err
 			continue


### PR DESCRIPTION
Because there is still a response that needs closing for non-200s, updated existing call sights to account for the new responsibility.