### PR TITLE
Playbook Event Field Filtering

### DIFF
--- a/model/playbook.go
+++ b/model/playbook.go
@@ -44,6 +44,9 @@ type Question struct {
 	FilledQuery string `json:"filledQuery,omitempty" yaml:"filledQuery,omitempty"`
 	// The results after the queries have been substituted, converted, and executed.
 	QueryResults []*EventRecord `json:"queryResults,omitempty" yaml:"queryResults,omitempty"`
+
+	// not returned by the API, only used internally
+	QueryFields []string `json:"-" yaml:"-"`
 }
 
 type ConvertedQuery struct {

--- a/server/modules/assistant/get_playbooks.go
+++ b/server/modules/assistant/get_playbooks.go
@@ -30,10 +30,10 @@ func (t *GetPlaybooksTool) GetName() string {
 
 func (t *GetPlaybooksTool) GetDescription() string {
 	return "Get playbooks for a given alert to guide investigation. Playbooks consist " +
-	"of questions and sigma searches to help gather context about the alert. The searches " +
-	"are executed and the results are returned along with the questions. If multiple playbooks " +
-	"are available for the alert, you can specify a playbook_index (0-based) to get questions " +
-	"from a specific playbook. Lower index playbooks are usually more specific to the alert."
+		"of questions and sigma searches to help gather context about the alert. The searches " +
+		"are executed and the results are returned along with the questions. If multiple playbooks " +
+		"are available for the alert, you can specify a playbook_index (0-based) to get questions " +
+		"from a specific playbook. Lower index playbooks are usually more specific to the alert."
 }
 
 func (t *GetPlaybooksTool) GetSchema() model.JSONSchema {
@@ -187,7 +187,7 @@ func simplifyPlaybooks(playbooks []*model.Playbook) []*SimplePlaybook {
 					Question:     q.Question,
 					Context:      q.Context,
 					Range:        q.Range,
-					QueryResults: filterEvents(q.QueryResults),
+					QueryResults: filterEvents(q.QueryResults, q.QueryFields...),
 				})
 			}
 		}
@@ -195,13 +195,7 @@ func simplifyPlaybooks(playbooks []*model.Playbook) []*SimplePlaybook {
 		simplePlaybooks = append(simplePlaybooks, &SimplePlaybook{
 			Name:        pb.Name,
 			Description: pb.Description,
-			// SourceCreated:     pb.SourceCreated,
-			// SourceUpdated:     pb.SourceUpdated,
-			// DetectionId:       pb.DetectionId,
-			// DetectionCategory: pb.DetectionCategory,
-			// DetectionType:     pb.DetectionType,
-			// Contributors:      pb.Contributors,
-			Questions: simpleQuestions,
+			Questions:   simpleQuestions,
 		})
 	}
 

