### PR TITLE
Assistant: Tools for querying cases and escalating to existing cases

### DIFF
--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -1121,6 +1121,8 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           params: toolUse.input,
           model: this.currentModel,
         };
+
+        this.applyToolSpecificChanges(toolUse, toolRequest);
         
         // Use streaming for tool results
         const response = await this.$root.papi.post(`/assistant/tool/${toolUse.name}`, toolRequest, {
@@ -1671,7 +1673,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
 
     // Check if a tool should be auto-approved based on localStorage settings
     shouldAutoApproveTool(toolName) {
-      return ['query_events', 'get_playbooks'].includes(toolName) && this.alwaysApproveReadRequests;
+      return ['query_events', 'get_playbooks', 'query_cases'].includes(toolName) && this.alwaysApproveReadRequests;
     },
 
     // Open the options menu programmatically
@@ -1716,6 +1718,16 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       this.contextLimitSmall = this.modelsMap.get(this.currentModel).contextLimitSmall;
       this.contextLimitLarge = this.modelsMap.get(this.currentModel).contextLimitLarge;
       this.lowBalanceColorAlert = this.modelsMap.get(this.currentModel).lowBalanceColorAlert;
+    },
+
+    applyToolSpecificChanges(toolUse, toolRequest) {
+      if (toolUse.name === 'query_cases') {
+        const rawMRU = localStorage.getItem('settings.case.mruCases');
+        if (rawMRU) {
+          const cases = JSON.parse(rawMRU);
+          toolRequest.auxData = cases;
+        }
+      }
     },
   }
 }});

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -4593,3 +4593,50 @@ test('handleToolExecutionContentBlockStop handles empty input JSON', () => {
   expect(comp.executeTool).toHaveBeenCalledWith(chainedToolUse);
   expect(result).toBe(null);
 });
+
+// applyToolSpecificChanges method tests
+test('applyToolSpecificChanges adds auxData for query_cases tool when MRU data exists', () => {
+  const toolUse = { id: 'tool_123', name: 'query_cases', input: { query: 'test query' } };
+  const toolRequest = {
+    sessionId: 'test-session',
+    toolUseId: 'tool_123',
+    params: { query: 'test query' },
+    model: 'test-model'
+  };
+
+  const mruCases = [
+    { id: 'case1', title: 'Test Case 1' },
+    { id: 'case2', title: 'Test Case 2' }
+  ];
+
+  // Spy on Storage.prototype so jsdom/localStorage is handled correctly
+  const getSpy = jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(JSON.stringify(mruCases));
+
+  comp.applyToolSpecificChanges(toolUse, toolRequest);
+
+  expect(getSpy).toHaveBeenCalledWith('settings.case.mruCases');
+  expect(toolRequest.auxData).toEqual(mruCases);
+
+  getSpy.mockRestore();
+});
+
+test('applyToolSpecificChanges does nothing for non-query_cases tools', () => {
+  const toolUse = { id: 'tool_other', name: 'query_events', input: { oql_query: 'event.module: suricata' } };
+  const toolRequest = {
+    sessionId: 'test-session',
+    toolUseId: 'tool_other',
+    params: { oql_query: 'event.module: suricata' },
+    model: 'test-model'
+  };
+
+  // Spy on the prototype (no return value needed)
+  const getSpy = jest.spyOn(Storage.prototype, 'getItem');
+
+  comp.applyToolSpecificChanges(toolUse, toolRequest);
+
+  expect(getSpy).not.toHaveBeenCalled();
+  expect(toolRequest.auxData).toBeUndefined();
+
+  getSpy.mockRestore();
+});
+

