### PR TITLE
Alerts Page: Playbook variable substitution refactor

### DIFF
--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -3003,7 +3003,7 @@ const huntComponent = {
       let payload = {
         name: 'hunt',
         query: {
-          q: question.filledOQL,
+          q: question.oqlQuery,
         },
       };
 

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2880,8 +2880,8 @@ const huntComponent = {
     async loadPlaybook(event, index) {
       if ('playbooks' in event || 'playbookLoading' in event || 'playbookErr' in event) return;
 
-      const publicId = event?.['rule.uuid'];
-      if (!publicId) {
+      const socId = event?.['soc_id'];
+      if (!socId) {
         event.playbookErr = true;
         return;
       }
@@ -2892,19 +2892,13 @@ const huntComponent = {
       let pbErr = false;
 
       try {
-        const response = await this.$root.papi.get(`playbook/detection/${publicId}`);
+        const response = await this.$root.papi.get(`playbook/event/${socId}`);
 
         playbooks = response.data;
       } catch (e) {
         pbErr = true;
         playbooks = null;
       }
-
-      if (playbooks) {
-        this.queryVariableSubstitution(event, playbooks);
-        await this.convertPlaybookQueries(playbooks);
-      }
-
       event.playbooks = playbooks;
       event.playbookErr = pbErr;
       delete event.playbookLoading;
@@ -2912,159 +2906,40 @@ const huntComponent = {
       if (playbooks) {
         // answer the questions and
         // stable sort them by results
+        let ips = [];
         let good = []; // has answers
         let bad = [];  // no answers
-        let ugly = []; // error
         for (let pb of event.playbooks) {
           for (let q of pb.questions) {
-            await this.$nextTick();
-            await this.askQuestion(q, event);
-
-            if (q.error) {
-              ugly.push(q);
-            } else if (q.answers.length > 0) {
+            if (q.queryResults.length > 0) {
               good.push(q);
             } else {
               bad.push(q);
             }
+            for (let answer of q.queryResults) {
+              if (answer.payload) {
+                for (let v of Object.values(answer.payload)) {
+                  if (v && typeof v === 'string') {
+                    ips.push(v);
+                  }
+                }
+              } else if (answer.keys) {
+                for (let key of answer.keys) {
+                  ips.push(key);
+                }
+              }
+            }
           }
         }
+        this.$root.batchLookup(ips, this);
 
-        event.questions = [...good, ...bad, ...ugly];
+        event.questions = [...good, ...bad];
 
         this.expandedPlaybookQuestions[index] = [];
         for (let i = 0; i < good.length; i++) {
           this.expandedPlaybookQuestions[index].push(i);
         }
       }
-    },
-    queryVariableSubstitution(event, playbooks) {
-      // Fields that require special array handling
-      const arrayFields = ['network.private_ip', 'network.public_ip', 'related.ip'];
-
-      for (let pb of playbooks) {
-        for (let question of pb.questions) {
-          let q = question.query;
-
-          // Find all variables in the query using regex
-          const variables = q.match(/\{([^}]+)\}/g) || [];
-
-          // Process each variable
-          for (const variable of variables) {
-            const fieldName = variable.slice(1, -1); // Remove { and }
-            let value = event[fieldName] || 'NODATA';
-
-            // Special handling for array fields
-            if (arrayFields.includes(fieldName) && Array.isArray(value)) {
-              // Find the line containing the variable
-              const lines = q.split('\n');
-              const lineWithVar = lines.findIndex(line => line.includes(variable));
-
-              if (lineWithVar !== -1) {
-                // Get the field being set (e.g., src_ip or dst_ip)
-                const match = lines[lineWithVar].match(/^(\s*)(?:-\s*)?(\w+(?:\.\w+)*(?:\|\w+)*):(?:\s*|$)/);
-                if (match) {
-                  const indent = match[1];
-                  const field = match[2];
-                  const originalLine = lines[lineWithVar];
-                  const hasDash = originalLine.trim().startsWith('-');
-                  const prefix = hasDash ? '- ' : '';
-                  const replacement = `${indent}${prefix}${field}:\n${value.map(ip => `${indent}    - ${ip}`).join('\n')}`;
-
-                  // Replace the entire line
-                  lines[lineWithVar] = replacement;
-                  q = lines.join('\n');
-                  continue;
-                }
-              }
-            }
-
-            // Default replacement if not handled as special case
-            q = q.replaceAll(variable, value);
-          }
-
-          question.filledQuery = q;
-        }
-      }
-    },
-
-    async convertPlaybookQueries(playbooks) {
-      let queries = playbooks.map((pb) => pb.questions.map((q) => q.filledQuery)).flat();
-
-      if (queries.length === 0) return;
-
-      let response = await this.$root.papi.post('playbook/convert', queries);
-
-      let index = 0;
-      for (let pb of playbooks) {
-        for (let question of pb.questions) {
-          question.filledOQL = response.data[index].query;
-          question.fields = response.data[index].fields;
-          index++;
-        }
-      }
-    },
-    async askQuestion(question, event) {
-      if (question.range) {
-        try {
-          const dateRange = this.buildQuestionRange(event, question.range);
-          let query = question.filledOQL;
-          if (!this.isQuestionAggregate(question)) {
-            query = query + ` | sortby @timestamp`;
-          }
-
-          let response = await this.$root.papi.get('events/', {
-            params: {
-              query: query,
-              range: dateRange,
-              format: this.i18n.timePickerSample,
-              zone: this.zone,
-              metricLimit: 5,
-              eventLimit: 5
-            }
-          });
-
-          if (this.isQuestionAggregate(question)) {
-            let biggest = '';
-            for (let field in response.data.metrics) {
-              if (field.length > biggest.length) biggest = field;
-            }
-            if (biggest) {
-              question.answers = this.sortAggregateEvents(response.data.metrics[biggest]);
-            } else {
-              // fallback, less than ideal
-              question.answers = response.data.events;
-            }
-          } else {
-            question.answers = response.data.events;
-          }
-        } catch (e) {
-          question.error = true;
-          question.answers = [];
-        }
-      } else {
-        // no range specified means we can find the answer on the event
-        // but avoid making a circular reference
-        const dupe = JSON.parse(JSON.stringify(event));
-        question.answers = [{ payload: dupe }];
-      }
-
-      let ips = [];
-      for (let answer of question.answers) {
-        if (answer.payload) {
-          for (let v of Object.values(answer.payload)) {
-            if (v && typeof v === 'string') {
-              ips.push(v);
-            }
-          }
-        } else if (answer.keys) {
-          for (let key of answer.keys) {
-            ips.push(key);
-          }
-        }
-      }
-
-      this.$root.batchLookup(ips, this);
     },
     sortAggregateEvents(events) {
       events = events.sort((a, b) => b.value - a.value);
@@ -3270,11 +3145,7 @@ const huntComponent = {
       }
     },
     pickQuestionColor(question) {
-      if (question.error) {
-        return 'has-error';
-      }
-
-      if (question.answers && question.answers.length > 0) {
+      if (question.queryResults && question.queryResults.length > 0) {
         return 'has-answers';
       }
 

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1904,227 +1904,6 @@ test('sortAggregateEvents', () => {
   }
 });
 
-test('askQuestion', async () => {
-  comp.$root.enableReverseLookup = true;
-  comp.zone = "Etc/UTC";
-
-  let question = {};
-  let event = {
-    field: 'present',
-    func: function() {}, // not present
-  };
-
-  await comp.askQuestion(question, event);
-
-  expect(question.answers.length).toBe(1);
-  expect('field' in question.answers[0].payload).toBe(true);
-  expect('func' in question.answers[0].payload).toBe(false);
-
-  const mock1 = mockPapi('get', {
-    data: {
-      metrics: {
-        biggest: [
-          {
-            payload: {
-              name: 'metric event',
-              ip: '1.1.1.1',
-            },
-          },
-        ],
-      },
-    },
-  });
-
-  const mock2 = mockPapi('put', {
-    then: function () { },
-  });
-
-  question = {
-    range: '-30d',
-    filledOQL: 'OQL Query',
-    isAggregate: true,
-  };
-  event = {
-    'soc_timestamp': '2023-10-01T12:00:00Z',
-  };
-
-  await comp.askQuestion(question, event);
-
-  expect(question.answers.length).toBe(1);
-  expect(question.answers[0].payload.name).toBe('metric event');
-  expect('error' in question).toBe(false);
-
-  expect(mock1).toHaveBeenCalledTimes(1);
-  expect(mock1).toHaveBeenCalledWith('events/', {
-    params: {
-      query: 'OQL Query',
-      range: '2023/09/01 12:00:00 PM - 2023/10/01 12:00:00 PM',
-      format: '2006/01/02 3:04:05 PM',
-      zone: 'Etc/UTC',
-      metricLimit: 5,
-      eventLimit: 5,
-    },
-  });
-
-  expect(mock2).toHaveBeenCalledTimes(1);
-  expect(mock2).toHaveBeenCalledWith('util/reverse-lookup', ['1.1.1.1'], {params: {gridId: ''}});
-
-  resetPapi();
-  const mock3 = mockPapi('get', null, new Error('something went wrong'));
-
-  question = {
-    range: '-30d',
-    filledOQL: 'OQL Query',
-    isAggregate: false,
-  };
-  event = {
-    'soc_timestamp': '2023-10-01T12:00:00Z',
-  };
-
-  await comp.askQuestion(question, event);
-
-  expect(question.answers.length).toBe(0);
-  expect('error' in question).toBe(true);
-  expect(question.error).toBe(true);
-
-  expect(mock3).toHaveBeenCalledTimes(1);
-  expect(mock3).toHaveBeenCalledWith('events/', {
-    params: {
-      query: 'OQL Query | sortby @timestamp',
-      range: '2023/09/01 12:00:00 PM - 2023/10/01 12:00:00 PM',
-      format: '2006/01/02 3:04:05 PM',
-      zone: 'Etc/UTC',
-      metricLimit: 5,
-      eventLimit: 5,
-    },
-  });
-
-  comp.$root.enableReverseLookup = false;
-  resetPapi();
-});
-
-test('queryVariableSubstitution - handles simple variable substitution', () => {
-    const event = {
-      'host.name': 'test-host',
-      'source.ip': '192.168.1.1'
-    };
-    const playbooks = [{
-      questions: [{
-        query: 'hostname: {host.name}\nsource_ip: {source.ip}'
-      }]
-    }];
-
-    comp.queryVariableSubstitution(event, playbooks);
-    expect(playbooks[0].questions[0].filledQuery).toBe(
-      'hostname: test-host\nsource_ip: 192.168.1.1'
-    );
-  });
-
-test('queryVariableSubstitution - handles array fields with proper indentation', () => {
-    const event = {
-      'network.private_ip': ['192.168.1.1', '10.0.0.1'],
-      'network.public_ip': ['203.0.113.1']
-    };
-    const playbooks = [{
-      questions: [{
-        query: '    private_ips: {network.private_ip}\n    public_ips: {network.public_ip}'
-      }]
-    }];
-
-    comp.queryVariableSubstitution(event, playbooks);
-    expect(playbooks[0].questions[0].filledQuery).toBe(
-      '    private_ips:\n        - 192.168.1.1\n        - 10.0.0.1\n    public_ips:\n        - 203.0.113.1'
-    );
-  });
-
-test('queryVariableSubstitution - handles missing fields with NODATA', () => {
-    const event = {
-      'host.name': 'test-host'
-    };
-    const playbooks = [{
-      questions: [{
-        query: 'hostname: {host.name}\nip: {missing.field}'
-      }]
-    }];
-
-    comp.queryVariableSubstitution(event, playbooks);
-    expect(playbooks[0].questions[0].filledQuery).toBe(
-      'hostname: test-host\nip: NODATA'
-    );
-  });
-
-test('queryVariableSubstitution - handles array fields with dashes', () => {
-    const event = {
-      'network.private_ip': ['192.168.1.1', '10.0.0.1']
-    };
-    const playbooks = [{
-      questions: [{
-        query: '    - private_ips: {network.private_ip}'
-      }]
-    }];
-
-    comp.queryVariableSubstitution(event, playbooks);
-    expect(playbooks[0].questions[0].filledQuery).toBe(
-      '    - private_ips:\n        - 192.168.1.1\n        - 10.0.0.1'
-    );
-  });
-
-test('queryVariableSubstitution - handles real-world query format', () => {
-  const event = {
-    'network.private_ip': ['192.168.1.1', '10.0.0.1'],
-    'dns.query_name': 'malicious.com',
-    'network.public_ip': ['203.0.113.1'],
-    'related.ip': ['203.0.113.1', '192.168.1.2'],
-  };
-  const playbooks = [{
-    questions: [{
-      query: `aggregation: false
-logsource:
-  category: network
-  service: dns
-detection:
-    selection:
-       - src_ip: '{network.private_ip}'
-       - dns.query.name|contains: '{dns.query_name}'
-       - dns.resolved_ip: '{network.public_ip}'
-    filter:
-      dst_ip: '{related.ip}'
-    condition: selection and filter
-fields:
-    - dns.query.name
-    - dns.query.type_name
-    - dns.resolved_ip
-    - dns.response.code_name`
-    }]
-  }];
-
-  comp.queryVariableSubstitution(event, playbooks);
-  expect(playbooks[0].questions[0].filledQuery).toBe(
-    `aggregation: false
-logsource:
-  category: network
-  service: dns
-detection:
-    selection:
-       - src_ip:
-           - 192.168.1.1
-           - 10.0.0.1
-       - dns.query.name|contains: 'malicious.com'
-       - dns.resolved_ip:
-           - 203.0.113.1
-    filter:
-      dst_ip:
-          - 203.0.113.1
-          - 192.168.1.2
-    condition: selection and filter
-fields:
-    - dns.query.name
-    - dns.query.type_name
-    - dns.resolved_ip
-    - dns.response.code_name`
-  );
-});
-
 test('fetchNewestEvent', async () => {
   const eventSearch = mockPapi('get', { data: { events: [{ id: '100', payload: { a: 1, b: "2", c: true } }] } });
   
@@ -2302,7 +2081,7 @@ test('toggleAllQuestions', () => {
 
 test('loadPlaybook', async () => {
   let event = {
-    'rule.uuid': '123',
+    'soc_id': '123',
   };
 
   const playbooks = [{ id: '1', questions: [] }, { id: '2', questions: [] }];
@@ -2311,7 +2090,7 @@ test('loadPlaybook', async () => {
 
   await comp.loadPlaybook(event, 0);
 
-  expect(papiMock).toHaveBeenCalledWith('playbook/detection/123');
+  expect(papiMock).toHaveBeenCalledWith('playbook/event/123');
   expect(event.playbooks).toStrictEqual(playbooks);
   expect(event.playbookLoading).toBe(undefined);
   expect(event.playbookErr).toBe(false);
@@ -2320,12 +2099,12 @@ test('loadPlaybook', async () => {
   papiMock = mockPapi('get', null, 'error');
 
   event = {
-    'rule.uuid': '456',
+    'soc_id': '456',
   };
 
   comp.loadPlaybook(event, 0);
 
-  expect(papiMock).toHaveBeenCalledWith('playbook/detection/456');
+  expect(papiMock).toHaveBeenCalledWith('playbook/event/456');
   expect(papiMock).toHaveBeenCalledTimes(1);
   expect(event.playbookErr).toBe(true);
   expect(event.playbooks).toBe(null);
@@ -2363,13 +2142,6 @@ test('loadPlaybook', async () => {
 });
 
 test('pickQuestionColor', () => {
-  let question = {
-    error: true,
-  };
-
-  let c = comp.pickQuestionColor(question);
-  expect(c).toBe('has-error');
-
   question = {
     error: false,
   };
@@ -2383,34 +2155,26 @@ test('pickQuestionColor', () => {
   expect(c).toBe('no-data');
 
   question = {
-    answers: [],
+    queryResults: [],
   };
 
   c = comp.pickQuestionColor(question);
   expect(c).toBe('no-data');
 
   question = {
-    answers: [{}],
+    queryResults: [{}],
   };
 
   c = comp.pickQuestionColor(question);
   expect(c).toBe('has-answers');
 
   question = {
-    answers: [{}],
+    queryResults: [{}],
     error: false,
   };
 
   c = comp.pickQuestionColor(question);
   expect(c).toBe('has-answers');
-
-  question = {
-    answers: [{}],
-    error: true,
-  };
-
-  c = comp.pickQuestionColor(question);
-  expect(c).toBe('has-error');
 });
 
 test('getExpandedData', () => {

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -426,10 +426,10 @@
 																							</v-btn>
 																						</v-col>
 																						<v-col style="align-content: center;" data-aid="playbook_grouped_question_query">
-																							{{ question.filledOQL }}
+																							{{ question.oqlQuery }}
 																						</v-col>
 																					</v-row>
-																					<template v-if="question.answers">
+																					<template v-if="question.queryResults">
 																						<span class="font-weight-bold font-italic">
 																							{{ i18n.instantInsight }}
 																						</span>
@@ -449,7 +449,7 @@
 																								</tr>
 																							</thead>
 																							<tbody>
-																								<tr v-for="agg in question.answers">
+																								<tr v-for="agg in question.queryResults">
 																									<td class="text-right" data-aid="playbook_grouped_instantinsights_aggregate_answer_count">
 																										{{ agg.value }}
 																									</td>
@@ -457,7 +457,7 @@
 																										{{ translateValue(value) }}<span class="resolved-host" v-if="$root.pickHostname(value)"> - {{ $root.pickHostname(value) }}</span>
 																									</td>
 																								</tr>
-																								<tr v-if="question.answers && question.answers.length === 0">
+																								<tr v-if="question.queryResults && question.queryResults.length === 0">
 																									<td colspan="100%" class="text-center" data-aid="playbook_grouped_instantinsights_aggregate_nodata">
 																										{{ question.error ? i18n.error : i18n.noData }}
 																									</td>
@@ -476,7 +476,7 @@
 																								</tr>
 																							</thead>
 																							<tbody>
-																								<tr v-for="answer in question.answers" :key="answer.id">
+																								<tr v-for="answer in question.queryResults" :key="answer.id">
 																									<td class="text-normal" data-aid="playbook_grouped_instantinsights_result_timestamp">
 																										{{ formatTimestamp(getEventTimestamp(answer.payload)) }}
 																									</td>
@@ -484,7 +484,7 @@
 																										{{ translateValue(getEventField(answer.payload, field)) }}<span class="resolved-host" v-if="$root.pickHostname(getEventField(answer.payload, field))"> - {{ $root.pickHostname(getEventField(answer.payload, field)) }}</span>
 																									</td>
 																								</tr>
-																								<tr v-if="question.answers && question.answers.length === 0">
+																								<tr v-if="question.queryResults && question.queryResults.length === 0">
 																									<td colspan="100%" class="text-center" data-aid="playbook_grouped_instantinsights_nodata">
 																										{{ question.error ? i18n.error : i18n.noData }}
 																									</td>
@@ -739,10 +739,10 @@
 																				</v-btn>
 																			</v-col>
 																			<v-col style="align-content: center;" data-aid="playbook_question_query">
-																				{{question.filledOQL}}
+																				{{question.oqlQuery}}
 																			</v-col>
 																		</v-row>
-																		<template v-if="question.answers">
+																		<template v-if="question.queryResults">
 																			<span class="font-weight-bold font-italic">
 																				{{i18n.instantInsight}}
 																			</span>
@@ -762,7 +762,7 @@
 																					</tr>
 																				</thead>
 																				<tbody>
-																					<tr v-for="agg in question.answers">
+																					<tr v-for="agg in question.queryResults">
 																						<td class="text-right" data-aid="playbook_instantinsights_aggregate_answer_count">
 																							{{ agg.value }}
 																						</td>
@@ -770,7 +770,7 @@
 																							{{ translateValue(value) }}<span class="resolved-host" v-if="$root.pickHostname(value)"> - {{ $root.pickHostname(value) }}</span>
 																						</td>
 																					</tr>
-																					<tr v-if="question.answers && question.answers.length === 0">
+																					<tr v-if="question.queryResults && question.queryResults.length === 0">
 																						<td colspan="100%" class="text-center" data-aid="playbook_instantinsights_aggregate_nodata">
 																							{{ question.error ? i18n.error : i18n.noData }}
 																						</td>
@@ -789,7 +789,7 @@
 																					</tr>
 																				</thead>
 																				<tbody>
-																					<tr v-for="answer in question.answers" :key="answer.id">
+																					<tr v-for="answer in question.queryResults" :key="answer.id">
 																						<td class="text-normal" data-aid="playbook_instantinsights_result_timestamp">
 																							{{ formatTimestamp(getEventTimestamp(answer.payload)) }}
 																						</td>
@@ -797,7 +797,7 @@
 																							{{ translateValue(getEventField(answer.payload, field)) }}<span class="resolved-host" v-if="$root.pickHostname(getEventField(answer.payload, field))"> - {{ $root.pickHostname(getEventField(answer.payload, field)) }}</span>
 																						</td>
 																					</tr>
-																					<tr v-if="question.answers && question.answers.length === 0">
+																					<tr v-if="question.queryResults && question.queryResults.length === 0">
 																						<td colspan="100%" class="text-center" data-aid="playbook_instantinsights_nodata">
 																							{{ question.error ? i18n.error : i18n.noData }}
 																						</td>

--- a/model/playbook.go
+++ b/model/playbook.go
@@ -43,10 +43,12 @@ type Question struct {
 	// The query after variable substitution has been performed.
 	FilledQuery string `json:"filledQuery,omitempty" yaml:"filledQuery,omitempty"`
 	// The results after the queries have been substituted, converted, and executed.
-	QueryResults []*EventRecord `json:"queryResults,omitempty" yaml:"queryResults,omitempty"`
+	QueryResults []*EventRecord `json:"queryResults" yaml:"-"`
 
 	// not returned by the API, only used internally
-	QueryFields []string `json:"-" yaml:"-"`
+	QueryFields []string `json:"fields" yaml:"-"`
+	// The event-specific query in OQL format
+	OqlQuery string `json:"oqlQuery" yaml:"-"`
 }
 
 type ConvertedQuery struct {

--- a/model/playbook_test.go
+++ b/model/playbook_test.go
@@ -1,0 +1,542 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/util"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestPlaybookCreation(t *testing.T) {
+	t.Parallel()
+
+	playbook := &Playbook{
+		Name: "Test Playbook",
+		Auditable: Auditable{
+			Id: "test-playbook-id",
+		},
+		DetectionId:       "detection-123",
+		DetectionCategory: "process_creation",
+		DetectionType:     "sigma",
+		Contributors:      []string{"SecurityOnionSolutions", "TestUser"},
+		Questions: []*Question{
+			{
+				Question:      "What process was executed?",
+				Context:       "Understanding the process helps identify malicious activity",
+				Range:         util.Ptr("-1h"),
+				AnswerSources: []string{"process_creation"},
+				Query:         "Image: {Image}",
+			},
+		},
+	}
+
+	assert.Equal(t, "Test Playbook", playbook.Name)
+	assert.Equal(t, "test-playbook-id", playbook.Id)
+	assert.Equal(t, "detection-123", playbook.DetectionId)
+	assert.Equal(t, "process_creation", playbook.DetectionCategory)
+	assert.Equal(t, "sigma", playbook.DetectionType)
+	assert.Len(t, playbook.Contributors, 2)
+	assert.Len(t, playbook.Questions, 1)
+	assert.Equal(t, "What process was executed?", playbook.Questions[0].Question)
+}
+
+func TestPlaybookJSONSerialization(t *testing.T) {
+	t.Parallel()
+
+	originalPlaybook := &Playbook{
+		Name:        "JSON Test Playbook",
+		Description: "Testing JSON serialization",
+		Auditable: Auditable{
+			Id: "json-test-id",
+		},
+		SourceCreated:     time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+		DetectionId:       "json-detection-123",
+		DetectionCategory: "network_connection",
+		DetectionType:     "nids",
+		Contributors:      []string{"TestUser1", "TestUser2"},
+		Questions: []*Question{
+			{
+				Question:      "What network connections were made?",
+				Context:       "Network connections can indicate C2 activity",
+				Range:         util.Ptr("+/-30m"),
+				AnswerSources: []string{"network_connection"},
+				Query:         "src_ip: {src_ip} AND dst_ip: {dst_ip}",
+				FilledQuery:   "src_ip: 192.168.1.10 AND dst_ip: 10.0.0.1",
+			},
+		},
+	}
+
+	// Test JSON marshaling
+	jsonData, err := json.Marshal(originalPlaybook)
+	assert.NoError(t, err)
+	assert.Contains(t, string(jsonData), "JSON Test Playbook")
+	assert.Contains(t, string(jsonData), "json-test-id")
+	assert.Contains(t, string(jsonData), "network_connection")
+
+	// Test JSON unmarshaling
+	var deserializedPlaybook Playbook
+	err = json.Unmarshal(jsonData, &deserializedPlaybook)
+	assert.NoError(t, err)
+
+	assert.Equal(t, originalPlaybook.Name, deserializedPlaybook.Name)
+	assert.Equal(t, originalPlaybook.Id, deserializedPlaybook.Id)
+	assert.Equal(t, originalPlaybook.DetectionId, deserializedPlaybook.DetectionId)
+	assert.Equal(t, originalPlaybook.DetectionCategory, deserializedPlaybook.DetectionCategory)
+	assert.Equal(t, originalPlaybook.DetectionType, deserializedPlaybook.DetectionType)
+	assert.Equal(t, originalPlaybook.Contributors, deserializedPlaybook.Contributors)
+	assert.Len(t, deserializedPlaybook.Questions, 1)
+	assert.Equal(t, originalPlaybook.Questions[0].Question, deserializedPlaybook.Questions[0].Question)
+	assert.Equal(t, originalPlaybook.Questions[0].Context, deserializedPlaybook.Questions[0].Context)
+	assert.Equal(t, *originalPlaybook.Questions[0].Range, *deserializedPlaybook.Questions[0].Range)
+}
+
+func TestPlaybookYAMLSerialization(t *testing.T) {
+	t.Parallel()
+
+	originalPlaybook := &Playbook{
+		Name:        "YAML Test Playbook",
+		Description: "Testing YAML serialization",
+		Auditable: Auditable{
+			Id: "yaml-test-id",
+		},
+		SourceCreated:     time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+		DetectionId:       "yaml-detection-123",
+		DetectionCategory: "file_event",
+		DetectionType:     "sigma",
+		Contributors:      []string{"YAMLTestUser"},
+		Questions: []*Question{
+			{
+				Question:      "What files were accessed?",
+				Context:       "File access patterns can reveal malicious behavior",
+				Range:         util.Ptr("-2h"),
+				AnswerSources: []string{"file_event"},
+				Query:         "TargetFilename: {TargetFilename}",
+			},
+		},
+	}
+
+	// Test YAML marshaling
+	yamlData, err := yaml.Marshal(originalPlaybook)
+	assert.NoError(t, err)
+	assert.Contains(t, string(yamlData), "YAML Test Playbook")
+	assert.Contains(t, string(yamlData), "yaml-test-id")
+	assert.Contains(t, string(yamlData), "file_event")
+
+	// Test YAML unmarshaling
+	var deserializedPlaybook Playbook
+	err = yaml.Unmarshal(yamlData, &deserializedPlaybook)
+	assert.NoError(t, err)
+
+	assert.Equal(t, originalPlaybook.Name, deserializedPlaybook.Name)
+	assert.Equal(t, originalPlaybook.Id, deserializedPlaybook.Id)
+	assert.Equal(t, originalPlaybook.DetectionId, deserializedPlaybook.DetectionId)
+	assert.Equal(t, originalPlaybook.DetectionCategory, deserializedPlaybook.DetectionCategory)
+	assert.Equal(t, originalPlaybook.DetectionType, deserializedPlaybook.DetectionType)
+	assert.Equal(t, originalPlaybook.Contributors, deserializedPlaybook.Contributors)
+	assert.Len(t, deserializedPlaybook.Questions, 1)
+	assert.Equal(t, originalPlaybook.Questions[0].Question, deserializedPlaybook.Questions[0].Question)
+}
+
+func TestQuestionCreation(t *testing.T) {
+	t.Parallel()
+
+	question := &Question{
+		Question:      "What is the source IP?",
+		Context:       "Source IP helps identify the origin of the attack",
+		Range:         util.Ptr("+/-1h"),
+		AnswerSources: []string{"network", "alert"},
+		Query:         "src_ip: {src_ip}",
+		FilledQuery:   "src_ip: 192.168.1.100",
+		QueryResults: []*EventRecord{
+			{
+				Id: "event-1",
+				Payload: map[string]interface{}{
+					"src_ip": "192.168.1.100",
+					"dst_ip": "10.0.0.1",
+				},
+			},
+		},
+		QueryFields: []string{"src_ip", "dst_ip", "timestamp"},
+		OqlQuery:    "src_ip: 192.168.1.100",
+	}
+
+	assert.Equal(t, "What is the source IP?", question.Question)
+	assert.Equal(t, "Source IP helps identify the origin of the attack", question.Context)
+	assert.Equal(t, "+/-1h", *question.Range)
+	assert.Len(t, question.AnswerSources, 2)
+	assert.Contains(t, question.AnswerSources, "network")
+	assert.Contains(t, question.AnswerSources, "alert")
+	assert.Equal(t, "src_ip: {src_ip}", question.Query)
+	assert.Equal(t, "src_ip: 192.168.1.100", question.FilledQuery)
+	assert.Len(t, question.QueryResults, 1)
+	assert.Equal(t, "event-1", question.QueryResults[0].Id)
+	assert.Len(t, question.QueryFields, 3)
+	assert.Equal(t, "src_ip: 192.168.1.100", question.OqlQuery)
+}
+
+func TestQuestionWithNilRange(t *testing.T) {
+	t.Parallel()
+
+	question := &Question{
+		Question:      "What is the alert content?",
+		Range:         nil, // No time range
+		AnswerSources: []string{"alert"},
+	}
+
+	assert.Equal(t, "What is the alert content?", question.Question)
+	assert.Nil(t, question.Range)
+	assert.Len(t, question.AnswerSources, 1)
+	assert.Equal(t, "alert", question.AnswerSources[0])
+}
+
+func TestConvertedQueryCreation(t *testing.T) {
+	t.Parallel()
+
+	convertedQuery := &ConvertedQuery{
+		Query:  "hostname: test-host AND user.name: admin",
+		Fields: []string{"hostname", "user.name", "process.name", "command_line"},
+	}
+
+	assert.Equal(t, "hostname: test-host AND user.name: admin", convertedQuery.Query)
+	assert.Len(t, convertedQuery.Fields, 4)
+	assert.Contains(t, convertedQuery.Fields, "hostname")
+	assert.Contains(t, convertedQuery.Fields, "user.name")
+	assert.Contains(t, convertedQuery.Fields, "process.name")
+	assert.Contains(t, convertedQuery.Fields, "command_line")
+}
+
+func TestConvertedQueryJSONSerialization(t *testing.T) {
+	t.Parallel()
+
+	originalQuery := &ConvertedQuery{
+		Query:  "src_ip: 10.0.0.1 AND dst_port: 443",
+		Fields: []string{"src_ip", "dst_ip", "dst_port", "protocol"},
+	}
+
+	// Test JSON marshaling
+	jsonData, err := json.Marshal(originalQuery)
+	assert.NoError(t, err)
+	assert.Contains(t, string(jsonData), "src_ip: 10.0.0.1 AND dst_port: 443")
+	assert.Contains(t, string(jsonData), "src_ip")
+	assert.Contains(t, string(jsonData), "dst_port")
+
+	// Test JSON unmarshaling
+	var deserializedQuery ConvertedQuery
+	err = json.Unmarshal(jsonData, &deserializedQuery)
+	assert.NoError(t, err)
+
+	assert.Equal(t, originalQuery.Query, deserializedQuery.Query)
+	assert.Equal(t, originalQuery.Fields, deserializedQuery.Fields)
+}
+
+func TestPlaybookDetectionTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		detectionType string
+		expectedValid bool
+		description   string
+	}{
+		{
+			name:          "Valid NIDS detection type",
+			detectionType: "nids",
+			expectedValid: true,
+			description:   "NIDS detection type should be valid",
+		},
+		{
+			name:          "Valid Sigma detection type",
+			detectionType: "sigma",
+			expectedValid: true,
+			description:   "Sigma detection type should be valid",
+		},
+		{
+			name:          "Valid YARA detection type",
+			detectionType: "yara",
+			expectedValid: true,
+			description:   "YARA detection type should be valid",
+		},
+		{
+			name:          "Empty detection type",
+			detectionType: "",
+			expectedValid: true,
+			description:   "Empty detection type should be valid for generic playbooks",
+		},
+		{
+			name:          "Case insensitive NIDS",
+			detectionType: "NIDS",
+			expectedValid: true,
+			description:   "Detection types should be case insensitive",
+		},
+		{
+			name:          "Case insensitive Sigma",
+			detectionType: "SIGMA",
+			expectedValid: true,
+			description:   "Detection types should be case insensitive",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			playbook := &Playbook{
+				DetectionType: test.detectionType,
+				Auditable: Auditable{
+					Id: "detection-type-test-" + test.name,
+				},
+			}
+
+			// Since there's no validation method in the model, we just test that the field can be set
+			assert.Equal(t, test.detectionType, playbook.DetectionType, test.description)
+		})
+	}
+}
+
+func TestPlaybookWithMultipleQuestions(t *testing.T) {
+	t.Parallel()
+
+	playbook := &Playbook{
+		Name: "Multi-Question Playbook",
+		Auditable: Auditable{
+			Id: "multi-question-test",
+		},
+		Questions: []*Question{
+			{
+				Question:      "What process triggered the alert?",
+				Context:       "Identify the initial process",
+				Range:         nil,
+				AnswerSources: []string{"process_creation"},
+				Query:         "ProcessGuid: {ProcessGuid}",
+			},
+			{
+				Question:      "What child processes were spawned?",
+				Context:       "Identify subsequent malicious activity",
+				Range:         util.Ptr("+5m"),
+				AnswerSources: []string{"process_creation"},
+				Query:         "ParentProcessGuid: {ProcessGuid}",
+			},
+			{
+				Question:      "What files were accessed?",
+				Context:       "Identify file system impact",
+				Range:         util.Ptr("+/-10m"),
+				AnswerSources: []string{"file_event"},
+				Query:         "ProcessGuid: {ProcessGuid}",
+			},
+			{
+				Question:      "What network connections were made?",
+				Context:       "Identify network-based indicators",
+				Range:         util.Ptr("+/-15m"),
+				AnswerSources: []string{"network_connection"},
+				Query:         "ProcessGuid: {ProcessGuid}",
+			},
+		},
+	}
+
+	assert.Equal(t, "Multi-Question Playbook", playbook.Name)
+	assert.Len(t, playbook.Questions, 4)
+
+	// Test first question (no range)
+	assert.Equal(t, "What process triggered the alert?", playbook.Questions[0].Question)
+	assert.Nil(t, playbook.Questions[0].Range)
+	assert.Contains(t, playbook.Questions[0].AnswerSources, "process_creation")
+
+	// Test second question (forward range)
+	assert.Equal(t, "What child processes were spawned?", playbook.Questions[1].Question)
+	assert.Equal(t, "+5m", *playbook.Questions[1].Range)
+
+	// Test third question (bidirectional range)
+	assert.Equal(t, "What files were accessed?", playbook.Questions[2].Question)
+	assert.Equal(t, "+/-10m", *playbook.Questions[2].Range)
+	assert.Contains(t, playbook.Questions[2].AnswerSources, "file_event")
+
+	// Test fourth question (longer bidirectional range)
+	assert.Equal(t, "What network connections were made?", playbook.Questions[3].Question)
+	assert.Equal(t, "+/-15m", *playbook.Questions[3].Range)
+	assert.Contains(t, playbook.Questions[3].AnswerSources, "network_connection")
+}
+
+func TestPlaybookWithSourceTimestamps(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	modified := time.Date(2024, 1, 16, 15, 30, 0, 0, time.UTC)
+
+	playbook := &Playbook{
+		SourceCreated: created,
+		SourceUpdated: &modified,
+		Auditable: Auditable{
+			Id: "timestamp-test",
+		},
+	}
+
+	assert.Equal(t, created, playbook.SourceCreated)
+	assert.NotNil(t, playbook.SourceUpdated)
+	assert.Equal(t, modified, *playbook.SourceUpdated)
+	assert.True(t, playbook.SourceUpdated.After(playbook.SourceCreated))
+}
+
+func TestPlaybookWithoutSourceUpdated(t *testing.T) {
+	t.Parallel()
+
+	playbook := &Playbook{
+		SourceCreated: time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+		SourceUpdated: nil,
+		Auditable: Auditable{
+			Id: "no-update-test",
+		},
+	}
+
+	assert.False(t, playbook.SourceCreated.IsZero())
+	assert.Nil(t, playbook.SourceUpdated)
+}
+
+func TestQuestionWithQueryResults(t *testing.T) {
+	t.Parallel()
+
+	eventResults := []*EventRecord{
+		{
+			Id: "result-1",
+			Payload: map[string]interface{}{
+				"Image":       "notepad.exe",
+				"CommandLine": "notepad.exe document.txt",
+				"User":        "DOMAIN\\user1",
+			},
+		},
+		{
+			Id: "result-2",
+			Payload: map[string]interface{}{
+				"Image":       "cmd.exe",
+				"CommandLine": "cmd.exe /c dir",
+				"User":        "DOMAIN\\user1",
+			},
+		},
+	}
+
+	question := &Question{
+		QueryResults: eventResults,
+		QueryFields:  []string{"Image", "CommandLine", "User", "ProcessGuid"},
+	}
+
+	assert.Len(t, question.QueryResults, 2)
+	assert.Equal(t, "result-1", question.QueryResults[0].Id)
+	assert.Equal(t, "result-2", question.QueryResults[1].Id)
+	assert.Equal(t, "notepad.exe", question.QueryResults[0].Payload["Image"])
+	assert.Equal(t, "cmd.exe", question.QueryResults[1].Payload["Image"])
+	assert.Len(t, question.QueryFields, 4)
+	assert.Contains(t, question.QueryFields, "Image")
+	assert.Contains(t, question.QueryFields, "CommandLine")
+	assert.Contains(t, question.QueryFields, "User")
+	assert.Contains(t, question.QueryFields, "ProcessGuid")
+}
+
+func TestPlaybookEngineSpecificFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		detectionType     string
+		detectionCategory string
+		expectedCategory  string
+		description       string
+	}{
+		{
+			name:              "Suricata NIDS playbook",
+			detectionType:     "nids",
+			detectionCategory: "ET SCAN",
+			expectedCategory:  "ET SCAN",
+			description:       "NIDS playbooks should support complex categories",
+		},
+		{
+			name:              "Sigma process creation playbook",
+			detectionType:     "sigma",
+			detectionCategory: "process_creation",
+			expectedCategory:  "process_creation",
+			description:       "Sigma playbooks should support standard categories",
+		},
+		{
+			name:              "YARA file analysis playbook",
+			detectionType:     "yara",
+			detectionCategory: "file_event",
+			expectedCategory:  "file_event",
+			description:       "YARA playbooks should support file-based categories",
+		},
+		{
+			name:              "Generic playbook",
+			detectionType:     "",
+			detectionCategory: "generic",
+			expectedCategory:  "generic",
+			description:       "Generic playbooks should work with any category",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			playbook := &Playbook{
+				DetectionType:     test.detectionType,
+				DetectionCategory: test.detectionCategory,
+				Auditable: Auditable{
+					Id: "engine-test-" + test.name,
+				},
+			}
+
+			assert.Equal(t, test.detectionType, playbook.DetectionType, test.description)
+			assert.Equal(t, test.expectedCategory, playbook.DetectionCategory, test.description)
+		})
+	}
+}
+
+func TestEmptyPlaybook(t *testing.T) {
+	t.Parallel()
+
+	playbook := &Playbook{}
+
+	assert.Empty(t, playbook.Name)
+	assert.Empty(t, playbook.Description)
+	assert.Empty(t, playbook.Id)
+	assert.True(t, playbook.SourceCreated.IsZero())
+	assert.Nil(t, playbook.SourceUpdated)
+	assert.Empty(t, playbook.DetectionId)
+	assert.Empty(t, playbook.DetectionCategory)
+	assert.Empty(t, playbook.DetectionType)
+	assert.Nil(t, playbook.Contributors)
+	assert.Nil(t, playbook.Questions)
+}
+
+func TestEmptyQuestion(t *testing.T) {
+	t.Parallel()
+
+	question := &Question{}
+
+	assert.Empty(t, question.Question)
+	assert.Empty(t, question.Context)
+	assert.Nil(t, question.Range)
+	assert.Nil(t, question.AnswerSources)
+	assert.Empty(t, question.Query)
+	assert.Empty(t, question.FilledQuery)
+	assert.Nil(t, question.QueryResults)
+	assert.Nil(t, question.QueryFields)
+	assert.Empty(t, question.OqlQuery)
+}
+
+func TestEmptyConvertedQuery(t *testing.T) {
+	t.Parallel()
+
+	convertedQuery := &ConvertedQuery{}
+
+	assert.Empty(t, convertedQuery.Query)
+	assert.Nil(t, convertedQuery.Fields)
+}

--- a/server/mock/mock_playbookstore.go
+++ b/server/mock/mock_playbookstore.go
@@ -70,6 +70,21 @@ func (mr *MockPlaybookstoreMockRecorder) ExecutePlaybookSearches(ctx, event, pbs
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePlaybookSearches", reflect.TypeOf((*MockPlaybookstore)(nil).ExecutePlaybookSearches), ctx, event, pbs)
 }
 
+// GetEventSpecificPlaybook mocks base method.
+func (m *MockPlaybookstore) GetEventSpecificPlaybook(ctx context.Context, id string) ([]*model.Playbook, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventSpecificPlaybook", ctx, id)
+	ret0, _ := ret[0].([]*model.Playbook)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEventSpecificPlaybook indicates an expected call of GetEventSpecificPlaybook.
+func (mr *MockPlaybookstoreMockRecorder) GetEventSpecificPlaybook(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventSpecificPlaybook", reflect.TypeOf((*MockPlaybookstore)(nil).GetEventSpecificPlaybook), ctx, id)
+}
+
 // GetPlaybookById mocks base method.
 func (m *MockPlaybookstore) GetPlaybookById(ctx context.Context, id string) (*model.Playbook, error) {
 	m.ctrl.T.Helper()

--- a/server/modules/playbook/playbook.go
+++ b/server/modules/playbook/playbook.go
@@ -552,6 +552,71 @@ func (pdm *PlaybookDiskManager) GetPlaybookById(ctx context.Context, id string) 
 	return pb, nil
 }
 
+func (pdm *PlaybookDiskManager) GetEventSpecificPlaybook(ctx context.Context, id string) ([]*model.Playbook, error) {
+	logger := log.FromContext(ctx)
+
+	query := fmt.Sprintf(`log.id.uid:"%[1]s" OR event.id:"%[1]s" OR _id:"%[1]s"`, id)
+	criteria := model.NewEventSearchCriteria()
+
+	dateRange := "1970-01-01T00:00:00Z - " + time.Now().Format(time.RFC3339)
+
+	err := criteria.Populate(query, dateRange, time.RFC3339, "", "0", "1")
+	if err != nil {
+		return nil, err
+	}
+
+	events, err := pdm.srv.Eventstore.Search(ctx, criteria)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search for alert: %w", err)
+	}
+	if events.TotalEvents == 0 || len(events.Events) == 0 {
+		return nil, fmt.Errorf("no alert found with ID %s", id)
+	}
+
+	event := events.Events[0]
+
+	detId, ok := event.Payload["rule.uuid"].(string)
+	if !ok {
+		logger.WithField("specifiedEvent", event).Error("event does not have a rule.uuid field")
+		return nil, fmt.Errorf("alert does not have a rule.uuid field")
+	}
+
+	detection, err := pdm.srv.Detectionstore.GetDetectionByPublicId(ctx, detId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get detection by ID %s: %w", detId, err)
+	}
+
+	engInt, ok := pdm.srv.DetectionEngines.Load(detection.Engine)
+	if ok {
+		eng := engInt.(server.DetectionEngine)
+
+		err = eng.ExtractDetails(detection)
+		if err != nil {
+			logger.WithError(err).WithFields(log.Fields{
+				"detectionEngine":   detection.Engine,
+				"detectionPublicId": detection.PublicID,
+			}).Error("unable to extract details from detection")
+		}
+	} else {
+		logger.WithFields(log.Fields{
+			"detectionEngine":   detection.Engine,
+			"detectionPublicId": detection.PublicID,
+		}).Error("retrieved detection with unsupported engine")
+	}
+
+	playbooks, err := pdm.srv.Playbookstore.GetPlaybooksForDetection(ctx, detection.PublicID, detection.Category, detection.Engine)
+	if err != nil || len(playbooks) == 0 {
+		return nil, fmt.Errorf("failed to get playbooks for detection %s: %w", detection.PublicID, err)
+	}
+
+	err = pdm.srv.Playbookstore.ExecutePlaybookSearches(ctx, event, playbooks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute playbook searches: %w", err)
+	}
+
+	return playbooks, nil
+}
+
 func (pdm *PlaybookDiskManager) ConvertQuestions(ctx context.Context, queries []string) ([]*model.ConvertedQuery, error) {
 	logger := log.FromContext(ctx)
 
@@ -654,6 +719,7 @@ func (pdm *PlaybookDiskManager) ExecutePlaybookSearches(ctx context.Context, eve
 
 				pb.Questions[i].QueryResults = searchResults.Events
 				pb.Questions[i].QueryFields = converted[i].Fields
+				pb.Questions[i].OqlQuery = converted[i].Query
 			}
 		}
 	}

--- a/server/playbookhandler.go
+++ b/server/playbookhandler.go
@@ -34,7 +34,7 @@ func RegisterPlaybookRoutes(srv *Server, r chi.Router, prefix string) {
 	r.Route(prefix, func(r chi.Router) {
 		r.Get("/{id}", h.GetPlaybook)
 		r.Get("/detection/{id}", h.GetPlaybooksForDetection)
-		r.Post("/convert", h.ConvertPlaybook)
+		r.Get("/event/{id}", h.GetEventSpecificPlaybook)
 	})
 }
 
@@ -187,16 +187,19 @@ func (h *PlaybookHandler) GetPlaybooksForDetection(w http.ResponseWriter, r *htt
 	web.Respond(w, r, http.StatusOK, pbs)
 }
 
-// @Summary      Convert Playbook Questions
-// @Description  Converts the questions of a playbook from Sigma to OQL.
+// @Summary      Get Event-Specific Playbook
+// @Description	 Fetches the playbook for a specific event.
 // @Tags         Playbooks
-// @Security     bearer[playbooks/read]
-// @Param        request body	[]string  true         "The variable substituted Sigma queries to convert"
-// @Success      200  {array}  model.ConvertedQuery  "The queries were successfully converted"
-// @Failure      401                                 "Request was not properly authenticated"
-// @Failure      500                                 "Internal SOC error; review SOC logs"
-// @Router       /connect/playbook/convert [post]
-func (h *PlaybookHandler) ConvertPlaybook(w http.ResponseWriter, r *http.Request) {
+// @Security     bearer[playbooks/read, detections/read, events/read]
+// @Param        id  path  string  true        "The SOC Id for the alert"
+// @Success      200  {array}  model.Playbook  "The playbook was successfully retrieved"
+// @Failure		 400                           "Malformed request"
+// @Failure      401                           "Request was not properly authenticated"
+// @Failure      404                           "Event not found"
+// @Failure      500                           "Internal SOC error; review SOC logs"
+// @Produce      application/json
+// @Router       /connect/playbook/event/{id} [get]
+func (h *PlaybookHandler) GetEventSpecificPlaybook(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.FromContext(ctx)
 
@@ -206,26 +209,39 @@ func (h *PlaybookHandler) ConvertPlaybook(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	queries := []string{}
-	err = web.ReadJson(r, &queries)
+	err = h.server.CheckAuthorized(ctx, "read", "detections")
 	if err != nil {
-		logger.WithError(err).Error("unable to read queries")
-		web.Respond(w, r, http.StatusBadRequest, err)
-
+		web.Respond(w, r, http.StatusUnauthorized, err)
 		return
 	}
 
-	pbConverted := []*model.ConvertedQuery{}
-
-	if len(queries) != 0 {
-		pbConverted, err = h.server.Playbookstore.ConvertQuestions(ctx, queries)
-		if err != nil {
-			logger.WithError(err).Error("unable to convert playbook")
-			web.Respond(w, r, http.StatusInternalServerError, err)
-
-			return
-		}
+	err = h.server.CheckAuthorized(ctx, "read", "events")
+	if err != nil {
+		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
 	}
 
-	web.Respond(w, r, http.StatusOK, pbConverted)
+	socId := chi.URLParam(r, "id")
+	if socId == "" {
+		logger.Error("detection id required")
+		web.Respond(w, r, http.StatusBadRequest, nil)
+		return
+	}
+
+	pbs, err := h.server.Playbookstore.GetEventSpecificPlaybook(ctx, socId)
+	if err != nil {
+		logger.WithError(err).Error("unable to get playbooks for event")
+		if strings.Contains(err.Error(), "no alert found") {
+			web.Respond(w, r, http.StatusNotFound, err)
+		} else {
+			web.Respond(w, r, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	if len(pbs) == 0 {
+		pbs = []*model.Playbook{}
+	}
+
+	web.Respond(w, r, http.StatusOK, pbs)
 }

--- a/server/playbookstore.go
+++ b/server/playbookstore.go
@@ -17,6 +17,7 @@ type Playbookstore interface {
 	GetPlaybookById(ctx context.Context, id string) (*model.Playbook, error)
 	ConvertQuestions(ctx context.Context, queries []string) ([]*model.ConvertedQuery, error)
 	ExecutePlaybookSearches(ctx context.Context, event *model.EventRecord, pbs []*model.Playbook) error
+	GetEventSpecificPlaybook(ctx context.Context, id string) ([]*model.Playbook, error)
 }
 
 //go:generate mockgen -destination mock/mock_playbookstore.go -package mock . Playbookstore


### PR DESCRIPTION
- Refactored the Playbooks retrieval methodology on the Alerts page to be more like the Assistant page, performing variable substitutions and other operations entirely in the backend. [#352](https://github.com/Security-Onion-Solutions/sos/issues/352)
- Added Go test coverage for Playbooks.