--- a/server/modules/assistant/get_playbooks_test.go
+++ b/server/modules/assistant/get_playbooks_test.go
@@ -688,6 +688,62 @@ func TestSimplifyPlaybooks(t *testing.T) {
 			description: "Should only include questions with query results",
 		},
 		{
+			name: "playbook with QueryFields preserves custom fields",
+			inputPlaybooks: []*model.Playbook{
+				{
+					Name:        "Custom Field Investigation",
+					Description: "Investigation playbook with custom fields specified",
+					Questions: []*model.Question{
+						{
+							Question:    "What custom fields are present?",
+							Context:     "Check for custom fields not in default list",
+							Range:       nil,
+							QueryFields: []string{"custom.field.one", "custom.field.two", "process.pid"},
+							QueryResults: []*model.EventRecord{
+								{
+									Id: "alert-3",
+									Payload: map[string]any{
+										"@timestamp":       "2024-01-01T00:03:00Z",
+										"custom.field.one": "value1",
+										"custom.field.two": "value2",
+										"process.pid":      5678,
+										"process.name":     "test.exe",
+										"unwanted.field":   "should be filtered",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: []*SimplePlaybook{
+				{
+					Name:        "Custom Field Investigation",
+					Description: "Investigation playbook with custom fields specified",
+					Questions: []*SimpleQuestion{
+						{
+							Question: "What custom fields are present?",
+							Context:  "Check for custom fields not in default list",
+							Range:    nil,
+							QueryResults: []map[string]any{
+								{
+									"payload": map[string]any{
+										"_id":              "alert-3",
+										"@timestamp":       "2024-01-01T00:03:00Z",
+										"custom.field.one": "value1",
+										"custom.field.two": "value2",
+										"process.pid":      5678,
+										"process.name":     "test.exe",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			description: "Should preserve fields specified in QueryFields even if not in default list",
+		},
+		{
 			name: "multiple playbooks",
 			inputPlaybooks: []*model.Playbook{
 				{

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -256,7 +256,7 @@ func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, pa
 }
 
 // filterEvents filters event fields to reduce payload size
-func filterEvents(events []*model.EventRecord) []map[string]any {
+func filterEvents(events []*model.EventRecord, extraFields ...string) []map[string]any {
 	// Default fields from Python implementation
 	defaultFields := []string{
 		"@timestamp",
@@ -286,13 +286,15 @@ func filterEvents(events []*model.EventRecord) []map[string]any {
 
 	filtered := make([]map[string]any, 0, len(events))
 
+	fields := append(defaultFields, extraFields...)
+
 	for _, event := range events {
 		filteredPayload := map[string]any{
 			"_id": event.Id,
 		}
 
 		// Copy only default fields starting with the Id field
-		for _, field := range defaultFields {
+		for _, field := range fields {
 			// First try the field as-is (for non-nested fields)
 			if val, exists := event.Payload[field]; exists && val != nil {
 				filteredPayload[field] = val

--- a/server/modules/assistant/query_events_test.go
+++ b/server/modules/assistant/query_events_test.go
@@ -182,3 +182,332 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterEvents(t *testing.T) {
+	testCases := []struct {
+		name         string
+		events       []*model.EventRecord
+		extraFields  []string
+		expectedLen  int
+		validateFunc func(t *testing.T, result []map[string]any)
+	}{
+		{
+			name: "basic event with default fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-1",
+					Source: "test-index",
+					Payload: map[string]any{
+						"@timestamp":   "2024-01-01T00:00:00Z",
+						"source.ip":    "192.168.1.1",
+						"destination.ip": "10.0.0.1",
+						"tags":         []string{"alert", "malware"},
+						"rule.name":    "ET MALWARE Suspicious",
+						"ignored_field": "this should not appear",
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				assert.Equal(t, "test-id-1", result[0]["payload"].(map[string]any)["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", result[0]["payload"].(map[string]any)["@timestamp"])
+				assert.Equal(t, "192.168.1.1", result[0]["payload"].(map[string]any)["source.ip"])
+				assert.Equal(t, "10.0.0.1", result[0]["payload"].(map[string]any)["destination.ip"])
+				assert.Equal(t, []string{"alert", "malware"}, result[0]["payload"].(map[string]any)["tags"])
+				assert.Equal(t, "ET MALWARE Suspicious", result[0]["payload"].(map[string]any)["rule.name"])
+				assert.NotContains(t, result[0]["payload"].(map[string]any), "ignored_field")
+			},
+		},
+		{
+			name: "nested fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-2",
+					Source: "test-index",
+					Payload: map[string]any{
+						"@timestamp": "2024-01-01T00:00:00Z",
+						"destination": map[string]any{
+							"ip":   "10.0.0.1",
+							"port": 443,
+							"geo": map[string]any{
+								"country_name": "United States",
+							},
+						},
+						"source": map[string]any{
+							"ip": "192.168.1.1",
+							"geo": map[string]any{
+								"country_name": "Canada",
+							},
+						},
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-id-2", payload["_id"])
+
+				// Check nested destination fields
+				dest := payload["destination"].(map[string]any)
+				assert.Equal(t, "10.0.0.1", dest["ip"])
+				assert.Equal(t, 443, dest["port"])
+				destGeo := dest["geo"].(map[string]any)
+				assert.Equal(t, "United States", destGeo["country_name"])
+
+				// Check nested source fields
+				src := payload["source"].(map[string]any)
+				assert.Equal(t, "192.168.1.1", src["ip"])
+				srcGeo := src["geo"].(map[string]any)
+				assert.Equal(t, "Canada", srcGeo["country_name"])
+			},
+		},
+		{
+			name: "event with extra fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-3",
+					Source: "test-index",
+					Payload: map[string]any{
+						"@timestamp": "2024-01-01T00:00:00Z",
+						"custom": map[string]any{
+							"field1": "value1",
+							"field2": "value2",
+						},
+						"ignored_field": "ignored",
+					},
+				},
+			},
+			extraFields: []string{"custom.field1", "custom.field2"},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-id-3", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+
+				// Check extra fields are included
+				custom := payload["custom"].(map[string]any)
+				assert.Equal(t, "value1", custom["field1"])
+				assert.Equal(t, "value2", custom["field2"])
+
+				// Check ignored field is not included
+				assert.NotContains(t, payload, "ignored_field")
+			},
+		},
+		{
+			name: "multiple events",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-4",
+					Source: "test-index",
+					Payload: map[string]any{
+						"@timestamp": "2024-01-01T00:00:00Z",
+						"source.ip":  "192.168.1.1",
+						"tags":       []string{"conn"},
+					},
+				},
+				{
+					Id:     "test-id-5",
+					Source: "test-index",
+					Payload: map[string]any{
+						"@timestamp": "2024-01-01T00:01:00Z",
+						"source.ip":  "192.168.1.2",
+						"tags":       []string{"dns"},
+					},
+				},
+			},
+			expectedLen: 2,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				assert.Equal(t, "test-id-4", result[0]["payload"].(map[string]any)["_id"])
+				assert.Equal(t, "test-id-5", result[1]["payload"].(map[string]any)["_id"])
+				assert.Equal(t, "192.168.1.1", result[0]["payload"].(map[string]any)["source.ip"])
+				assert.Equal(t, "192.168.1.2", result[1]["payload"].(map[string]any)["source.ip"])
+			},
+		},
+		{
+			name: "missing fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-6",
+					Source: "test-index",
+					Payload: map[string]any{
+						"@timestamp": "2024-01-01T00:00:00Z",
+						"source.ip":  "192.168.1.1",
+						// Missing many default fields
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-id-6", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "192.168.1.1", payload["source.ip"])
+				// Missing fields should not be present
+				assert.NotContains(t, payload, "destination.ip")
+				assert.NotContains(t, payload, "rule.name")
+			},
+		},
+		{
+			name: "nil field values are excluded",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-7",
+					Source: "test-index",
+					Payload: map[string]any{
+						"@timestamp":     "2024-01-01T00:00:00Z",
+						"source.ip":      "192.168.1.1",
+						"destination.ip": nil,
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-id-7", payload["_id"])
+				assert.Equal(t, "192.168.1.1", payload["source.ip"])
+				// Nil field should not be included
+				assert.NotContains(t, payload, "destination.ip")
+			},
+		},
+		{
+			name: "dns event with multiple field formats",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-8",
+					Source: "dns-index",
+					Payload: map[string]any{
+						"@timestamp": "2024-01-01T00:00:00Z",
+						"tags":       []string{"dns"},
+						"dns": map[string]any{
+							"query": map[string]any{
+								"name": "example.com",
+							},
+							"query_name": "alternative.com",
+						},
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				// Both dns field formats should be present
+				dns := payload["dns"].(map[string]any)
+				assert.Equal(t, "alternative.com", dns["query_name"])
+				query := dns["query"].(map[string]any)
+				assert.Equal(t, "example.com", query["name"])
+			},
+		},
+		{
+			name: "comprehensive security event",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-id-9",
+					Source: "alert-index",
+					Payload: map[string]any{
+						"@timestamp": "2024-01-01T00:00:00Z",
+						"tags":       []string{"alert", "ids"},
+						"source": map[string]any{
+							"ip":   "192.168.1.100",
+							"port": 45678,
+						},
+						"destination": map[string]any{
+							"ip":   "10.0.0.1",
+							"port": 443,
+						},
+						"network": map[string]any{
+							"protocol":     "TLS",
+							"transport":    "tcp",
+							"community_id": "1:abc123",
+						},
+						"rule": map[string]any{
+							"name":     "ET MALWARE Suspicious Connection",
+							"category": "Malware",
+							"uuid":     "abc-123-def",
+						},
+						"event": map[string]any{
+							"severity":       2,
+							"severity_label": "high",
+						},
+						"log": map[string]any{
+							"id": map[string]any{
+								"uid": "uid123",
+							},
+						},
+						"observer": map[string]any{
+							"name": "sensor1",
+						},
+						"some": map[string]any{
+							"random": map[string]any{
+								"field": "not included",
+							},
+						},
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-id-9", payload["_id"])
+				assert.Equal(t, []string{"alert", "ids"}, payload["tags"])
+
+				// Check nested source fields
+				source := payload["source"].(map[string]any)
+				assert.Equal(t, "192.168.1.100", source["ip"])
+				assert.Equal(t, 45678, source["port"])
+
+				// Check nested destination fields
+				destination := payload["destination"].(map[string]any)
+				assert.Equal(t, "10.0.0.1", destination["ip"])
+				assert.Equal(t, 443, destination["port"])
+
+				// Check nested network fields
+				network := payload["network"].(map[string]any)
+				assert.Equal(t, "TLS", network["protocol"])
+				assert.Equal(t, "tcp", network["transport"])
+				assert.Equal(t, "1:abc123", network["community_id"])
+
+				// Check nested rule fields
+				rule := payload["rule"].(map[string]any)
+				assert.Equal(t, "ET MALWARE Suspicious Connection", rule["name"])
+				assert.Equal(t, "Malware", rule["category"])
+				assert.Equal(t, "abc-123-def", rule["uuid"])
+
+				// Check event fields
+				event := payload["event"].(map[string]any)
+				assert.Equal(t, 2, event["severity"])
+				assert.Equal(t, "high", event["severity_label"])
+
+				// Check log ID and observer
+				log := payload["log"].(map[string]any)
+				logID := log["id"].(map[string]any)
+				assert.Equal(t, "uid123", logID["uid"])
+
+				observer := payload["observer"].(map[string]any)
+				assert.Equal(t, "sensor1", observer["name"])
+
+				// Verify random field is not included
+				assert.NotContains(t, payload, "some")
+			},
+		},
+		{
+			name:        "empty events list",
+			events:      []*model.EventRecord{},
+			expectedLen: 0,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				assert.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterEvents(tc.events, tc.extraFields...)
+
+			assert.Len(t, result, tc.expectedLen)
+
+			if tc.validateFunc != nil {
+				tc.validateFunc(t, result)
+			}
+		})
+	}
+}

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -653,6 +653,7 @@ func (pdm *PlaybookDiskManager) ExecutePlaybookSearches(ctx context.Context, eve
 				}
 
 				pb.Questions[i].QueryResults = searchResults.Events
+				pb.Questions[i].QueryFields = converted[i].Fields
 			}
 		}
 	}


### PR DESCRIPTION
If a playbook indicates that certain fields should be visible on the UI, then those fields should survive the event field filter in the get_playbooks tool to be assessed by the AI.