--- a/model/tool.go
+++ b/model/tool.go
@@ -19,6 +19,8 @@ type ToolRequest struct {
 	Params json.RawMessage `json:"params" example:"{\"key\":\"value\"}"`
 	// The model to use for this tool execution.
 	Model string `json:"model,omitempty" example:"claude-sonnet-4.5"`
+	// Auxiliary data for certain tools.
+	AuxData json.RawMessage `json:"auxData,omitempty" example:"{toolSpecificData: 'example'}"`
 }
 
 type ToolResponse struct {

--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -246,7 +246,7 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, toolErr := h.server.AssistantManager.ExecuteTool(ctx, toolName, string(toolReq.Params))
+	result, toolErr := h.server.AssistantManager.ExecuteTool(ctx, toolName, string(toolReq.Params), string(toolReq.AuxData))
 	if toolErr != nil {
 		logger.WithError(toolErr).Error("unable to execute tool")
 	}

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -293,7 +293,7 @@ func TestPostTool(t *testing.T) {
 		ToolName: "query_events",
 		Result:   map[string]interface{}{"events": []string{"event1", "event2"}},
 	}
-	mockManager.EXPECT().ExecuteTool(gomock.Any(), "query_events", `{"query":"test query"}`).Return(mockToolResponse, nil)
+	mockManager.EXPECT().ExecuteTool(gomock.Any(), "query_events", `{"query":"test query"}`, "").Return(mockToolResponse, nil)
 
 	expectedText := fmt.Sprintf("ToolUseId: %s, Error: <nil>, Result: %s", toolUseId, `{"events":["event1","event2"]}`)
 

--- a/server/assistantmanager.go
+++ b/server/assistantmanager.go
@@ -15,7 +15,7 @@ import (
 type AssistantManager interface {
 	Chat(ctx context.Context, aiModel string, messages []*model.Message, opts ...model.ChatOpt) ([]*model.Message, error)
 	ChatStream(ctx context.Context, aiModel string, messages []*model.Message) (*http.Response, error)
-	ExecuteTool(ctx context.Context, toolName string, params string) (*model.ToolResponse, error)
+	ExecuteTool(ctx context.Context, toolName string, params string, auxData string) (*model.ToolResponse, error)
 	Balance(ctx context.Context) (*model.BalanceResponse, error)
 	Health(ctx context.Context) (*model.HealthResponse, error)
 }

--- a/server/mock/mock_assistantmanager.go
+++ b/server/mock/mock_assistantmanager.go
@@ -93,18 +93,18 @@ func (mr *MockAssistantManagerMockRecorder) ChatStream(ctx, aiModel, messages an
 }
 
 // ExecuteTool mocks base method.
-func (m *MockAssistantManager) ExecuteTool(ctx context.Context, toolName, params string) (*model.ToolResponse, error) {
+func (m *MockAssistantManager) ExecuteTool(ctx context.Context, toolName, params, auxData string) (*model.ToolResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecuteTool", ctx, toolName, params)
+	ret := m.ctrl.Call(m, "ExecuteTool", ctx, toolName, params, auxData)
 	ret0, _ := ret[0].(*model.ToolResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExecuteTool indicates an expected call of ExecuteTool.
-func (mr *MockAssistantManagerMockRecorder) ExecuteTool(ctx, toolName, params any) *gomock.Call {
+func (mr *MockAssistantManagerMockRecorder) ExecuteTool(ctx, toolName, params, auxData any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteTool", reflect.TypeOf((*MockAssistantManager)(nil).ExecuteTool), ctx, toolName, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteTool", reflect.TypeOf((*MockAssistantManager)(nil).ExecuteTool), ctx, toolName, params, auxData)
 }
 
 // Health mocks base method.

--- a/server/modules/assistant/ack_alerts.go
+++ b/server/modules/assistant/ack_alerts.go
@@ -78,7 +78,7 @@ type ackAlertArgs struct {
 	RangeFormat  string         `json:"range_format,omitempty"`
 }
 
-func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, params string) (result *model.ToolResponse, err error) {
+func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
 	logger := log.FromContext(ctx)
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")

--- a/server/modules/assistant/ack_alerts_test.go
+++ b/server/modules/assistant/ack_alerts_test.go
@@ -46,11 +46,11 @@ func TestAckAlertsTool_GetSchema(t *testing.T) {
 
 func TestAckAlertsTool_Execute(t *testing.T) {
 	testCases := []struct {
-		name                    string
-		params                  string
-		mockResults             *model.EventUpdateResults
-		mockError               error
-		expectedResult          string
+		name                string
+		params              string
+		mockResults         *model.EventUpdateResults
+		mockError           error
+		expectedResult      string
 		expectedError       bool
 		expectedEventFilter map[string]any
 		expectDateRange     bool
@@ -157,7 +157,7 @@ func TestAckAlertsTool_Execute(t *testing.T) {
 
 			// Create tool and execute
 			tool := &AckAlertsTool{}
-			result, err := tool.Execute(ctx, mockServer, tc.params)
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
 
 			// Assert error expectations
 			if tc.expectedError {
@@ -234,7 +234,7 @@ func TestAckAlertsTool_Execute_VerifyContextPropagation(t *testing.T) {
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-123")
 
 	tool := &AckAlertsTool{}
-	_, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:test-alert"}`)
+	_, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:test-alert"}`, "")
 
 	assert.NoError(t, err)
 	assert.Len(t, mockEventstore.InputContexts, 1)
@@ -260,7 +260,7 @@ func TestAckAlertTool_Execute_EmptySearchFilter(t *testing.T) {
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
 
 	tool := &AckAlertsTool{}
-	result, err := tool.Execute(ctx, mockServer, `{"search_filter": ""}`)
+	result, err := tool.Execute(ctx, mockServer, `{"search_filter": ""}`, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -295,7 +295,7 @@ func TestAckAlertsTool_Execute_ComplexQuery(t *testing.T) {
 		"range_end": "2024/12/07 12:00:00 PM",
 		"range_format": "2006/01/02 3:04:05 PM"
 	}`
-	result, err := tool.Execute(ctx, mockServer, params)
+	result, err := tool.Execute(ctx, mockServer, params, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -226,7 +226,7 @@ func (ac *AssistantCoordinator) Chat(ctx context.Context, aiModel string, messag
 			for _, content := range responses[i].ContentBlocks {
 				if content.Type == "tool_use" {
 					// Execute the tool and add result back to conversation
-					result, err := ac.ExecuteTool(ctx, content.Name, string(content.Input))
+					result, err := ac.ExecuteTool(ctx, content.Name, string(content.Input), "")
 					if err != nil {
 						logger.WithError(err).WithField("toolName", content.Name).Error("failed to execute tool")
 						continue
@@ -346,7 +346,7 @@ func (ac *AssistantCoordinator) ChatStream(ctx context.Context, aiModel string, 
 	return res, nil
 }
 
-func (ac *AssistantCoordinator) ExecuteTool(ctx context.Context, toolName string, params string) (*model.ToolResponse, error) {
+func (ac *AssistantCoordinator) ExecuteTool(ctx context.Context, toolName string, params string, auxData string) (*model.ToolResponse, error) {
 	logger := log.FromContext(ctx).WithFields(log.Fields{
 		"toolName":  toolName,
 		"toolUseId": uuid.New().String(),
@@ -367,7 +367,7 @@ func (ac *AssistantCoordinator) ExecuteTool(ctx context.Context, toolName string
 		"userId":   userID,
 	}).Info("executing tool for assistant")
 
-	result, err := tool.Execute(assistantCtx, ac.srv, params)
+	result, err := tool.Execute(assistantCtx, ac.srv, params, auxData)
 	if err != nil {
 		logger.WithError(err).Error("error executing tool")
 		return nil, err

--- a/server/modules/assistant/assistant_test.go
+++ b/server/modules/assistant/assistant_test.go
@@ -267,7 +267,7 @@ func TestAssistantCoordinator_ExecuteTool(t *testing.T) {
 			toolName: "test_tool",
 			params:   `{"param1": "value1"}`,
 			setupMocks: func(mockTool *mock.MockTool) {
-				mockTool.EXPECT().Execute(gomock.Any(), gomock.Any(), `{"param1": "value1"}`).Return(&model.ToolResponse{
+				mockTool.EXPECT().Execute(gomock.Any(), gomock.Any(), `{"param1": "value1"}`, "").Return(&model.ToolResponse{
 					ToolName:       "test_tool",
 					OnBehalfOfUser: "test-user",
 					Result:         "success",
@@ -293,7 +293,7 @@ func TestAssistantCoordinator_ExecuteTool(t *testing.T) {
 			toolName: "failing_tool",
 			params:   `{"param1": "value1"}`,
 			setupMocks: func(mockTool *mock.MockTool) {
-				mockTool.EXPECT().Execute(gomock.Any(), gomock.Any(), `{"param1": "value1"}`).Return(nil, errors.New("tool execution failed"))
+				mockTool.EXPECT().Execute(gomock.Any(), gomock.Any(), `{"param1": "value1"}`, "").Return(nil, errors.New("tool execution failed"))
 			},
 			expectedResult: nil,
 			expectedError:  errors.New("tool execution failed"),
@@ -319,7 +319,7 @@ func TestAssistantCoordinator_ExecuteTool(t *testing.T) {
 
 			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
 
-			result, err := ac.ExecuteTool(ctx, tc.toolName, tc.params)
+			result, err := ac.ExecuteTool(ctx, tc.toolName, tc.params, "")
 
 			if tc.expectedError != nil {
 				assert.Error(t, err)
@@ -555,7 +555,7 @@ func TestAssistantCoordinator_Chat(t *testing.T) {
 
 			// Setup tool mock for auto-execute cases
 			if len(tc.chatOpts) > 0 {
-				mockTool.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any()).Return(&model.ToolResponse{
+				mockTool.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any(), "").Return(&model.ToolResponse{
 					ToolName:       "test_tool",
 					OnBehalfOfUser: "test-user",
 					Result:         "tool result",
@@ -887,7 +887,7 @@ func (m *mockTool) GetSchema() model.JSONSchema {
 	return m.schema
 }
 
-func (m *mockTool) Execute(ctx context.Context, srv *server.Server, params string) (*model.ToolResponse, error) {
+func (m *mockTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (*model.ToolResponse, error) {
 	return &model.ToolResponse{
 		ToolName: m.name,
 		Result:   "mock result",

--- a/server/modules/assistant/escalate_alerts.go
+++ b/server/modules/assistant/escalate_alerts.go
@@ -32,7 +32,7 @@ func (t *EscalateAlertsTool) GetName() string {
 
 func (t *EscalateAlertsTool) GetDescription() string {
 	return "Escalate an alert in Security Onion to a case using the alert's unique identifier (_id). This tool should create a new case if case_title is provided. On the other hand, if case_id is provided, escalate to that case.\n" +
-		"- *IMPORTANT* You MUST provide ONE of case_title or case_id, but NEVER both." +
+		"- *IMPORTANT* You MUST provide ONE of case_title or case_id, but NEVER both.\n" +
 		"- Examples for wild cards in the search_filter:\n" +
 		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
 		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `rule.name:(A B*)` is valid, but `rule.name:\"A B*\"` will not work as expected)"

--- a/server/modules/assistant/escalate_alerts.go
+++ b/server/modules/assistant/escalate_alerts.go
@@ -31,7 +31,8 @@ func (t *EscalateAlertsTool) GetName() string {
 }
 
 func (t *EscalateAlertsTool) GetDescription() string {
-	return "Escalate an alert in Security Onion to a new case using the alert's unique identifier (_id). This tool will only create new cases, and never attach to existing cases. If a user wishes to add to an existing case, they must manually do so through the SOC case interface.\n" +
+	return "Escalate an alert in Security Onion to a case using the alert's unique identifier (_id). This tool should create a new case if case_title is provided. On the other hand, if case_id is provided, escalate to that case.\n" +
+		"- *IMPORTANT* You MUST provide ONE of case_title or case_id, but NEVER both." +
 		"- Examples for wild cards in the search_filter:\n" +
 		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
 		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `rule.name:(A B*)` is valid, but `rule.name:\"A B*\"` will not work as expected)"
@@ -49,6 +50,10 @@ func (t *EscalateAlertsTool) GetSchema() model.JSONSchema {
 				"case_title": {
 					Type:        "string",
 					Description: `Title for the new case, usually named after the rule name of the alert(s) being escalated (e.g., "ET SCAN Potential SSH Scan")`,
+				},
+				"case_id": {
+					Type:        "string",
+					Description: `Id of the case we want to escalate to. (e.g., "Y6i16JkBZwOCEak1tWqX")`,
 				},
 				"range_start": {
 					Type:        "string",
@@ -71,12 +76,13 @@ func (t *EscalateAlertsTool) GetSchema() model.JSONSchema {
 type escalateAlertArgs struct {
 	SearchFilter string `json:"search_filter"`
 	CaseTitle    string `json:"case_title"`
+	CaseId       string `json:"case_id"`
 	RangeStart   string `json:"range_start,omitempty"`
 	RangeEnd     string `json:"range_end,omitempty"`
 	RangeFormat  string `json:"range_format,omitempty"`
 }
 
-func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server, params string) (result *model.ToolResponse, err error) {
+func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
 	logger := log.FromContext(ctx)
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
@@ -157,21 +163,30 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 		return result, nil
 	}
 
+	var modelCase *model.Case
+
 	// Step 2: Create Case
+	if args.CaseTitle != "" {
+		newCase := model.NewCase()
+		newCase.Title = args.CaseTitle
+		newCase.Description = "Review escalated event details in the Events tab below. Click here to update this description."
 
-	newCase := model.NewCase()
-	newCase.Title = args.CaseTitle
-	newCase.Description = "Review escalated event details in the Events tab below. Click here to update this description."
+		modelCase, err = server.Casestore.Create(ctx, newCase)
+		if err != nil {
+			logger.WithError(err).Error("error creating case for escalated alert")
 
-	savedCase, err := server.Casestore.Create(ctx, newCase)
-	if err != nil {
-		logger.WithError(err).Error("error creating case for escalated alert")
+			return nil, err
+		}
+	} else {
+		modelCase, err = server.Casestore.GetCase(ctx, args.CaseId)
+		if err != nil {
+			logger.WithField("caseId", args.CaseId).WithError(err).Error("error fetching case for escalated alert")
 
-		return nil, err
+			return nil, err
+		}
 	}
-
 	for _, ev := range relatedEvents {
-		ev.CaseId = savedCase.Id
+		ev.CaseId = modelCase.Id
 	}
 
 	// Step 3: Link Alerts to Case
@@ -186,7 +201,7 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 	logger.WithFields(log.Fields{
 		"relatedEventsCreated": created,
 		"errMap":               util.TruncateMap(errMap, 20),
-	}).Info("linked alerts to new case")
+	}).Info("linked alerts case")
 
 	// Step 4: Mark Alerts as Escalated
 
@@ -203,7 +218,7 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 
 	ackResults, err := server.Eventstore.Acknowledge(ctx, ackCrit)
 	if err != nil {
-		logger.WithError(err).Error("error escalating alert to new case")
+		logger.WithError(err).Error("error escalating alert")
 
 		return nil, err
 	}
@@ -216,7 +231,7 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 			plural = "s"
 		}
 
-		result.Result = fmt.Sprintf(`Successfully added %d alert%s to new case "%s" (Id: %s)`, created, plural, savedCase.Title, savedCase.Id)
+		result.Result = fmt.Sprintf(`Successfully added %d alert%s to case "%s" (Id: %s)`, created, plural, modelCase.Title, modelCase.Id)
 	}
 
 	return result, nil

--- a/server/modules/assistant/escalate_alerts_test.go
+++ b/server/modules/assistant/escalate_alerts_test.go
@@ -81,7 +81,7 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				},
 				Title: "Test Alert Case",
 			},
-			expectedResult: `Successfully added 1 alert to new case "Test Alert Case" (Id: case-123)`,
+			expectedResult: `Successfully added 1 alert to case "Test Alert Case" (Id: case-123)`,
 		},
 		{
 			name:   "no alerts found",
@@ -125,7 +125,7 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				},
 				Title: "Multiple Alerts Case",
 			},
-			expectedResult: `Successfully added 3 alerts to new case "Multiple Alerts Case" (Id: case-456)`,
+			expectedResult: `Successfully added 3 alerts to case "Multiple Alerts Case" (Id: case-456)`,
 		},
 		{
 			name:          "invalid JSON parameters",
@@ -170,7 +170,7 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				},
 				Title: "Test Case",
 			},
-			expectedResult:  `Successfully added 1 alert to new case "Test Case" (Id: case-123)`,
+			expectedResult:  `Successfully added 1 alert to case "Test Case" (Id: case-123)`,
 			expectDateRange: true,
 		},
 		{
@@ -201,7 +201,7 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				},
 				Title: "Date Range Case",
 			},
-			expectedResult:  `Successfully added 2 alerts to new case "Date Range Case" (Id: case-789)`,
+			expectedResult:  `Successfully added 2 alerts to case "Date Range Case" (Id: case-789)`,
 			expectDateRange: true,
 		},
 		{
@@ -226,7 +226,7 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 				},
 				Title: "Relative Date Case",
 			},
-			expectedResult:  `Successfully added 1 alert to new case "Relative Date Case" (Id: case-999)`,
+			expectedResult:  `Successfully added 1 alert to case "Relative Date Case" (Id: case-999)`,
 			expectDateRange: true,
 		},
 	}
