### PR TITLE
LowBalanceColorAlert too

### DIFF
--- a/model/clientparameters.go
+++ b/model/clientparameters.go
@@ -200,8 +200,9 @@ type ModelParameters struct {
 func (m *ModelParameters) UnmarshalJSON(data []byte) error {
 	type Alias ModelParameters // Prevent recursion
 	aux := struct {
-		ContextLimitSmall any `json:"contextLimitSmall"`
-		ContextLimitLarge any `json:"contextLimitLarge"`
+		ContextLimitSmall    any `json:"contextLimitSmall"`
+		ContextLimitLarge    any `json:"contextLimitLarge"`
+		LowBalanceColorAlert any `json:"lowBalanceColorAlert"`
 		*Alias
 	}{
 		Alias: (*Alias)(m),
@@ -234,6 +235,9 @@ func (m *ModelParameters) UnmarshalJSON(data []byte) error {
 	}
 	if m.ContextLimitLarge, err = parseToInt(aux.ContextLimitLarge); err != nil {
 		return fmt.Errorf("parsing contextLimitLarge: %w", err)
+	}
+	if m.LowBalanceColorAlert, err = parseToInt(aux.LowBalanceColorAlert); err != nil {
+		return fmt.Errorf("parsing LowBalanceColorAlert: %w", err)
 	}
 
 	return nil

--- a/model/clientparameters_test.go
+++ b/model/clientparameters_test.go
@@ -131,14 +131,14 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 				"displayName": "Sci Notation",
 				"contextLimitSmall": "1e3",
 				"contextLimitLarge": "2e6",
-				"lowBalanceColorAlert": 3
+				"lowBalanceColorAlert": "3e4"
 			}`,
 			want: ModelParameters{
 				ID:                   "sci",
 				DisplayName:          "Sci Notation",
 				ContextLimitSmall:    1000,
 				ContextLimitLarge:    2000000,
-				LowBalanceColorAlert: 3,
+				LowBalanceColorAlert: 30000,
 			},
 		},
 		{
@@ -148,7 +148,7 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 				"displayName": "String Ints",
 				"contextLimitSmall": "1234",
 				"contextLimitLarge": "5678",
-				"lowBalanceColorAlert": 9
+				"lowBalanceColorAlert": "9"
 			}`,
 			want: ModelParameters{
 				ID:                   "str",
@@ -165,7 +165,7 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 				"displayName": "Mixed",
 				"contextLimitSmall": 8000,
 				"contextLimitLarge": "9e3",
-				"lowBalanceColorAlert": 4
+				"lowBalanceColorAlert": "4"
 			}`,
 			want: ModelParameters{
 				ID:                   "mix",
@@ -189,15 +189,14 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 			name: "missing context fields should default to zero",
 			input: `{
 				"id": "missing",
-				"displayName": "Missing Fields",
-				"lowBalanceColorAlert": 42
+				"displayName": "Missing Fields"
 			}`,
 			want: ModelParameters{
 				ID:                   "missing",
 				DisplayName:          "Missing Fields",
 				ContextLimitSmall:    0,
 				ContextLimitLarge:    0,
-				LowBalanceColorAlert: 42,
+				LowBalanceColorAlert: 0,
 			},
 		},
 		{
@@ -207,7 +206,7 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 				"displayName": "Weird Types",
 				"contextLimitSmall": false,
 				"contextLimitLarge": true,
-				"lowBalanceColorAlert": 42
+				"lowBalanceColorAlert": undefined
 			}`,
 			wantErr: true,
 		},


### PR DESCRIPTION
I skipped this field on the first pass because we stored <1M values in it but python/jinja doesn't care and put it in a string anyway. Wasn't even scientific notation.