@@ -279,7 +279,7 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 
 			// Create tool and execute
 			tool := &EscalateAlertsTool{}
-			result, err := tool.Execute(ctx, mockServer, tc.params)
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
 
 			// Assert error expectations
 			if tc.expectedError {
@@ -380,7 +380,7 @@ func TestEscalateAlertsTool_Execute_VerifyContextPropagation(t *testing.T) {
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-123")
 
 	tool := &EscalateAlertsTool{}
-	_, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:test-alert", "case_title": "Test Case"}`)
+	_, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:test-alert", "case_title": "Test Case"}`, "")
 
 	assert.NoError(t, err)
 	assert.Len(t, mockEventstore.InputContexts, 2) // Once for Search, once for Acknowledge
@@ -413,7 +413,7 @@ func TestEscalateAlertsTool_Execute_EmptySearchFilter(t *testing.T) {
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
 
 	tool := &EscalateAlertsTool{}
-	result, err := tool.Execute(ctx, mockServer, `{"search_filter": "", "case_title": "Empty Filter Case"}`)
+	result, err := tool.Execute(ctx, mockServer, `{"search_filter": "", "case_title": "Empty Filter Case"}`, "")
 
 	// Empty search filter results in an error during query parsing
 	assert.Error(t, err)
@@ -476,11 +476,11 @@ func TestEscalateAlertsTool_Execute_ComplexQuery(t *testing.T) {
 		"range_end": "2024/12/07 12:00:00 PM",
 		"range_format": "2006/01/02 3:04:05 PM"
 	}`
-	result, err := tool.Execute(ctx, mockServer, params)
+	result, err := tool.Execute(ctx, mockServer, params, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, `Successfully added 10 alerts to new case "Complex Phishing Case" (Id: case-complex)`, result.Result)
+	assert.Equal(t, `Successfully added 10 alerts to case "Complex Phishing Case" (Id: case-complex)`, result.Result)
 
 	// Verify all search criteria fields were populated correctly
 	assert.Len(t, mockEventstore.InputSearchCriterias, 1)
@@ -541,7 +541,7 @@ func TestEscalateAlertsTool_Execute_NoAlertsEscalated(t *testing.T) {
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
 
 	tool := &EscalateAlertsTool{}
-	result, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:alert-123", "case_title": "Test Case"}`)
+	result, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:alert-123", "case_title": "Test Case"}`, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/server/modules/assistant/escalate_alerts_test.go
+++ b/server/modules/assistant/escalate_alerts_test.go
@@ -7,6 +7,7 @@ package assistant
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
@@ -37,6 +38,8 @@ func TestEscalateAlertsTool_GetSchema(t *testing.T) {
 	assert.Equal(t, "string", schema.Json.Properties["search_filter"].Type)
 	assert.Contains(t, schema.Json.Properties, "case_title")
 	assert.Equal(t, "string", schema.Json.Properties["case_title"].Type)
+	assert.Contains(t, schema.Json.Properties, "case_id")
+	assert.Equal(t, "string", schema.Json.Properties["case_id"].Type)
 	assert.Contains(t, schema.Json.Properties, "range_start")
 	assert.Equal(t, "string", schema.Json.Properties["range_start"].Type)
 	assert.Contains(t, schema.Json.Properties, "range_end")
@@ -229,6 +232,102 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 			expectedResult:  `Successfully added 1 alert to case "Relative Date Case" (Id: case-999)`,
 			expectDateRange: true,
 		},
+		{
+			name:   "successful escalation with case_id",
+			params: `{"search_filter": "soc_id:alert-456", "case_id": "existing-case-123"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-456",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+							"rule.name":  "Existing Case Rule",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "existing-case-123",
+				},
+				Title: "Existing Case Title",
+			},
+			expectedResult: `Successfully added 1 alert to case "Existing Case Title" (Id: existing-case-123)`,
+		},
+		{
+			name:   "multiple alerts escalated to existing case",
+			params: `{"search_filter": "rule.uuid:existing-rule", "case_id": "existing-case-456"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-10",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T11:00:00Z",
+						},
+					},
+					{
+						Id: "alert-11",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T11:01:00Z",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 2,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "existing-case-456",
+				},
+				Title: "Multi Alert Existing Case",
+			},
+			expectedResult: `Successfully added 2 alerts to case "Multi Alert Existing Case" (Id: existing-case-456)`,
+		},
+		{
+			name:   "case_id with date range",
+			params: `{"search_filter": "soc_id:alert-789", "case_id": "existing-case-789", "range_start": "-3h", "range_end": "now"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-789",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T12:00:00Z",
+						},
+					},
+				},
+			},
+			mockUpdateResults: &model.EventUpdateResults{
+				UpdatedCount: 1,
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "existing-case-789",
+				},
+				Title: "Date Range Existing Case",
+			},
+			expectedResult:  `Successfully added 1 alert to case "Date Range Existing Case" (Id: existing-case-789)`,
+			expectDateRange: true,
+		},
+		{
+			name:   "case_id not found error",
+			params: `{"search_filter": "soc_id:alert-999", "case_id": "nonexistent-case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-999",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+				},
+			},
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -253,19 +352,33 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 
 			// Only set up casestore expectations if we expect to create a case
 			if !tc.expectedError && tc.mockSearchResults != nil && len(tc.mockSearchResults.Events) > 0 {
-				// Expect Create call
-				mockCasestore.EXPECT().
-					Create(gomock.Any(), gomock.Any()).
-					Return(tc.mockCase, nil).
-					Times(1)
+				// Parse params to determine if we're using case_id or case_title
+				var args escalateAlertArgs
+				json.Unmarshal([]byte(tc.params), &args)
 
-				// Expect CreateRelatedEvents call
-				mockCasestore.EXPECT().
-					CreateRelatedEvents(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, events []*model.RelatedEvent) (int, map[string]error, error) {
-						return len(events), nil, nil
-					}).
-					Times(1)
+				if args.CaseId != "" {
+					// Expect GetCase call for existing case
+					mockCasestore.EXPECT().
+						GetCase(gomock.Any(), args.CaseId).
+						Return(tc.mockCase, tc.mockError).
+						Times(1)
+				} else {
+					// Expect Create call for new case
+					mockCasestore.EXPECT().
+						Create(gomock.Any(), gomock.Any()).
+						Return(tc.mockCase, nil).
+						Times(1)
+				}
+
+				// Expect CreateRelatedEvents call (only if GetCase/Create succeeds)
+				if tc.mockError == nil {
+					mockCasestore.EXPECT().
+						CreateRelatedEvents(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(ctx context.Context, events []*model.RelatedEvent) (int, map[string]error, error) {
+							return len(events), nil, nil
+						}).
+						Times(1)
+				}
 			}
 
 			// Create mock server

--- a/server/modules/assistant/get_playbooks.go
+++ b/server/modules/assistant/get_playbooks.go
@@ -60,7 +60,7 @@ type getPlaybookQuestionsArgs struct {
 	PlaybookIndex *int   `json:"playbook_index,omitempty"`
 }
 
-func (t *GetPlaybooksTool) Execute(ctx context.Context, srv *server.Server, params string) (result *model.ToolResponse, err error) {
+func (t *GetPlaybooksTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
 	logger := log.FromContext(ctx)
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")

--- a/server/modules/assistant/get_playbooks_test.go
+++ b/server/modules/assistant/get_playbooks_test.go
@@ -444,7 +444,7 @@ func TestGetPlaybooksTool_Execute(t *testing.T) {
 
 			// Create tool and execute
 			tool := &GetPlaybooksTool{}
-			result, err := tool.Execute(ctx, mockServer, tc.params)
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
 
 			// Assert error expectations
 			if tc.expectedError {

--- a/server/modules/assistant/mock/mock_tool.go
+++ b/server/modules/assistant/mock/mock_tool.go
@@ -43,18 +43,18 @@ func (m *MockTool) EXPECT() *MockToolMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockTool) Execute(arg0 context.Context, arg1 *server.Server, arg2 string) (*model.ToolResponse, error) {
+func (m *MockTool) Execute(arg0 context.Context, arg1 *server.Server, arg2, arg3 string) (*model.ToolResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*model.ToolResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockToolMockRecorder) Execute(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockToolMockRecorder) Execute(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockTool)(nil).Execute), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockTool)(nil).Execute), arg0, arg1, arg2, arg3)
 }
 
 // GetDescription mocks base method.

--- a/server/modules/assistant/query_cases.go
+++ b/server/modules/assistant/query_cases.go
@@ -1,0 +1,257 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/apex/log"
+)
+
+func init() {
+	t := &QueryCasesTool{}
+	knownTools[t.GetName()] = t
+}
+
+type QueryCasesTool struct{}
+
+type QueryCasesResult struct {
+	QueryResults []map[string]any `json:"query_results"`
+	RecentCases  []map[string]any `json:"recent_cases"`
+}
+
+func (t *QueryCasesTool) GetName() string {
+	return "query_cases"
+}
+
+func (t *QueryCasesTool) GetDescription() string {
+	return "- Execute OQL queries to retrieve Security Onion cases that are most applicable to the given alert(s)\n" +
+		"- Search for cases by referencing so_case.description and so_case.title" +
+		"- *IMPORTANT* All queries should include `AND _index:\"*:so-case\" AND so_kind:case` appended to the end. The quotes around *:so-case MUST be included." +
+		"- When searching for cases, specify a date range of 999 days ago" +
+		"- Examples for wild cards in the oql_query:\n" +
+		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
+		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `rule.name:(A B*)` is valid, but `rule.name:\"A B*\"` will not work as expected)" +
+		"- In addition to search results, you'll also get the user's most recently viewed cases. This field is called recent_cases." +
+		"- If the most applicable case is clear-cut, explain that to the user. Otherwise, give multiple options, compare them, and let the user choose."
+}
+
+func (t *QueryCasesTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"oql_query": {
+					Type:        "string",
+					Description: "The OQL query string to execute",
+				},
+				"range_start": {
+					Type:        "string",
+					Description: "Optional start time for the query range (e.g., \"-1h\", \"2023/10/26 10:00:00 AM\"). Default is 24 hours ago (\"-24h\")",
+				},
+				"range_end": {
+					Type:        "string",
+					Description: "Optional end time for the query range (e.g., \"now\", \"2023/10/26 12:00:00 PM\"). Default is now.",
+				},
+				"range_format": {
+					Type:        "string",
+					Description: "Format of the date range (default: \"2006/01/02 3:04:05 PM\"). The format must be specified using Go's time package's reference layout format. Required if either range_start or range_end is provided.",
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "The maximum number of events to return",
+					Default:     100,
+				},
+			},
+			Required: []string{"oql_query"},
+		},
+	}
+}
+
+type queryCasesArgs struct {
+	OQLQuery    string `json:"oql_query"`
+	Query       string `json:"query"` // Support both query and oql_query
+	RangeStart  string `json:"range_start,omitempty"`
+	RangeEnd    string `json:"range_end,omitempty"`
+	RangeFormat string `json:"range_format,omitempty"`
+	Limit       int    `json:"limit"`
+}
+
+func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &queryCasesArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Parameters = args
+
+	var metricLimit, eventLimit int
+	zone := "UTC"
+	query := args.OQLQuery
+
+	if args.Query != "" && args.OQLQuery == "" {
+		query = args.Query
+	}
+
+	if query != "" && !strings.Contains(query, "NOT metadata.raw_index:") {
+		query = fmt.Sprintf(`(%s) AND NOT metadata.raw_index:"logs-soc-so"`, query)
+	} else if query == "" {
+		query = `NOT metadata.raw_index:"logs-soc-so"`
+	}
+
+	if args.Limit > 0 {
+		eventLimit = args.Limit
+	} else {
+		eventLimit = 10
+	}
+	metricLimit = 10000
+
+	var timeRange string
+
+	if args.RangeStart != "" || args.RangeEnd != "" {
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+	}
+
+	criteria := model.NewEventSearchCriteria()
+	err = criteria.Populate(query,
+		timeRange,
+		"2006/01/02 3:04:05 PM",
+		zone,
+		strconv.Itoa(metricLimit),
+		strconv.Itoa(eventLimit))
+	if err != nil {
+		return nil, err
+	}
+
+	criteria.SortFields = []*model.SortCriteria{
+		{
+			Field: "@timestamp",
+			Order: "desc",
+		},
+	}
+
+	searchResults, err := server.Eventstore.Search(ctx, criteria)
+	if err != nil {
+		return nil, err
+	}
+
+	events := searchResults.Events
+
+	if len(events) == 0 {
+		result.Result = "No events found"
+		return result, nil
+	}
+
+	logger.WithField("eventsFound", len(events)).Info("query executed successfully")
+
+	// Log raw event size before filtering
+	rawJSON, _ := json.Marshal(events)
+	logger.WithField("rawEventSize", len(rawJSON)).Debug("raw event size before filtering")
+
+	// Filter event fields to reduce size
+	filteredEvents := filterCases(events)
+
+	// Convert to JSON
+	resultJSON, err := json.MarshalIndent(filteredEvents, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	// Log filtered result size and preview
+	logger.WithField("filteredResultSize", len(resultJSON)).Debug("filtered result size")
+
+	recentCases := []map[string]any{}
+
+	err = json.Unmarshal([]byte(auxData), &recentCases)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Result = QueryCasesResult{
+		QueryResults: filteredEvents,
+		RecentCases:  recentCases,
+	}
+
+	return result, nil
+}
+
+// filterEvents filters event fields to reduce payload size
+func filterCases(events []*model.EventRecord, extraFields ...string) []map[string]any {
+	// Default fields from Python implementation
+	defaultFields := []string{
+		"so_case.assigneeId",
+		"so_case.category",
+		"so_case.completeTime",
+		"so_case.createTime",
+		"so_case.description",
+		"so_case.pap",
+		"so_case.priority",
+		"so_case.severity",
+		"so_case.startTime",
+		"so_case.status",
+		"so_case.tags",
+		"so_case.template",
+		"so_case.title",
+		"so_case.tlp",
+		"so_case.userId",
+		"@timestamp",
+	}
+
+	filtered := make([]map[string]any, 0, len(events))
+
+	fields := append(defaultFields, extraFields...)
+
+	for _, event := range events {
+		filteredPayload := map[string]any{
+			"_id": event.Id,
+		}
+
+		// Copy only default fields starting with the Id field
+		for _, field := range fields {
+			// First try the field as-is (for non-nested fields)
+			if val, exists := event.Payload[field]; exists && val != nil {
+				filteredPayload[field] = val
+			} else if value := getNestedField(event.Payload, field); value != nil {
+				// Try nested field lookup
+				setNestedField(filteredPayload, field, value)
+			}
+		}
+
+		filtered = append(filtered, map[string]any{
+			"payload": filteredPayload,
+		})
+	}
+
+	return filtered
+}

--- a/server/modules/assistant/query_cases.go
+++ b/server/modules/assistant/query_cases.go
@@ -37,7 +37,7 @@ func (t *QueryCasesTool) GetName() string {
 }
 
 func (t *QueryCasesTool) GetDescription() string {
-	return "- Execute OQL queries to retrieve Security Onion cases that are most applicable to the given alert(s).\n" +
+	return "- Execute OQL queries to retrieve Security Onion cases that are most applicable to the given alert(s) (or other event(s)/topic(s)) at hand.\n" +
 		"- Search for cases by referencing so_case.description and so_case.title\n" +
 		"- *IMPORTANT* All queries should include `AND _index:\"*:so-case\" AND so_kind:case` appended to the end. The quotes around *:so-case MUST be included.\n" +
 		"- When searching for cases, specify a date range of 999 days ago.\n" +

--- a/server/modules/assistant/query_cases.go
+++ b/server/modules/assistant/query_cases.go
@@ -37,14 +37,14 @@ func (t *QueryCasesTool) GetName() string {
 }
 
 func (t *QueryCasesTool) GetDescription() string {
-	return "- Execute OQL queries to retrieve Security Onion cases that are most applicable to the given alert(s)\n" +
-		"- Search for cases by referencing so_case.description and so_case.title" +
-		"- *IMPORTANT* All queries should include `AND _index:\"*:so-case\" AND so_kind:case` appended to the end. The quotes around *:so-case MUST be included." +
-		"- When searching for cases, specify a date range of 999 days ago" +
+	return "- Execute OQL queries to retrieve Security Onion cases that are most applicable to the given alert(s).\n" +
+		"- Search for cases by referencing so_case.description and so_case.title\n" +
+		"- *IMPORTANT* All queries should include `AND _index:\"*:so-case\" AND so_kind:case` appended to the end. The quotes around *:so-case MUST be included.\n" +
+		"- When searching for cases, specify a date range of 999 days ago.\n" +
 		"- Examples for wild cards in the oql_query:\n" +
 		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
-		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `rule.name:(A B*)` is valid, but `rule.name:\"A B*\"` will not work as expected)" +
-		"- In addition to search results, you'll also get the user's most recently viewed cases. This field is called recent_cases." +
+		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `rule.name:(A B*)` is valid, but `rule.name:\"A B*\"` will not work as expected)\n" +
+		"- In addition to search results, you'll also get the user's most recently viewed cases. This field is called recent_cases.\n" +
 		"- If the most applicable case is clear-cut, explain that to the user. Otherwise, give multiple options, compare them, and let the user choose."
 }
 
@@ -168,10 +168,19 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 
 	caseEvents := searchResults.Events
 
-	if len(caseEvents) == 0 {
+	// Parse auxData first, regardless of whether cases are found
+	recentCases := []map[string]any{}
+	err = json.Unmarshal([]byte(auxData), &recentCases)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal recent cases from auxData: %w", err)
+	}
+
+	if len(caseEvents) == 0 && len(recentCases) == 0 {
 		result.Result = "No cases found"
 		return result, nil
 	}
+
+	logger.WithField("recentCasesFound", len(recentCases)).Debug("recent cases parsed from auxData")
 
 	logger.WithField("casesFound", len(caseEvents)).Info("query executed successfully")
 
@@ -190,13 +199,6 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 
 	// Log filtered result size and preview
 	logger.WithField("filteredResultSize", len(resultJSON)).Debug("filtered result size")
-
-	recentCases := []map[string]any{}
-
-	err = json.Unmarshal([]byte(auxData), &recentCases)
-	if err != nil {
-		return nil, err
-	}
 
 	result.Result = QueryCasesResult{
 		QueryResults: filteredCases,

--- a/server/modules/assistant/query_cases.go
+++ b/server/modules/assistant/query_cases.go
@@ -71,7 +71,7 @@ func (t *QueryCasesTool) GetSchema() model.JSONSchema {
 				},
 				"limit": {
 					Type:        "integer",
-					Description: "The maximum number of events to return",
+					Description: "The maximum number of cases to return",
 					Default:     100,
 				},
 			},
@@ -116,7 +116,7 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 
 	result.Parameters = args
 
-	var metricLimit, eventLimit int
+	var metricLimit, caseLimit int
 	zone := "UTC"
 	query := args.OQLQuery
 
@@ -131,9 +131,9 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 	}
 
 	if args.Limit > 0 {
-		eventLimit = args.Limit
+		caseLimit = args.Limit
 	} else {
-		eventLimit = 10
+		caseLimit = 10
 	}
 	metricLimit = 10000
 
@@ -149,7 +149,7 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 		"2006/01/02 3:04:05 PM",
 		zone,
 		strconv.Itoa(metricLimit),
-		strconv.Itoa(eventLimit))
+		strconv.Itoa(caseLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -166,24 +166,24 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 		return nil, err
 	}
 
-	events := searchResults.Events
+	caseEvents := searchResults.Events
 
-	if len(events) == 0 {
-		result.Result = "No events found"
+	if len(caseEvents) == 0 {
+		result.Result = "No cases found"
 		return result, nil
 	}
 
-	logger.WithField("eventsFound", len(events)).Info("query executed successfully")
+	logger.WithField("casesFound", len(caseEvents)).Info("query executed successfully")
 
-	// Log raw event size before filtering
-	rawJSON, _ := json.Marshal(events)
-	logger.WithField("rawEventSize", len(rawJSON)).Debug("raw event size before filtering")
+	// Log raw case size before filtering
+	rawJSON, _ := json.Marshal(caseEvents)
+	logger.WithField("rawCaseSize", len(rawJSON)).Debug("raw case size before filtering")
 
-	// Filter event fields to reduce size
-	filteredEvents := filterCases(events)
+	// Filter case fields to reduce size
+	filteredCases := filterCases(caseEvents)
 
 	// Convert to JSON
-	resultJSON, err := json.MarshalIndent(filteredEvents, "", "  ")
+	resultJSON, err := json.MarshalIndent(filteredCases, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal result: %w", err)
 	}
@@ -199,14 +199,14 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 	}
 
 	result.Result = QueryCasesResult{
-		QueryResults: filteredEvents,
+		QueryResults: filteredCases,
 		RecentCases:  recentCases,
 	}
 
 	return result, nil
 }
 
-// filterEvents filters event fields to reduce payload size
+// filterCases filters case event fields to reduce payload size
 func filterCases(events []*model.EventRecord, extraFields ...string) []map[string]any {
 	// Default fields from Python implementation
 	defaultFields := []string{

--- a/server/modules/assistant/query_cases_test.go
+++ b/server/modules/assistant/query_cases_test.go
@@ -1,0 +1,621 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryCasesTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name           string
+		params         string
+		auxData        string
+		mockResults    *model.EventSearchResults
+		mockError      error
+		expectedResult any
+		expectedError  bool
+	}{
+		{
+			name:    "basic case query",
+			params:  `{"oql_query": "so_case.title:malware AND _index:\"*:so-case\" AND so_kind:case", "limit": 10}`,
+			auxData: `[]`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-case-index",
+						Id:     "case-1",
+						Payload: map[string]any{
+							"@timestamp":          "2024-01-01T00:00:00Z",
+							"so_case.title":       "Malware Investigation",
+							"so_case.description": "Investigating suspicious malware activity",
+							"so_case.status":      "open",
+							"so_case.priority":    "high",
+							"so_case.severity":    3,
+							"so_case.assigneeId":  "analyst1",
+							"so_case.userId":      "user1",
+						},
+					},
+					{
+						Source: "so-case-index",
+						Id:     "case-2",
+						Payload: map[string]any{
+							"@timestamp":          "2024-01-01T00:01:00Z",
+							"so_case.title":       "Malware Detection Follow-up",
+							"so_case.description": "Follow-up investigation for malware detection",
+							"so_case.status":      "in-progress",
+							"so_case.priority":    "medium",
+							"so_case.severity":    2,
+							"so_case.assigneeId":  "analyst2",
+							"so_case.userId":      "user2",
+						},
+					},
+				},
+				TotalEvents: 2,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: QueryCasesResult{
+				QueryResults: []map[string]any{
+					{
+						"payload": map[string]any{
+							"_id":                 "case-1",
+							"@timestamp":          "2024-01-01T00:00:00Z",
+							"so_case.title":       "Malware Investigation",
+							"so_case.description": "Investigating suspicious malware activity",
+							"so_case.status":      "open",
+							"so_case.priority":    "high",
+							"so_case.severity":    3,
+							"so_case.assigneeId":  "analyst1",
+							"so_case.userId":      "user1",
+						},
+					},
+					{
+						"payload": map[string]any{
+							"_id":                 "case-2",
+							"@timestamp":          "2024-01-01T00:01:00Z",
+							"so_case.title":       "Malware Detection Follow-up",
+							"so_case.description": "Follow-up investigation for malware detection",
+							"so_case.status":      "in-progress",
+							"so_case.priority":    "medium",
+							"so_case.severity":    2,
+							"so_case.assigneeId":  "analyst2",
+							"so_case.userId":      "user2",
+						},
+					},
+				},
+				RecentCases: []map[string]any{},
+			},
+		},
+		{
+			name:    "query with recent cases in auxData",
+			params:  `{"oql_query": "so_case.category:phishing AND _index:\"*:so-case\" AND so_kind:case", "limit": 5}`,
+			auxData: `[{"case_id": "recent-1", "title": "Recent Phishing Case", "status": "closed"}]`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-case-index",
+						Id:     "case-3",
+						Payload: map[string]any{
+							"@timestamp":       "2024-01-01T00:00:00Z",
+							"so_case.title":    "Phishing Email Investigation",
+							"so_case.category": "phishing",
+							"so_case.status":   "open",
+							"so_case.priority": "high",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: QueryCasesResult{
+				QueryResults: []map[string]any{
+					{
+						"payload": map[string]any{
+							"_id":              "case-3",
+							"@timestamp":       "2024-01-01T00:00:00Z",
+							"so_case.title":    "Phishing Email Investigation",
+							"so_case.category": "phishing",
+							"so_case.status":   "open",
+							"so_case.priority": "high",
+						},
+					},
+				},
+				RecentCases: []map[string]any{
+					{"case_id": "recent-1", "title": "Recent Phishing Case", "status": "closed"},
+				},
+			},
+		},
+		{
+			name:    "query with time range",
+			params:  `{"oql_query": "so_case.status:closed AND _index:\"*:so-case\" AND so_kind:case", "range_start": "-7d", "range_end": "now", "limit": 20}`,
+			auxData: `[]`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-case-index",
+						Id:     "case-4",
+						Payload: map[string]any{
+							"@timestamp":           "2024-01-01T00:00:00Z",
+							"so_case.title":        "Closed Investigation",
+							"so_case.status":       "closed",
+							"so_case.completeTime": "2024-01-01T12:00:00Z",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: QueryCasesResult{
+				QueryResults: []map[string]any{
+					{
+						"payload": map[string]any{
+							"_id":                  "case-4",
+							"@timestamp":           "2024-01-01T00:00:00Z",
+							"so_case.title":        "Closed Investigation",
+							"so_case.status":       "closed",
+							"so_case.completeTime": "2024-01-01T12:00:00Z",
+						},
+					},
+				},
+				RecentCases: []map[string]any{},
+			},
+		},
+		{
+			name:    "query with absolute time range",
+			params:  `{"oql_query": "so_case.priority:critical AND _index:\"*:so-case\" AND so_kind:case", "range_start": "2024/01/01 10:00:00 AM", "range_end": "2024/01/01 11:00:00 AM", "limit": 15}`,
+			auxData: `[]`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-case-index",
+						Id:     "case-5",
+						Payload: map[string]any{
+							"@timestamp":       "2024-01-01T10:00:00Z",
+							"so_case.title":    "Critical Security Incident",
+							"so_case.priority": "critical",
+							"so_case.severity": 4,
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: QueryCasesResult{
+				QueryResults: []map[string]any{
+					{
+						"payload": map[string]any{
+							"_id":              "case-5",
+							"@timestamp":       "2024-01-01T10:00:00Z",
+							"so_case.title":    "Critical Security Incident",
+							"so_case.priority": "critical",
+							"so_case.severity": 4,
+						},
+					},
+				},
+				RecentCases: []map[string]any{},
+			},
+		},
+		{
+			name:    "query with legacy query field",
+			params:  `{"query": "so_case.tags:incident AND _index:\"*:so-case\" AND so_kind:case", "limit": 12}`,
+			auxData: `[]`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-case-index",
+						Id:     "case-6",
+						Payload: map[string]any{
+							"@timestamp":    "2024-01-01T00:00:00Z",
+							"so_case.title": "Security Incident Response",
+							"so_case.tags":  []string{"incident", "response"},
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: QueryCasesResult{
+				QueryResults: []map[string]any{
+					{
+						"payload": map[string]any{
+							"_id":           "case-6",
+							"@timestamp":    "2024-01-01T00:00:00Z",
+							"so_case.title": "Security Incident Response",
+							"so_case.tags":  []string{"incident", "response"},
+						},
+					},
+				},
+				RecentCases: []map[string]any{},
+			},
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"oql_query": "invalid json}`,
+			auxData:       `[]`,
+			expectedError: true,
+		},
+		{
+			name:    "invalid auxData JSON",
+			params:  `{"oql_query": "so_case.title:test AND _index:\"*:so-case\" AND so_kind:case", "limit": 10}`,
+			auxData: `invalid json`,
+			mockResults: &model.EventSearchResults{
+				Events:  []*model.EventRecord{},
+				Metrics: make(map[string][]*model.EventMetric),
+			},
+			expectedError: true,
+		},
+		{
+			name:          "eventstore error",
+			params:        `{"oql_query": "so_case.title:test AND _index:\"*:so-case\" AND so_kind:case", "limit": 10}`,
+			auxData:       `[]`,
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
+		{
+			name:    "no cases found",
+			params:  `{"oql_query": "so_case.title:nonexistent AND _index:\"*:so-case\" AND so_kind:case", "limit": 10}`,
+			auxData: `[]`,
+			mockResults: &model.EventSearchResults{
+				Events:  []*model.EventRecord{},
+				Metrics: make(map[string][]*model.EventMetric),
+			},
+			expectedResult: "No cases found",
+		},
+		{
+			name:    "case with all so_case fields",
+			params:  `{"oql_query": "so_case.template:incident AND _index:\"*:so-case\" AND so_kind:case", "limit": 5}`,
+			auxData: `[]`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-case-index",
+						Id:     "case-7",
+						Payload: map[string]any{
+							"@timestamp":           "2024-01-01T00:00:00Z",
+							"so_case.assigneeId":   "analyst3",
+							"so_case.category":     "malware",
+							"so_case.completeTime": "2024-01-02T00:00:00Z",
+							"so_case.createTime":   "2024-01-01T00:00:00Z",
+							"so_case.description":  "Comprehensive incident investigation",
+							"so_case.pap":          2,
+							"so_case.priority":     "high",
+							"so_case.severity":     3,
+							"so_case.startTime":    "2024-01-01T01:00:00Z",
+							"so_case.status":       "closed",
+							"so_case.tags":         []string{"incident", "malware", "investigation"},
+							"so_case.template":     "incident",
+							"so_case.title":        "Comprehensive Incident Case",
+							"so_case.tlp":          "amber",
+							"so_case.userId":       "user3",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: QueryCasesResult{
+				QueryResults: []map[string]any{
+					{
+						"payload": map[string]any{
+							"_id":                  "case-7",
+							"@timestamp":           "2024-01-01T00:00:00Z",
+							"so_case.assigneeId":   "analyst3",
+							"so_case.category":     "malware",
+							"so_case.completeTime": "2024-01-02T00:00:00Z",
+							"so_case.createTime":   "2024-01-01T00:00:00Z",
+							"so_case.description":  "Comprehensive incident investigation",
+							"so_case.pap":          2,
+							"so_case.priority":     "high",
+							"so_case.severity":     3,
+							"so_case.startTime":    "2024-01-01T01:00:00Z",
+							"so_case.status":       "closed",
+							"so_case.tags":         []string{"incident", "malware", "investigation"},
+							"so_case.template":     "incident",
+							"so_case.title":        "Comprehensive Incident Case",
+							"so_case.tlp":          "amber",
+							"so_case.userId":       "user3",
+						},
+					},
+				},
+				RecentCases: []map[string]any{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock eventstore
+			mockEventstore := server.NewFakeEventstore()
+			if tc.mockResults != nil {
+				mockEventstore.SearchResults = []*model.EventSearchResults{tc.mockResults}
+			}
+			if tc.mockError != nil {
+				mockEventstore.Err = tc.mockError
+			}
+
+			// Create mock server
+			mockServer := &server.Server{
+				Eventstore: mockEventstore,
+			}
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create tool and execute
+			tool := &QueryCasesTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, tc.auxData)
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "query_cases", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+
+			// Verify search criteria was populated correctly
+			if !tc.expectedError && tc.mockError == nil {
+				assert.Len(t, mockEventstore.InputSearchCriterias, 1)
+				criteria := mockEventstore.InputSearchCriterias[0]
+				assert.NotNil(t, criteria)
+				assert.Contains(t, criteria.RawQuery, "NOT metadata.raw_index:")
+			}
+
+			// Assert result content
+			if tc.expectedResult != nil {
+				if resultStr, ok := tc.expectedResult.(string); ok {
+					// Handle string results (like "No cases found")
+					assert.Equal(t, resultStr, result.Result)
+				} else {
+					// Handle QueryCasesResult
+					assert.Equal(t, tc.expectedResult, result.Result)
+				}
+			} else {
+				assert.Nil(t, result.Result)
+			}
+		})
+	}
+}
+
+func TestFilterCases(t *testing.T) {
+	testCases := []struct {
+		name         string
+		events       []*model.EventRecord
+		extraFields  []string
+		expectedLen  int
+		validateFunc func(t *testing.T, result []map[string]any)
+	}{
+		{
+			name: "basic case with default fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-case-1",
+					Source: "so-case-index",
+					Payload: map[string]any{
+						"@timestamp":          "2024-01-01T00:00:00Z",
+						"so_case.title":       "Test Case",
+						"so_case.description": "Test case description",
+						"so_case.status":      "open",
+						"so_case.priority":    "medium",
+						"so_case.severity":    2,
+						"so_case.assigneeId":  "analyst1",
+						"so_case.userId":      "user1",
+						"ignored_field":       "this should not appear",
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-case-1", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "Test Case", payload["so_case.title"])
+				assert.Equal(t, "Test case description", payload["so_case.description"])
+				assert.Equal(t, "open", payload["so_case.status"])
+				assert.Equal(t, "medium", payload["so_case.priority"])
+				assert.Equal(t, 2, payload["so_case.severity"])
+				assert.Equal(t, "analyst1", payload["so_case.assigneeId"])
+				assert.Equal(t, "user1", payload["so_case.userId"])
+				assert.NotContains(t, payload, "ignored_field")
+			},
+		},
+		{
+			name: "case with all so_case fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-case-2",
+					Source: "so-case-index",
+					Payload: map[string]any{
+						"@timestamp":           "2024-01-01T00:00:00Z",
+						"so_case.assigneeId":   "analyst2",
+						"so_case.category":     "phishing",
+						"so_case.completeTime": "2024-01-02T00:00:00Z",
+						"so_case.createTime":   "2024-01-01T00:00:00Z",
+						"so_case.description":  "Phishing investigation case",
+						"so_case.pap":          1,
+						"so_case.priority":     "high",
+						"so_case.severity":     3,
+						"so_case.startTime":    "2024-01-01T01:00:00Z",
+						"so_case.status":       "in-progress",
+						"so_case.tags":         []string{"phishing", "email"},
+						"so_case.template":     "phishing",
+						"so_case.title":        "Phishing Email Case",
+						"so_case.tlp":          "green",
+						"so_case.userId":       "user2",
+						"extra_field":          "should not appear",
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-case-2", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "analyst2", payload["so_case.assigneeId"])
+				assert.Equal(t, "phishing", payload["so_case.category"])
+				assert.Equal(t, "2024-01-02T00:00:00Z", payload["so_case.completeTime"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["so_case.createTime"])
+				assert.Equal(t, "Phishing investigation case", payload["so_case.description"])
+				assert.Equal(t, 1, payload["so_case.pap"])
+				assert.Equal(t, "high", payload["so_case.priority"])
+				assert.Equal(t, 3, payload["so_case.severity"])
+				assert.Equal(t, "2024-01-01T01:00:00Z", payload["so_case.startTime"])
+				assert.Equal(t, "in-progress", payload["so_case.status"])
+				assert.Equal(t, []string{"phishing", "email"}, payload["so_case.tags"])
+				assert.Equal(t, "phishing", payload["so_case.template"])
+				assert.Equal(t, "Phishing Email Case", payload["so_case.title"])
+				assert.Equal(t, "green", payload["so_case.tlp"])
+				assert.Equal(t, "user2", payload["so_case.userId"])
+				assert.NotContains(t, payload, "extra_field")
+			},
+		},
+		{
+			name: "case with extra fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-case-3",
+					Source: "so-case-index",
+					Payload: map[string]any{
+						"@timestamp":     "2024-01-01T00:00:00Z",
+						"so_case.title":  "Custom Case",
+						"so_case.status": "open",
+						"custom_field1":  "custom_value1",
+						"custom_field2":  "custom_value2",
+						"ignored_field":  "ignored",
+					},
+				},
+			},
+			extraFields: []string{"custom_field1", "custom_field2"},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-case-3", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "Custom Case", payload["so_case.title"])
+				assert.Equal(t, "open", payload["so_case.status"])
+				assert.Equal(t, "custom_value1", payload["custom_field1"])
+				assert.Equal(t, "custom_value2", payload["custom_field2"])
+				assert.NotContains(t, payload, "ignored_field")
+			},
+		},
+		{
+			name: "multiple cases",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-case-4",
+					Source: "so-case-index",
+					Payload: map[string]any{
+						"@timestamp":       "2024-01-01T00:00:00Z",
+						"so_case.title":    "First Case",
+						"so_case.status":   "open",
+						"so_case.priority": "high",
+					},
+				},
+				{
+					Id:     "test-case-5",
+					Source: "so-case-index",
+					Payload: map[string]any{
+						"@timestamp":       "2024-01-01T00:01:00Z",
+						"so_case.title":    "Second Case",
+						"so_case.status":   "closed",
+						"so_case.priority": "low",
+					},
+				},
+			},
+			expectedLen: 2,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				assert.Equal(t, "test-case-4", result[0]["payload"].(map[string]any)["_id"])
+				assert.Equal(t, "test-case-5", result[1]["payload"].(map[string]any)["_id"])
+				assert.Equal(t, "First Case", result[0]["payload"].(map[string]any)["so_case.title"])
+				assert.Equal(t, "Second Case", result[1]["payload"].(map[string]any)["so_case.title"])
+				assert.Equal(t, "open", result[0]["payload"].(map[string]any)["so_case.status"])
+				assert.Equal(t, "closed", result[1]["payload"].(map[string]any)["so_case.status"])
+			},
+		},
+		{
+			name: "missing fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-case-6",
+					Source: "so-case-index",
+					Payload: map[string]any{
+						"@timestamp":     "2024-01-01T00:00:00Z",
+						"so_case.title":  "Minimal Case",
+						"so_case.status": "open",
+						// Missing many default fields
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-case-6", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "Minimal Case", payload["so_case.title"])
+				assert.Equal(t, "open", payload["so_case.status"])
+				// Missing fields should not be present
+				assert.NotContains(t, payload, "so_case.description")
+				assert.NotContains(t, payload, "so_case.priority")
+				assert.NotContains(t, payload, "so_case.assigneeId")
+			},
+		},
+		{
+			name: "nil field values are excluded",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-case-7",
+					Source: "so-case-index",
+					Payload: map[string]any{
+						"@timestamp":          "2024-01-01T00:00:00Z",
+						"so_case.title":       "Case with Nil Fields",
+						"so_case.status":      "open",
+						"so_case.description": nil,
+						"so_case.assigneeId":  nil,
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-case-7", payload["_id"])
+				assert.Equal(t, "Case with Nil Fields", payload["so_case.title"])
+				assert.Equal(t, "open", payload["so_case.status"])
+				// Nil fields should not be included
+				assert.NotContains(t, payload, "so_case.description")
+				assert.NotContains(t, payload, "so_case.assigneeId")
+			},
+		},
+		{
+			name:        "empty cases list",
+			events:      []*model.EventRecord{},
+			expectedLen: 0,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				assert.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterCases(tc.events, tc.extraFields...)
+
+			assert.Len(t, result, tc.expectedLen)
+
+			if tc.validateFunc != nil {
+				tc.validateFunc(t, result)
+			}
+		})
+	}
+}

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -95,7 +95,7 @@ type queryEventsArgs struct {
 	GroupByField *string `json:"groupby_field,omitempty"`
 }
 
-func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, params string) (result *model.ToolResponse, err error) {
+func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
 	logger := log.FromContext(ctx)
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")

--- a/server/modules/assistant/query_events_test.go
+++ b/server/modules/assistant/query_events_test.go
@@ -152,7 +152,7 @@ func TestQueryEventsTool_Execute(t *testing.T) {
 
 			// Create tool and execute
 			tool := &QueryEventsTool{}
-			result, err := tool.Execute(ctx, mockServer, tc.params)
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
 
 			// Assert error expectations
 			if tc.expectedError {
@@ -198,12 +198,12 @@ func TestFilterEvents(t *testing.T) {
 					Id:     "test-id-1",
 					Source: "test-index",
 					Payload: map[string]any{
-						"@timestamp":   "2024-01-01T00:00:00Z",
-						"source.ip":    "192.168.1.1",
+						"@timestamp":     "2024-01-01T00:00:00Z",
+						"source.ip":      "192.168.1.1",
 						"destination.ip": "10.0.0.1",
-						"tags":         []string{"alert", "malware"},
-						"rule.name":    "ET MALWARE Suspicious",
-						"ignored_field": "this should not appear",
+						"tags":           []string{"alert", "malware"},
+						"rule.name":      "ET MALWARE Suspicious",
+						"ignored_field":  "this should not appear",
 					},
 				},
 			},

--- a/server/modules/assistant/tool.go
+++ b/server/modules/assistant/tool.go
@@ -16,7 +16,7 @@ type Tool interface {
 	GetName() string
 	GetDescription() string
 	GetSchema() model.JSONSchema
-	Execute(context.Context, *server.Server, string) (*model.ToolResponse, error)
+	Execute(context.Context, *server.Server, string, string) (*model.ToolResponse, error)
 }
 
 //go:generate mockgen -destination mock/mock_tool.go -package mock . Tool


### PR DESCRIPTION
- Implemented functionality for escalating to an existing case on the Assistant page [#344](https://github.com/Security-Onion-Solutions/sos/issues/344). This involved creating a new tool and updating an existing one.
    - query_cases: This new tool behaves similarly to query_events, except it looks for cases. It also takes in auxiliary data in the form of mruCases from local storage, allowing the AI to take into account both queried cases and recently viewed cases when deciding which are most applicable to the alert/topic at hand.
    - escalate_alerts: This tool has been updated to be able to escalate alerts to existing cases. It can now take a case that has been retrieved and analyzed by query_cases, and use that as a parameter to escalate alert(s) onto.
- Added unit testing for both of these tools.