### PR TITLE
Assistant: Detections Tools

### DIFF
--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -1726,7 +1726,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
 
     // Check if a tool should be auto-approved based on localStorage settings
     shouldAutoApproveTool(toolName) {
-      return ['query_events', 'get_playbooks', 'query_cases'].includes(toolName) && this.alwaysApproveReadRequests;
+      return ['query_events', 'get_playbooks', 'query_cases', 'query_detections'].includes(toolName) && this.alwaysApproveReadRequests;
     },
 
     // Open the options menu programmatically

--- a/model/detection.go
+++ b/model/detection.go
@@ -213,6 +213,14 @@ type OverrideNoteUpdate struct {
 	Note string `json:"note" example:"corrected note"`
 }
 
+type BulkUpdateStats struct {
+	Updated        int
+	Audited        int
+	Filtered       int
+	ErrMap         map[string]string
+	UpdateDuration time.Duration
+}
+
 func (o Override) PrepareForSigma() (map[string]interface{}, error) {
 	if o.CustomFilter == nil || !o.IsEnabled {
 		return map[string]interface{}{}, nil

--- a/model/detection.go
+++ b/model/detection.go
@@ -219,6 +219,7 @@ type BulkUpdateStats struct {
 	Filtered       int
 	ErrMap         map[string]string
 	UpdateDuration time.Duration
+	NeedToSync     []*Detection
 }
 
 func (o Override) PrepareForSigma() (map[string]interface{}, error) {

--- a/model/tool.go
+++ b/model/tool.go
@@ -57,7 +57,8 @@ type ToolSchema struct {
 }
 
 type ToolSchemaProperty struct {
-	Type        string `json:"type"`
-	Description string `json:"description"`
-	Default     any    `json:"default,omitempty"`
+	Type        string                        `json:"type"`
+	Description string                        `json:"description"`
+	Default     any                           `json:"default,omitempty"`
+	Items       map[string]ToolSchemaProperty `json:"items,omitempty"`
 }

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -55,6 +55,14 @@ type DetectionHandler struct {
 	server *Server
 }
 
+type BulkUpdateStats struct {
+	Updated        int
+	Audited        int
+	Filtered       int
+	ErrMap         map[string]string
+	UpdateDuration time.Duration
+}
+
 func NewDetectionHandler(srv *Server) *DetectionHandler {
 	return &DetectionHandler{
 		server: srv,

--- a/server/detectionhandler.go
+++ b/server/detectionhandler.go
@@ -55,14 +55,6 @@ type DetectionHandler struct {
 	server *Server
 }
 
-type BulkUpdateStats struct {
-	Updated        int
-	Audited        int
-	Filtered       int
-	ErrMap         map[string]string
-	UpdateDuration time.Duration
-}
-
 func NewDetectionHandler(srv *Server) *DetectionHandler {
 	return &DetectionHandler{
 		server: srv,

--- a/server/detectionstore.go
+++ b/server/detectionstore.go
@@ -23,7 +23,7 @@ type Detectionstore interface {
 	DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error)
 	GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) // map[detection.PublicId]detection
 	Query(ctx context.Context, query string, max int) ([]interface{}, error)
-	QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string) ([]interface{}, error)
+	QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string, limit int) ([]interface{}, error)
 	GetDetectionHistory(ctx context.Context, detectID string) ([]interface{}, error)
 
 	CreateComment(ctx context.Context, newComment *model.DetectionComment) (*model.DetectionComment, error)

--- a/server/detectionstore.go
+++ b/server/detectionstore.go
@@ -19,9 +19,11 @@ type Detectionstore interface {
 	GetDetection(ctx context.Context, detectId string) (*model.Detection, error)
 	GetDetectionByPublicId(ctx context.Context, publicId string) (*model.Detection, error)
 	UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error)
+	BulkUpdateDetections(ctx context.Context, newStatus bool, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error)
 	DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error)
 	GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) // map[detection.PublicId]detection
 	Query(ctx context.Context, query string, max int) ([]interface{}, error)
+	QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string) ([]interface{}, error)
 	GetDetectionHistory(ctx context.Context, detectID string) ([]interface{}, error)
 
 	CreateComment(ctx context.Context, newComment *model.DetectionComment) (*model.DetectionComment, error)

--- a/server/detectionstore.go
+++ b/server/detectionstore.go
@@ -20,6 +20,7 @@ type Detectionstore interface {
 	GetDetectionByPublicId(ctx context.Context, publicId string) (*model.Detection, error)
 	UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error)
 	BulkUpdateDetections(ctx context.Context, newStatus bool, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error)
+	BulkAddOverrides(ctx context.Context, newOverrides []*model.Override, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error)
 	DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error)
 	GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) // map[detection.PublicId]detection
 	Query(ctx context.Context, query string, max int) ([]interface{}, error)

--- a/server/detectionstore.go
+++ b/server/detectionstore.go
@@ -24,7 +24,8 @@ type Detectionstore interface {
 	DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error)
 	GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) // map[detection.PublicId]detection
 	Query(ctx context.Context, query string, max int) ([]interface{}, error)
-	QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string, limit int) ([]interface{}, error)
+	QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string, limit int) (*model.EventSearchResults, error)
+	ConvertEventsToDetections(ctx context.Context, detectEvents *model.EventSearchResults) (detects []*model.Detection, err error)
 	GetDetectionHistory(ctx context.Context, detectID string) ([]interface{}, error)
 
 	CreateComment(ctx context.Context, newComment *model.DetectionComment) (*model.DetectionComment, error)

--- a/server/mock/mock_detectionstore.go
+++ b/server/mock/mock_detectionstore.go
@@ -58,6 +58,21 @@ func (mr *MockDetectionstoreMockRecorder) BuildBulkIndexer(ctx, logger any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildBulkIndexer", reflect.TypeOf((*MockDetectionstore)(nil).BuildBulkIndexer), ctx, logger)
 }
 
+// BulkAddOverrides mocks base method.
+func (m *MockDetectionstore) BulkAddOverrides(ctx context.Context, newOverrides []*model.Override, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkAddOverrides", ctx, newOverrides, detects, logger)
+	ret0, _ := ret[0].(*model.BulkUpdateStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BulkAddOverrides indicates an expected call of BulkAddOverrides.
+func (mr *MockDetectionstoreMockRecorder) BulkAddOverrides(ctx, newOverrides, detects, logger any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkAddOverrides", reflect.TypeOf((*MockDetectionstore)(nil).BulkAddOverrides), ctx, newOverrides, detects, logger)
+}
+
 // BulkUpdateDetections mocks base method.
 func (m *MockDetectionstore) BulkUpdateDetections(ctx context.Context, newStatus bool, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
 	m.ctrl.T.Helper()

--- a/server/mock/mock_detectionstore.go
+++ b/server/mock/mock_detectionstore.go
@@ -274,18 +274,18 @@ func (mr *MockDetectionstoreMockRecorder) Query(ctx, query, max any) *gomock.Cal
 }
 
 // QueryWithRange mocks base method.
-func (m *MockDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string) ([]any, error) {
+func (m *MockDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryWithRange", ctx, query, rangeStart, rangeEnd, rangeFormat)
+	ret := m.ctrl.Call(m, "QueryWithRange", ctx, query, rangeStart, rangeEnd, rangeFormat, limit)
 	ret0, _ := ret[0].([]any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueryWithRange indicates an expected call of QueryWithRange.
-func (mr *MockDetectionstoreMockRecorder) QueryWithRange(ctx, query, rangeStart, rangeEnd, rangeFormat any) *gomock.Call {
+func (mr *MockDetectionstoreMockRecorder) QueryWithRange(ctx, query, rangeStart, rangeEnd, rangeFormat, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryWithRange", reflect.TypeOf((*MockDetectionstore)(nil).QueryWithRange), ctx, query, rangeStart, rangeEnd, rangeFormat)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryWithRange", reflect.TypeOf((*MockDetectionstore)(nil).QueryWithRange), ctx, query, rangeStart, rangeEnd, rangeFormat, limit)
 }
 
 // UpdateComment mocks base method.

--- a/server/mock/mock_detectionstore.go
+++ b/server/mock/mock_detectionstore.go
@@ -88,6 +88,21 @@ func (mr *MockDetectionstoreMockRecorder) BulkUpdateDetections(ctx, newStatus, d
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateDetections", reflect.TypeOf((*MockDetectionstore)(nil).BulkUpdateDetections), ctx, newStatus, detects, logger)
 }
 
+// ConvertEventsToDetections mocks base method.
+func (m *MockDetectionstore) ConvertEventsToDetections(ctx context.Context, detectEvents *model.EventSearchResults) ([]*model.Detection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConvertEventsToDetections", ctx, detectEvents)
+	ret0, _ := ret[0].([]*model.Detection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ConvertEventsToDetections indicates an expected call of ConvertEventsToDetections.
+func (mr *MockDetectionstoreMockRecorder) ConvertEventsToDetections(ctx, detectEvents any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertEventsToDetections", reflect.TypeOf((*MockDetectionstore)(nil).ConvertEventsToDetections), ctx, detectEvents)
+}
+
 // ConvertObjectToDocument mocks base method.
 func (m *MockDetectionstore) ConvertObjectToDocument(ctx context.Context, kind string, obj any, auditable *model.Auditable, isEdit bool, auditDocId, op *string) ([]byte, string, error) {
 	m.ctrl.T.Helper()
@@ -289,10 +304,10 @@ func (mr *MockDetectionstoreMockRecorder) Query(ctx, query, max any) *gomock.Cal
 }
 
 // QueryWithRange mocks base method.
-func (m *MockDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]any, error) {
+func (m *MockDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) (*model.EventSearchResults, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueryWithRange", ctx, query, rangeStart, rangeEnd, rangeFormat, limit)
-	ret0, _ := ret[0].([]any)
+	ret0, _ := ret[0].(*model.EventSearchResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/server/mock/mock_detectionstore.go
+++ b/server/mock/mock_detectionstore.go
@@ -58,6 +58,21 @@ func (mr *MockDetectionstoreMockRecorder) BuildBulkIndexer(ctx, logger any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildBulkIndexer", reflect.TypeOf((*MockDetectionstore)(nil).BuildBulkIndexer), ctx, logger)
 }
 
+// BulkUpdateDetections mocks base method.
+func (m *MockDetectionstore) BulkUpdateDetections(ctx context.Context, newStatus bool, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkUpdateDetections", ctx, newStatus, detects, logger)
+	ret0, _ := ret[0].(*model.BulkUpdateStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BulkUpdateDetections indicates an expected call of BulkUpdateDetections.
+func (mr *MockDetectionstoreMockRecorder) BulkUpdateDetections(ctx, newStatus, detects, logger any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkUpdateDetections", reflect.TypeOf((*MockDetectionstore)(nil).BulkUpdateDetections), ctx, newStatus, detects, logger)
+}
+
 // ConvertObjectToDocument mocks base method.
 func (m *MockDetectionstore) ConvertObjectToDocument(ctx context.Context, kind string, obj any, auditable *model.Auditable, isEdit bool, auditDocId, op *string) ([]byte, string, error) {
 	m.ctrl.T.Helper()
@@ -256,6 +271,21 @@ func (m *MockDetectionstore) Query(ctx context.Context, query string, max int) (
 func (mr *MockDetectionstoreMockRecorder) Query(ctx, query, max any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Query", reflect.TypeOf((*MockDetectionstore)(nil).Query), ctx, query, max)
+}
+
+// QueryWithRange mocks base method.
+func (m *MockDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string) ([]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryWithRange", ctx, query, rangeStart, rangeEnd, rangeFormat)
+	ret0, _ := ret[0].([]any)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryWithRange indicates an expected call of QueryWithRange.
+func (mr *MockDetectionstoreMockRecorder) QueryWithRange(ctx, query, rangeStart, rangeEnd, rangeFormat any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryWithRange", reflect.TypeOf((*MockDetectionstore)(nil).QueryWithRange), ctx, query, rangeStart, rangeEnd, rangeFormat)
 }
 
 // UpdateComment mocks base method.

--- a/server/modules/assistant/ack_alerts.go
+++ b/server/modules/assistant/ack_alerts.go
@@ -108,7 +108,7 @@ func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, para
 	if args.RangeFormat != "" {
 		timeFormat = args.RangeFormat
 	} else {
-		timeFormat = "2006-01-02 3:04:05 PM"
+		timeFormat = "2006/01/02 3:04:05 PM"
 	}
 
 	var timeRange string

--- a/server/modules/assistant/ack_alerts.go
+++ b/server/modules/assistant/ack_alerts.go
@@ -103,10 +103,18 @@ func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, para
 		return nil, err
 	}
 
+	var timeFormat string
+
+	if args.RangeFormat != "" {
+		timeFormat = args.RangeFormat
+	} else {
+		timeFormat = "2006-01-02 3:04:05 PM"
+	}
+
 	var timeRange string
 
 	if args.RangeStart != "" || args.RangeEnd != "" {
-		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, timeFormat)
 	}
 
 	result.Parameters = args
@@ -116,7 +124,7 @@ func (t *AckAlertsTool) Execute(ctx context.Context, server *server.Server, para
 	crit.SearchFilter = "(tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true) AND (" + args.SearchFilter + ")"
 	crit.EventFilter = args.EventFilter
 	crit.DateRange = timeRange
-	crit.DateRangeFormat = "2006/01/02 3:04:05 PM"
+	crit.DateRangeFormat = timeFormat
 	crit.Timezone = "UTC"
 
 	if len(crit.EventFilter) == 0 {

--- a/server/modules/assistant/add_overrides.go
+++ b/server/modules/assistant/add_overrides.go
@@ -234,48 +234,7 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 
 	result.Parameters = args
 
-	var newOverrides []*model.Override
-
-	for _, overrideMap := range args.Overrides {
-		override := &model.Override{}
-
-		if v, ok := overrideMap["type"].(string); ok {
-			override.Type = model.OverrideType(v)
-		}
-		if v, ok := overrideMap["isEnabled"].(bool); ok {
-			override.IsEnabled = v
-		}
-		if v, ok := overrideMap["note"].(string); ok {
-			override.Note = v
-		}
-		if v, ok := overrideMap["regex"].(string); ok {
-			override.Regex = &v
-		}
-		if v, ok := overrideMap["value"].(string); ok {
-			override.Value = &v
-		}
-		if v, ok := overrideMap["track"].(string); ok {
-			override.Track = &v
-		}
-		if v, ok := overrideMap["ip"].(string); ok {
-			override.IP = &v
-		}
-		if v, ok := overrideMap["thresholdType"].(string); ok {
-			override.ThresholdType = &v
-		}
-		if v, ok := overrideMap["count"].(float64); ok {
-			count := int(v)
-			override.Count = &count
-		}
-		if v, ok := overrideMap["seconds"].(float64); ok {
-			seconds := int(v)
-			override.Seconds = &seconds
-		}
-		if v, ok := overrideMap["customFilter"].(string); ok {
-			override.CustomFilter = &v
-		}
-		newOverrides = append(newOverrides, override)
-	}
+	newOverrides := populateOverridesFromMaps(args.Overrides, false)
 
 	query := args.SearchFilter
 

--- a/server/modules/assistant/add_overrides.go
+++ b/server/modules/assistant/add_overrides.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -20,27 +19,39 @@ import (
 )
 
 func init() {
-	t := &ToggleDetectionsTool{}
+	t := &AddOverridesTool{}
 	knownTools[t.GetName()] = t
 }
 
-type ToggleDetectionsTool struct{}
+type AddOverridesTool struct{}
 
-func (t *ToggleDetectionsTool) GetName() string {
-	return "toggle_detections"
+func (t *AddOverridesTool) GetName() string {
+	return "add_overrides"
 }
 
-func (t *ToggleDetectionsTool) GetDescription() string {
-	return "Enable or disable detections in Security Onion (per the user's request) by querying for them with a search filter.\n" +
-		"- Search for detections by referencing any potentially relevant field(s), whichever you see fit from the ones described to you.\n" +
-		"- *IMPORTANT* All queries should include `AND _index:\"*:so-detection\" AND so_kind:detection` appended to the end. The quotes around *:so-detection MUST be included.\n" +
-		"- When searching for detections, specify a date range of 999 days ago unless advised otherwise.\n" +
-		"- Examples for wild cards in the oql_query:\n" +
-		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
-		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `so_detection.title:(A B*)` is valid, but `so_detection.title:\"A B*\"` will not work as expected)\n"
+func (t *AddOverridesTool) GetDescription() string {
+	return `Add one or more new overrides to existing detection(s) per the user's request. Search for detections by referencing any potentially relevant field(s), whichever you see fit from the ones described to you.
+	- *IMPORTANT* All detections MUST be of the same language/engine (Suricata or Sigma). Otherwise, the new override(s) won't be compatible with some of them.
+	- *IMPORTANT* All queries should include 'AND _index:"*:so-detection" AND so_kind:detection' appended to the end. The quotes around *:so-detection MUST be included.
+	- When searching for detections, specify a date range of 999 days ago unless advised otherwise.
+	- Examples for wild cards in the oql_query:
+	  - Search terms cannot begin with a wildcard (e.g., "*xyz" the wildcard is ignored, but "xyz*" is valid)
+	  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., so_detection.title:(A B*) is valid, but so_detection.title:"A B*" will not work as expected)
+	The types of overrides and the fields for each override can vary between the Suricata and Sigma languages.
+	YARA does not have overrides. The 5 fields that all overrides do share in common, no matter the language, are "isEnabled", "createdAt", "updatedAt", "type", and "note".
+	The "note" field is the only one that can be empty. Here is a run-down of the language-specific override types and their respective fields and potential values:
+	Suricata:
+	- 3 different values for "type": "modify", "suppress", and "threshold"
+	  - "modify" overrides also have the fields "regex" and "value".
+	  - "suppress" overrides also have the fields "track" and "ip". The "track" field can ONLY take ONE of the following 3 values: "by_dst", "by_src", or "by_either". The "ip" field can be in CIDR notation or a Suricata variable.
+	  - "threshold" overrides also have the fields "thresholdType", "track", "count", and "seconds". The "track" field can only take one of 2 values: "by_dst" or "by_src". The "thresholdType" field can only take one of 3 values: "threshold", "limit", or "both".
+	Sigma:
+	- Only 1 value for "type": "customFilter"
+	  - "customFilter" overrides also have a field called "customFilter", where you put the actual filter.
+	*IMPORTANT* When creating a new override, DO NOT include createdAt or updatedAt fields for the new override.`
 }
 
-func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
+func (t *AddOverridesTool) GetSchema() model.JSONSchema {
 	return model.JSONSchema{
 		Json: &model.ToolSchema{
 			Type: "object",
@@ -72,10 +83,32 @@ func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
 						"- so_detection.service: Used by Sigma rules for filtering a subset of log outputs to a specific server. Example: \"sshd\"\n" +
 						"- @timestamp: The date and time when this detection was last created/updated/modified. Example: \"2025-11-12T19:38:17.413984706Z\"",
 				},
-				"enable": {
+				"overrides": {
 					Type: "string",
-					Description: "This is a \"true\"/\"false\" value based on whether the user wants to enable or disable the detections at hand. A value of \"true\" corresponds to the enable operation, and \"false\" corresponds to the disable operation.\n" +
-						"*IMPORTANT* This can only have one of two values: \"true\" or \"false\".",
+					Description: `The new overrides to add to the detections at hand. These will be appended to the existing overrides block for each queried detection.
+					This field should be a list of the new override(s), in string format. Note that even in the case where there is only one new override being added, this new override
+					should still be placed inside a list, with the entire input in string format. Here is an example input for this field, in the case where the user wants
+					to append two new overrides to each of the detections returned by the search_filter:
+[
+	{
+		"note": "",
+		"seconds": 60,
+		"isEnabled": true,
+		"count": 10,
+		"type": "threshold",
+		"track": "by_src",
+		"thresholdType": "both",
+	},
+	{
+		"note": "Override Note",
+		"regex": "rev:1;",
+		"isEnabled": true,
+		"type": "modify",
+		"value": "rev:2;",
+	}
+]
+					The above example should be passed as an input in string format. The above "overrides" argument is only the *new* overrides that the user wants to add to the given detection(s). This argument
+					should NOT include any existing overrides from the given detections' so_detection.overrides blocks, only new ones.`,
 				},
 				"range_start": {
 					Type:        "string",
@@ -92,7 +125,7 @@ func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
 				"limit": {
 					Type: "integer",
 					Description: `The maximum number of detections to return. Unless some kind of limit is applicable to the user's request, this field should be left out.
-						Here's an example where "limit" would be useful: "enable the 5 most recent suricata detections".`,
+						Here's an example where "limit" would be useful: "add the following override to the 5 most recent suricata detections: ...".`,
 				},
 			},
 			Required: []string{"search_filter"},
@@ -100,23 +133,23 @@ func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
 	}
 }
 
-type toggleDetectionsArgs struct {
+type AddOverridesArgs struct {
 	SearchFilter string `json:"search_filter"`
-	Enable       string `json:"enable" enums:"true,false"`
+	Overrides    string `json:"overrides" example:"[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"},{\"note\":\"Override Note\",\"regex\":\"rev:1;\",\"isEnabled\":true,\"type\":\"modify\",\"value\":\"rev:2;\"}]"`
 	RangeStart   string `json:"range_start,omitempty"`
 	RangeEnd     string `json:"range_end,omitempty"`
 	RangeFormat  string `json:"range_format,omitempty"`
 	Limit        int    `json:"limit"`
 }
 
-func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
 	logger := log.FromContext(ctx)
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
 
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
 
-	args := &toggleDetectionsArgs{}
+	args := &AddOverridesArgs{}
 	result = &model.ToolResponse{
 		ToolName:       t.GetName(),
 		OnBehalfOfUser: userId,
@@ -136,9 +169,11 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 
 	result.Parameters = args
 
-	enableBool, err := strconv.ParseBool(args.Enable)
+	var newOverrides []*model.Override
+
+	err = json.Unmarshal([]byte(args.Overrides), &newOverrides)
 	if err != nil {
-		return nil, fmt.Errorf("invalid value for argument \"enable\": %w", err)
+		return nil, fmt.Errorf("couldn't unmarshal overrides param: %w", err)
 	}
 
 	query := args.SearchFilter
@@ -180,67 +215,48 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 		detects = append(detects, det)
 	}
 
-	bulkStats, err := srv.Detectionstore.BulkUpdateDetections(ctx, enableBool, detects, logger)
+	engInt, ok := srv.DetectionEngines.Load(detects[0].Engine)
+	if !ok {
+		logger.WithField("detectionEngine", detects[0].Engine).Error("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine")
+	}
+
+	engine := engInt.(server.DetectionEngine)
+
+	bulkStats, err := srv.Detectionstore.BulkAddOverrides(ctx, newOverrides, detects, logger)
 	if err != nil {
-		logger.WithError(err).Error("error updating detections")
-		return nil, fmt.Errorf("error updating detections: %w", err)
+		logger.WithError(err).Error("error adding overrides")
+		return nil, fmt.Errorf("error adding overrides: %w", err)
 	}
 
 	syncDetects := bulkStats.NeedToSync
 	syncStart := time.Now()
-	errMap := map[string]string{}
 
-	byEngine := map[model.EngineName][]*model.Detection{}
-	for _, detectCurr := range syncDetects {
-		byEngine[detectCurr.Engine] = append(byEngine[detectCurr.Engine], detectCurr)
-	}
-
-	srv.DetectionEngines.Range(func(n, engineInt interface{}) bool {
-		name := n.(model.EngineName)
-		engine := engineInt.(server.DetectionEngine)
-
-		if len(byEngine[name]) != 0 {
-			var eMap map[string]string
-
-			eMap, err = engine.SyncLocalDetections(ctx, byEngine[name])
-			for sid, e := range eMap {
-				errMap[sid] = e
-			}
-			if err != nil {
-				return false
-			}
-		}
-
-		return true
-	})
-
+	errMap, err := engine.SyncLocalDetections(ctx, syncDetects)
 	if err != nil {
-		logger.WithError(err).Error("unable to sync detections")
-		return nil, fmt.Errorf("unable to sync detections: %w", err)
+		logger.WithError(err).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection: %w", err)
 	}
 
 	if len(errMap) != 0 {
-		logger.WithField("errMap", errMap).Error("unable to sync detections")
-		return nil, fmt.Errorf("unable to sync detections")
+		logger.WithField("errMap", errMap).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection")
 	}
 
 	syncDur := time.Since(syncStart)
 
-	var opString string
-	if enableBool {
-		opString = "Enabled"
-	} else {
-		opString = "Disabled"
+	plural := ""
+	if len(newOverrides) > 1 {
+		plural = "s"
 	}
 
 	result.Result = fmt.Sprintf(
-		"Successfully %s %d detections. %s=%d, Audited=%d, Filtered=%d, Errors=%v, UpdateDuration=%s, SyncDuration=%s",
-		opString,
+		"Successfully added %d override%s to %d detections. Updated=%d, Audited=%d, Errors=%v, UpdateDuration=%s, SyncDuration=%s",
+		len(newOverrides),
+		plural,
 		bulkStats.Updated,
-		opString,
 		bulkStats.Updated,
 		bulkStats.Audited,
-		bulkStats.Filtered,
 		bulkStats.ErrMap,
 		bulkStats.UpdateDuration,
 		syncDur,

--- a/server/modules/assistant/add_overrides.go
+++ b/server/modules/assistant/add_overrides.go
@@ -207,6 +207,11 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
 
+	err = srv.CheckAuthorized(ctx, "write", "detections")
+	if err != nil {
+		return nil, err
+	}
+
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
 
 	args := &AddOverridesArgs{}
@@ -285,11 +290,6 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 		detectLimit = args.Limit
 	} else {
 		detectLimit = 10000
-	}
-
-	err = srv.CheckAuthorized(ctx, "write", "detections")
-	if err != nil {
-		return nil, err
 	}
 
 	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)

--- a/server/modules/assistant/add_overrides.go
+++ b/server/modules/assistant/add_overrides.go
@@ -84,10 +84,70 @@ func (t *AddOverridesTool) GetSchema() model.JSONSchema {
 						"- @timestamp: The date and time when this detection was last created/updated/modified. Example: \"2025-11-12T19:38:17.413984706Z\"",
 				},
 				"overrides": {
-					Type: "string",
+					Type: "array",
+					Items: map[string]model.ToolSchemaProperty{
+						"override": {
+							Description: "Each of these objects represents an individual override.",
+							Type:        "object",
+							Items: map[string]model.ToolSchemaProperty{
+								"isEnabled": {
+									Type:        "boolean",
+									Description: "Indicates whether this override is enabled.",
+								},
+								"createdAt": {
+									Type:        "string",
+									Description: "The date and time when this override was created. This field should not be included for newly created overrides, and it also should not be modified.",
+								},
+								"updatedAt": {
+									Type:        "string",
+									Description: "The date and time when this override was last modified. This field should not be included for newly created overrides, and it also should not be modified.",
+								},
+								"type": {
+									Type:        "string",
+									Description: "The type of override; available values vary between detection engines.",
+								},
+								"note": {
+									Type:        "string",
+									Description: "An optional operational note for this override.",
+								},
+								"regex": {
+									Type:        "string",
+									Description: "(suricata only) Regular expression for matching modify overrides.",
+								},
+								"value": {
+									Type:        "string",
+									Description: "(suricata only) The value needing to match the regex in order for this override to apply.",
+								},
+								"track": {
+									Type:        "string",
+									Description: "(suricata only) Track type for suppress and threshold overrides (by_either only applies to suppress overrides).",
+								},
+								"ip": {
+									Type:        "string",
+									Description: "(suricata only) The IP address or network value.",
+								},
+								"thresholdType": {
+									Type:        "string",
+									Description: "(suricata only) Threshold type, for threshold overrides.",
+								},
+								"count": {
+									Type:        "integer",
+									Description: "(suricata only) For treshold overrides, this is the number of occurrences allowed, within the given seconds interval, before this detection triggers an alert. Must be non-negative and greater than 0.",
+								},
+								"seconds": {
+									Type:        "integer",
+									Description: "(suricata only) For treshold overrides, this is the number of seconds that the occurrence threshold must occur within. Must be non-negative and greater than 0.",
+								},
+								"customFilter": {
+									Type:        "string",
+									Description: "(elastalert only) The custom filter applied to Sigma detections before the detection will trigger an alert.",
+								},
+							},
+						},
+					},
 					Description: `The new overrides to add to the detections at hand. These will be appended to the existing overrides block for each queried detection.
-					This field should be a list of the new override(s), in string format. Note that even in the case where there is only one new override being added, this new override
-					should still be placed inside a list, with the entire input in string format. Here is an example input for this field, in the case where the user wants
+					This field should be a list of the new override(s), as an array of objects. Note that even in the case where there is only one new override being added,
+					this new override should still be placed inside an array. Here is an example input for this field, in the case where the user wants
 					to append two new overrides to each of the detections returned by the search_filter:
 [
 	{
@@ -107,8 +167,8 @@ func (t *AddOverridesTool) GetSchema() model.JSONSchema {
 		"value": "rev:2;",
 	}
 ]
-					The above example should be passed as an input in string format. The above "overrides" argument is only the *new* overrides that the user wants to add to the given detection(s). This argument
-					should NOT include any existing overrides from the given detections' so_detection.overrides blocks, only new ones.`,
+					If used as input, the above example should be passed as an array of objects. The above "overrides" argument is only the *new* overrides that the user wants to add to the given detection(s).
+					This argument should NOT include any existing overrides from the given detections' so_detection.overrides blocks, only new ones.`,
 				},
 				"range_start": {
 					Type:        "string",
@@ -134,12 +194,12 @@ func (t *AddOverridesTool) GetSchema() model.JSONSchema {
 }
 
 type AddOverridesArgs struct {
-	SearchFilter string `json:"search_filter"`
-	Overrides    string `json:"overrides" example:"[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"},{\"note\":\"Override Note\",\"regex\":\"rev:1;\",\"isEnabled\":true,\"type\":\"modify\",\"value\":\"rev:2;\"}]"`
-	RangeStart   string `json:"range_start,omitempty"`
-	RangeEnd     string `json:"range_end,omitempty"`
-	RangeFormat  string `json:"range_format,omitempty"`
-	Limit        int    `json:"limit"`
+	SearchFilter string           `json:"search_filter"`
+	Overrides    []map[string]any `json:"overrides"`
+	RangeStart   string           `json:"range_start,omitempty"`
+	RangeEnd     string           `json:"range_end,omitempty"`
+	RangeFormat  string           `json:"range_format,omitempty"`
+	Limit        int              `json:"limit"`
 }
 
 func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
@@ -171,7 +231,12 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 
 	var newOverrides []*model.Override
 
-	err = json.Unmarshal([]byte(args.Overrides), &newOverrides)
+	overridesBytes, err := json.Marshal(args.Overrides)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal overrides param: %w", err)
+	}
+
+	err = json.Unmarshal(overridesBytes, &newOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't unmarshal overrides param: %w", err)
 	}

--- a/server/modules/assistant/add_overrides.go
+++ b/server/modules/assistant/add_overrides.go
@@ -231,14 +231,45 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 
 	var newOverrides []*model.Override
 
-	overridesBytes, err := json.Marshal(args.Overrides)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal overrides param: %w", err)
-	}
+	for _, overrideMap := range args.Overrides {
+		override := &model.Override{}
 
-	err = json.Unmarshal(overridesBytes, &newOverrides)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't unmarshal overrides param: %w", err)
+		if v, ok := overrideMap["type"].(string); ok {
+			override.Type = model.OverrideType(v)
+		}
+		if v, ok := overrideMap["isEnabled"].(bool); ok {
+			override.IsEnabled = v
+		}
+		if v, ok := overrideMap["note"].(string); ok {
+			override.Note = v
+		}
+		if v, ok := overrideMap["regex"].(string); ok {
+			override.Regex = &v
+		}
+		if v, ok := overrideMap["value"].(string); ok {
+			override.Value = &v
+		}
+		if v, ok := overrideMap["track"].(string); ok {
+			override.Track = &v
+		}
+		if v, ok := overrideMap["ip"].(string); ok {
+			override.IP = &v
+		}
+		if v, ok := overrideMap["thresholdType"].(string); ok {
+			override.ThresholdType = &v
+		}
+		if v, ok := overrideMap["count"].(float64); ok {
+			count := int(v)
+			override.Count = &count
+		}
+		if v, ok := overrideMap["seconds"].(float64); ok {
+			seconds := int(v)
+			override.Seconds = &seconds
+		}
+		if v, ok := overrideMap["customFilter"].(string); ok {
+			override.CustomFilter = &v
+		}
+		newOverrides = append(newOverrides, override)
 	}
 
 	query := args.SearchFilter

--- a/server/modules/assistant/add_overrides.go
+++ b/server/modules/assistant/add_overrides.go
@@ -292,24 +292,22 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 		detectLimit = 10000
 	}
 
-	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
+	detectEvents, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
 	if err != nil {
 		return nil, fmt.Errorf("unable to search for detections with query %s: %w", query, err)
 	}
 
-	if len(detectObjects) == 0 {
+	detects, err := srv.Detectionstore.ConvertEventsToDetections(ctx, detectEvents)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert events to detections: %w", err)
+	}
+
+	if len(detects) == 0 {
 		result.Result = "No detections found"
 		return result, nil
 	}
 
-	logger.WithField("detectionsFound", len(detectObjects)).Info("query executed successfully")
-
-	detects := []*model.Detection{}
-
-	for _, d := range detectObjects {
-		det := d.(*model.Detection)
-		detects = append(detects, det)
-	}
+	logger.WithField("detectionsFound", len(detects)).Info("query executed successfully")
 
 	engInt, ok := srv.DetectionEngines.Load(detects[0].Engine)
 	if !ok {

--- a/server/modules/assistant/add_overrides.go
+++ b/server/modules/assistant/add_overrides.go
@@ -209,7 +209,7 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 
 	err = srv.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("user is not authorized to write detections: %w", err)
 	}
 
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
@@ -229,7 +229,7 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 
 	err = json.Unmarshal([]byte(params), args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't unmarshal params: %w", err)
 	}
 
 	result.Parameters = args
@@ -294,7 +294,7 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 
 	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to search for detections with query %s: %w", query, err)
 	}
 
 	if len(detectObjects) == 0 {
@@ -314,7 +314,7 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 	engInt, ok := srv.DetectionEngines.Load(detects[0].Engine)
 	if !ok {
 		logger.WithField("detectionEngine", detects[0].Engine).Error("unsupported engine")
-		return nil, fmt.Errorf("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine %s", detects[0].Engine)
 	}
 
 	engine := engInt.(server.DetectionEngine)
@@ -331,12 +331,12 @@ func (t *AddOverridesTool) Execute(ctx context.Context, srv *server.Server, para
 	errMap, err := engine.SyncLocalDetections(ctx, syncDetects)
 	if err != nil {
 		logger.WithError(err).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection: %w", err)
+		return nil, fmt.Errorf("unable to sync detections: %w", err)
 	}
 
 	if len(errMap) != 0 {
 		logger.WithField("errMap", errMap).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detections: %v", errMap)
 	}
 
 	syncDur := time.Since(syncStart)

--- a/server/modules/assistant/add_overrides_test.go
+++ b/server/modules/assistant/add_overrides_test.go
@@ -60,9 +60,8 @@ func TestAddOverridesTool_GetSchema(t *testing.T) {
 
 	// Check overrides property
 	overrides := schema.Json.Properties["overrides"]
-	assert.Equal(t, "string", overrides.Type)
+	assert.Equal(t, "array", overrides.Type)
 	assert.Contains(t, overrides.Description, "new overrides to add")
-	assert.Contains(t, overrides.Description, "string format")
 
 	// Check range properties
 	rangeStart := schema.Json.Properties["range_start"]
@@ -100,7 +99,7 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 	}{
 		{
 			name:   "successfully add suricata threshold override",
-			params: `{"search_filter": "so_detection.title:malware AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			params: `{"search_filter": "so_detection.title:malware AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"","seconds":60,"isEnabled":true,"count":10,"type":"threshold","track":"by_src","thresholdType":"both"}]}`,
 			mockQueryResults: []interface{}{
 				&model.Detection{
 					Auditable: model.Auditable{Id: "detection-1"},
@@ -144,7 +143,7 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "successfully add multiple suricata overrides",
-			params: `{"search_filter": "so_detection.engine:suricata AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"Threshold override\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"},{\"note\":\"Modify override\",\"regex\":\"rev:1;\",\"isEnabled\":true,\"type\":\"modify\",\"value\":\"rev:2;\"}]"}`,
+			params: `{"search_filter": "so_detection.engine:suricata AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"Threshold override","seconds":60,"isEnabled":true,"count":10,"type":"threshold","track":"by_src","thresholdType":"both"},{"note":"Modify override","regex":"rev:1;","isEnabled":true,"type":"modify","value":"rev:2;"}]}`,
 			mockQueryResults: []interface{}{
 				&model.Detection{
 					Auditable: model.Auditable{Id: "detection-1"},
@@ -175,7 +174,7 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "successfully add sigma custom filter override",
-			params: `{"search_filter": "so_detection.language:sigma AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"Custom filter\",\"isEnabled\":true,\"type\":\"customFilter\",\"customFilter\":\"sofilter:\\n  user.name: test_user\"}]"}`,
+			params: `{"search_filter": "so_detection.language:sigma AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"Custom filter","isEnabled":true,"type":"customFilter","customFilter":"sofilter:\n  user.name: test_user"}]}`,
 			mockQueryResults: []interface{}{
 				&model.Detection{
 					Auditable: model.Auditable{Id: "detection-1"},
@@ -206,7 +205,7 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:             "no detections found",
-			params:           `{"search_filter": "so_detection.title:nonexistent AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			params:           `{"search_filter": "so_detection.title:nonexistent AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"","seconds":60,"isEnabled":true,"count":10,"type":"threshold","track":"by_src","thresholdType":"both"}]}`,
 			mockQueryResults: []interface{}{},
 			expectedResult:   "No detections found",
 		},
@@ -222,13 +221,13 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:           "query error",
-			params:         `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			params:         `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"","seconds":60,"isEnabled":true,"count":10,"type":"threshold","track":"by_src","thresholdType":"both"}]}`,
 			mockQueryError: assert.AnError,
 			expectedError:  true,
 		},
 		{
 			name:   "bulk add overrides error",
-			params: `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			params: `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"","seconds":60,"isEnabled":true,"count":10,"type":"threshold","track":"by_src","thresholdType":"both"}]}`,
 			mockQueryResults: []interface{}{
 				&model.Detection{
 					Auditable: model.Auditable{Id: "detection-1"},
@@ -253,7 +252,7 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "sync error during detection sync",
-			params: `{"search_filter": "so_detection.title:sync AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			params: `{"search_filter": "so_detection.title:sync AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"","seconds":60,"isEnabled":true,"count":10,"type":"threshold","track":"by_src","thresholdType":"both"}]}`,
 			mockQueryResults: []interface{}{
 				&model.Detection{
 					Auditable: model.Auditable{Id: "detection-sync"},
@@ -284,7 +283,7 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "sync error map during detection sync",
-			params: `{"search_filter": "so_detection.title:sync AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			params: `{"search_filter": "so_detection.title:sync AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": [{"note":"","seconds":60,"isEnabled":true,"count":10,"type":"threshold","track":"by_src","thresholdType":"both"}]}`,
 			mockQueryResults: []interface{}{
 				&model.Detection{
 					Auditable: model.Auditable{Id: "detection-sync"},

--- a/server/modules/assistant/add_overrides_test.go
+++ b/server/modules/assistant/add_overrides_test.go
@@ -328,14 +328,28 @@ func TestAddOverridesTool_Execute(t *testing.T) {
 			if tc.mockQueryResults != nil || tc.mockQueryError != nil {
 				mockDetectionstore.EXPECT().
 					QueryWithRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]interface{}, error) {
+					DoAndReturn(func(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) (*model.EventSearchResults, error) {
 						// Verify query contains metadata filter
 						assert.Contains(t, query, "NOT metadata.raw_index:")
 						if tc.mockQueryError != nil {
 							return nil, tc.mockQueryError
 						}
-						return tc.mockQueryResults, nil
+						return &model.EventSearchResults{Events: []*model.EventRecord{}}, nil
 					})
+
+				// Setup ConvertEventsToDetections expectations
+				if tc.mockQueryError == nil {
+					mockDetectionstore.EXPECT().
+						ConvertEventsToDetections(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(ctx context.Context, detectEvents *model.EventSearchResults) ([]*model.Detection, error) {
+							// Convert []interface{} to []*model.Detection
+							detections := make([]*model.Detection, len(tc.mockQueryResults))
+							for i, obj := range tc.mockQueryResults {
+								detections[i] = obj.(*model.Detection)
+							}
+							return detections, nil
+						})
+				}
 			}
 
 			if tc.mockBulkAddStats != nil || tc.mockBulkAddError != nil {

--- a/server/modules/assistant/add_overrides_test.go
+++ b/server/modules/assistant/add_overrides_test.go
@@ -1,0 +1,422 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/mock"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestAddOverridesTool_GetName(t *testing.T) {
+	tool := &AddOverridesTool{}
+	assert.Equal(t, "add_overrides", tool.GetName())
+}
+
+func TestAddOverridesTool_GetDescription(t *testing.T) {
+	tool := &AddOverridesTool{}
+	description := tool.GetDescription()
+	assert.Contains(t, description, "Add one or more new overrides to existing detection(s)")
+	assert.Contains(t, description, "_index:\"*:so-detection\" AND so_kind:detection")
+	assert.Contains(t, description, "999 days ago")
+	assert.Contains(t, description, "Suricata:")
+	assert.Contains(t, description, "Sigma:")
+	assert.Contains(t, description, "YARA does not have overrides")
+}
+
+func TestAddOverridesTool_GetSchema(t *testing.T) {
+	tool := &AddOverridesTool{}
+	schema := tool.GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+	assert.Contains(t, schema.Json.Required, "search_filter")
+
+	// Check that all expected properties are present
+	expectedProperties := []string{"search_filter", "overrides", "range_start", "range_end", "range_format", "limit"}
+	for _, prop := range expectedProperties {
+		assert.Contains(t, schema.Json.Properties, prop)
+	}
+
+	// Check search_filter property
+	searchFilter := schema.Json.Properties["search_filter"]
+	assert.Equal(t, "string", searchFilter.Type)
+	assert.Contains(t, searchFilter.Description, "so_detection.id")
+	assert.Contains(t, searchFilter.Description, "so_detection.title")
+	assert.Contains(t, searchFilter.Description, "so_detection.severity")
+	assert.Contains(t, searchFilter.Description, "so_detection.isEnabled")
+
+	// Check overrides property
+	overrides := schema.Json.Properties["overrides"]
+	assert.Equal(t, "string", overrides.Type)
+	assert.Contains(t, overrides.Description, "new overrides to add")
+	assert.Contains(t, overrides.Description, "string format")
+
+	// Check range properties
+	rangeStart := schema.Json.Properties["range_start"]
+	assert.Equal(t, "string", rangeStart.Type)
+	assert.Contains(t, rangeStart.Description, "start time")
+
+	rangeEnd := schema.Json.Properties["range_end"]
+	assert.Equal(t, "string", rangeEnd.Type)
+	assert.Contains(t, rangeEnd.Description, "end time")
+
+	rangeFormat := schema.Json.Properties["range_format"]
+	assert.Equal(t, "string", rangeFormat.Type)
+	assert.Contains(t, rangeFormat.Description, "format")
+
+	// Check limit property
+	limit := schema.Json.Properties["limit"]
+	assert.Equal(t, "integer", limit.Type)
+	assert.Contains(t, limit.Description, "maximum number")
+}
+
+func TestAddOverridesTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		params                  string
+		mockQueryResults        []interface{}
+		mockQueryError          error
+		mockBulkAddStats        *model.BulkUpdateStats
+		mockBulkAddError        error
+		mockSyncError           error
+		mockSyncErrorMap        map[string]string
+		expectedResult          string
+		expectedError           bool
+		expectedOverridesCount  int
+		expectedDetectionsCount int
+	}{
+		{
+			name:   "successfully add suricata threshold override",
+			params: `{"search_filter": "so_detection.title:malware AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-1"},
+					PublicID:  "PUB001",
+					Title:     "Malware Detection 1",
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+					Overrides: []*model.Override{},
+				},
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-2"},
+					PublicID:  "PUB002",
+					Title:     "Malware Detection 2",
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+					Overrides: []*model.Override{},
+				},
+			},
+			mockBulkAddStats: &model.BulkUpdateStats{
+				Updated:        2,
+				Audited:        2,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 100 * time.Millisecond,
+				NeedToSync: []*model.Detection{
+					{
+						Auditable: model.Auditable{Id: "detection-1"},
+						PublicID:  "PUB001",
+						Engine:    model.EngineNameSuricata,
+					},
+					{
+						Auditable: model.Auditable{Id: "detection-2"},
+						PublicID:  "PUB002",
+						Engine:    model.EngineNameSuricata,
+					},
+				},
+			},
+			expectedResult:          "Successfully added 1 override to 2 detections. Updated=2, Audited=2, Errors=map[], UpdateDuration=100ms, SyncDuration=",
+			expectedOverridesCount:  1,
+			expectedDetectionsCount: 2,
+		},
+		{
+			name:   "successfully add multiple suricata overrides",
+			params: `{"search_filter": "so_detection.engine:suricata AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"Threshold override\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"},{\"note\":\"Modify override\",\"regex\":\"rev:1;\",\"isEnabled\":true,\"type\":\"modify\",\"value\":\"rev:2;\"}]"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-1"},
+					PublicID:  "PUB001",
+					Title:     "Suricata Detection",
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+					Overrides: []*model.Override{},
+				},
+			},
+			mockBulkAddStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 75 * time.Millisecond,
+				NeedToSync: []*model.Detection{
+					{
+						Auditable: model.Auditable{Id: "detection-1"},
+						PublicID:  "PUB001",
+						Engine:    model.EngineNameSuricata,
+					},
+				},
+			},
+			expectedResult:          "Successfully added 2 overrides to 1 detections. Updated=1, Audited=1, Errors=map[], UpdateDuration=75ms, SyncDuration=",
+			expectedOverridesCount:  2,
+			expectedDetectionsCount: 1,
+		},
+		{
+			name:   "successfully add sigma custom filter override",
+			params: `{"search_filter": "so_detection.language:sigma AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"Custom filter\",\"isEnabled\":true,\"type\":\"customFilter\",\"customFilter\":\"sofilter:\\n  user.name: test_user\"}]"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-1"},
+					PublicID:  "PUB001",
+					Title:     "Sigma Detection",
+					Engine:    model.EngineNameElastAlert,
+					Language:  model.SigLangSigma,
+					Overrides: []*model.Override{},
+				},
+			},
+			mockBulkAddStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 50 * time.Millisecond,
+				NeedToSync: []*model.Detection{
+					{
+						Auditable: model.Auditable{Id: "detection-1"},
+						PublicID:  "PUB001",
+						Engine:    model.EngineNameElastAlert,
+					},
+				},
+			},
+			expectedResult:          "Successfully added 1 override to 1 detections. Updated=1, Audited=1, Errors=map[], UpdateDuration=50ms, SyncDuration=",
+			expectedOverridesCount:  1,
+			expectedDetectionsCount: 1,
+		},
+		{
+			name:             "no detections found",
+			params:           `{"search_filter": "so_detection.title:nonexistent AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			mockQueryResults: []interface{}{},
+			expectedResult:   "No detections found",
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"search_filter": "invalid json}`,
+			expectedError: true,
+		},
+		{
+			name:          "invalid overrides JSON",
+			params:        `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "invalid json"}`,
+			expectedError: true,
+		},
+		{
+			name:           "query error",
+			params:         `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			mockQueryError: assert.AnError,
+			expectedError:  true,
+		},
+		{
+			name:   "bulk add overrides error",
+			params: `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-1"},
+					PublicID:  "PUB001",
+					Title:     "Test Detection",
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+				},
+			},
+			mockBulkAddStats: &model.BulkUpdateStats{
+				Updated:        0,
+				Audited:        0,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 25 * time.Millisecond,
+				NeedToSync:     []*model.Detection{},
+			},
+			mockBulkAddError:        assert.AnError,
+			expectedError:           true,
+			expectedOverridesCount:  1,
+			expectedDetectionsCount: 1,
+		},
+		{
+			name:   "sync error during detection sync",
+			params: `{"search_filter": "so_detection.title:sync AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-sync"},
+					PublicID:  "PUB-SYNC",
+					Title:     "Sync Detection",
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+				},
+			},
+			mockBulkAddStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 30 * time.Millisecond,
+				NeedToSync: []*model.Detection{
+					{
+						Auditable: model.Auditable{Id: "detection-sync"},
+						PublicID:  "PUB-SYNC",
+						Engine:    model.EngineNameSuricata,
+					},
+				},
+			},
+			mockSyncError:           assert.AnError,
+			expectedError:           true,
+			expectedOverridesCount:  1,
+			expectedDetectionsCount: 1,
+		},
+		{
+			name:   "sync error map during detection sync",
+			params: `{"search_filter": "so_detection.title:sync AND _index:\"*:so-detection\" AND so_kind:detection", "overrides": "[{\"note\":\"\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\"}]"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-sync"},
+					PublicID:  "PUB-SYNC",
+					Title:     "Sync Detection",
+					Engine:    model.EngineNameSuricata,
+					Language:  model.SigLangSuricata,
+				},
+			},
+			mockBulkAddStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 30 * time.Millisecond,
+				NeedToSync: []*model.Detection{
+					{
+						Auditable: model.Auditable{Id: "detection-sync"},
+						PublicID:  "PUB-SYNC",
+						Engine:    model.EngineNameSuricata,
+					},
+				},
+			},
+			mockSyncErrorMap: map[string]string{
+				"PUB-SYNC": "sync failed",
+			},
+			expectedError:           true,
+			expectedOverridesCount:  1,
+			expectedDetectionsCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+			mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+			// Set up mock expectations
+			if tc.mockQueryResults != nil || tc.mockQueryError != nil {
+				mockDetectionstore.EXPECT().
+					QueryWithRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]interface{}, error) {
+						// Verify query contains metadata filter
+						assert.Contains(t, query, "NOT metadata.raw_index:")
+						if tc.mockQueryError != nil {
+							return nil, tc.mockQueryError
+						}
+						return tc.mockQueryResults, nil
+					})
+			}
+
+			if tc.mockBulkAddStats != nil || tc.mockBulkAddError != nil {
+				mockDetectionstore.EXPECT().
+					BulkAddOverrides(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, newOverrides []*model.Override, detects []*model.Detection, logger interface{}) (*model.BulkUpdateStats, error) {
+						if tc.expectedOverridesCount > 0 {
+							assert.Len(t, newOverrides, tc.expectedOverridesCount)
+						}
+						if tc.expectedDetectionsCount > 0 {
+							assert.Len(t, detects, tc.expectedDetectionsCount)
+						}
+						if tc.mockBulkAddError != nil {
+							return nil, tc.mockBulkAddError
+						}
+						return tc.mockBulkAddStats, nil
+					})
+			}
+
+			// Set up sync expectations
+			if tc.mockBulkAddStats != nil && len(tc.mockBulkAddStats.NeedToSync) > 0 {
+				if tc.mockSyncError != nil {
+					mockDetectionEngine.EXPECT().
+						SyncLocalDetections(gomock.Any(), gomock.Any()).
+						Return(nil, tc.mockSyncError)
+				} else if tc.mockSyncErrorMap != nil {
+					mockDetectionEngine.EXPECT().
+						SyncLocalDetections(gomock.Any(), gomock.Any()).
+						Return(tc.mockSyncErrorMap, nil)
+				} else {
+					mockDetectionEngine.EXPECT().
+						SyncLocalDetections(gomock.Any(), gomock.Any()).
+						Return(map[string]string{}, nil)
+				}
+			}
+
+			// Create mock server with proper authorization
+			mockServer := server.NewFakeAuthorizedServer(map[string][]string{
+				"test-user-id": {"detections/write"},
+			})
+			mockServer.Detectionstore = mockDetectionstore
+
+			// Add DetectionEngines with mock engine
+			// The engine must be loaded for any test that returns detections from the query
+			mockServer.DetectionEngines = sync.Map{}
+			if len(tc.mockQueryResults) > 0 {
+				mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockDetectionEngine)
+				mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
+			}
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create tool and execute
+			tool := &AddOverridesTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "add_overrides", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+			assert.True(t, result.TimeToExecute > 0)
+
+			// Assert result content - check if result contains expected parts since sync duration varies
+			if tc.expectedResult != "" {
+				resultStr := result.Result.(string)
+				if strings.Contains(tc.expectedResult, "SyncDuration=") {
+					// For results with sync duration, check that it starts correctly and contains expected parts
+					assert.True(t, strings.HasPrefix(resultStr, strings.Split(tc.expectedResult, "SyncDuration=")[0]))
+					assert.Contains(t, resultStr, "SyncDuration=")
+				} else {
+					assert.Equal(t, tc.expectedResult, resultStr)
+				}
+			}
+		})
+	}
+}

--- a/server/modules/assistant/common.go
+++ b/server/modules/assistant/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/util"
 )
 
@@ -36,4 +37,65 @@ func parseRangeAllowRelative(rangeStart string, rangeEnd string, format string) 
 	}
 
 	return fmt.Sprintf("%s - %s", startFormatted, endFormatted)
+}
+
+func populateOverridesFromMaps(inputMaps []map[string]any, includeTimes bool) []*model.Override {
+
+	var populatedOverrides []*model.Override
+
+	for _, overrideMap := range inputMaps {
+		override := &model.Override{}
+
+		if v, ok := overrideMap["type"].(string); ok {
+			override.Type = model.OverrideType(v)
+		}
+		if v, ok := overrideMap["isEnabled"].(bool); ok {
+			override.IsEnabled = v
+		}
+		if v, ok := overrideMap["note"].(string); ok {
+			override.Note = v
+		}
+		if includeTimes {
+			if v, ok := overrideMap["createdAt"].(string); ok {
+				if t, err := time.Parse(time.RFC3339, v); err == nil {
+					override.CreatedAt = t
+				}
+			}
+
+			if v, ok := overrideMap["updatedAt"].(string); ok {
+				if t, err := time.Parse(time.RFC3339, v); err == nil {
+					override.UpdatedAt = t
+				}
+			}
+		}
+		if v, ok := overrideMap["regex"].(string); ok {
+			override.Regex = &v
+		}
+		if v, ok := overrideMap["value"].(string); ok {
+			override.Value = &v
+		}
+		if v, ok := overrideMap["track"].(string); ok {
+			override.Track = &v
+		}
+		if v, ok := overrideMap["ip"].(string); ok {
+			override.IP = &v
+		}
+		if v, ok := overrideMap["thresholdType"].(string); ok {
+			override.ThresholdType = &v
+		}
+		if v, ok := overrideMap["count"].(float64); ok {
+			count := int(v)
+			override.Count = &count
+		}
+		if v, ok := overrideMap["seconds"].(float64); ok {
+			seconds := int(v)
+			override.Seconds = &seconds
+		}
+		if v, ok := overrideMap["customFilter"].(string); ok {
+			override.CustomFilter = &v
+		}
+		populatedOverrides = append(populatedOverrides, override)
+	}
+
+	return populatedOverrides
 }

--- a/server/modules/assistant/common_test.go
+++ b/server/modules/assistant/common_test.go
@@ -10,6 +10,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -258,4 +259,382 @@ func splitRange(rangeStr string) []string {
 		}
 	}
 	return parts
+}
+
+func TestPopulateOverridesFromMaps(t *testing.T) {
+	testCases := []struct {
+		name         string
+		inputMaps    []map[string]any
+		includeTimes bool
+		expected     []*model.Override
+	}{
+		{
+			name:         "empty input",
+			inputMaps:    []map[string]any{},
+			includeTimes: false,
+			expected:     []*model.Override{},
+		},
+		{
+			name: "single suppress override without times",
+			inputMaps: []map[string]any{
+				{
+					"type":      "suppress",
+					"isEnabled": true,
+					"note":      "Test suppress note",
+					"ip":        "192.168.1.0/24",
+					"track":     "by_src",
+				},
+			},
+			includeTimes: false,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeSuppress,
+					IsEnabled: true,
+					Note:      "Test suppress note",
+					OverrideParameters: model.OverrideParameters{
+						IP:    stringPtr("192.168.1.0/24"),
+						Track: stringPtr("by_src"),
+					},
+				},
+			},
+		},
+		{
+			name: "single threshold override with times",
+			inputMaps: []map[string]any{
+				{
+					"type":          "threshold",
+					"isEnabled":     true,
+					"note":          "Test threshold note",
+					"thresholdType": "limit",
+					"track":         "by_dst",
+					"count":         float64(10),
+					"seconds":       float64(60),
+					"createdAt":     "2024-01-15T10:00:00Z",
+					"updatedAt":     "2024-01-15T11:00:00Z",
+				},
+			},
+			includeTimes: true,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeThreshold,
+					IsEnabled: true,
+					Note:      "Test threshold note",
+					CreatedAt: mustParseTime("2024-01-15T10:00:00Z"),
+					UpdatedAt: mustParseTime("2024-01-15T11:00:00Z"),
+					OverrideParameters: model.OverrideParameters{
+						ThresholdType: stringPtr("limit"),
+						Track:         stringPtr("by_dst"),
+						Count:         intPtr(10),
+						Seconds:       intPtr(60),
+					},
+				},
+			},
+		},
+		{
+			name: "modify override",
+			inputMaps: []map[string]any{
+				{
+					"type":      "modify",
+					"isEnabled": false,
+					"note":      "Test modify note",
+					"regex":     "content:xyz",
+					"value":     "content:abc",
+				},
+			},
+			includeTimes: false,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeModify,
+					IsEnabled: false,
+					Note:      "Test modify note",
+					OverrideParameters: model.OverrideParameters{
+						Regex: stringPtr("content:xyz"),
+						Value: stringPtr("content:abc"),
+					},
+				},
+			},
+		},
+		{
+			name: "customFilter override",
+			inputMaps: []map[string]any{
+				{
+					"type":         "customFilter",
+					"isEnabled":    true,
+					"note":         "Test custom filter note",
+					"customFilter": "sofilter:\n  user.name: test",
+				},
+			},
+			includeTimes: false,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeCustomFilter,
+					IsEnabled: true,
+					Note:      "Test custom filter note",
+					OverrideParameters: model.OverrideParameters{
+						CustomFilter: stringPtr("sofilter:\n  user.name: test"),
+					},
+				},
+			},
+		},
+		{
+			name: "multiple overrides with mixed types",
+			inputMaps: []map[string]any{
+				{
+					"type":      "suppress",
+					"isEnabled": true,
+					"note":      "First override",
+					"ip":        "10.0.0.0/8",
+					"track":     "by_either",
+				},
+				{
+					"type":          "threshold",
+					"isEnabled":     false,
+					"note":          "Second override",
+					"thresholdType": "both",
+					"track":         "by_src",
+					"count":         float64(5),
+					"seconds":       float64(120),
+				},
+				{
+					"type":      "modify",
+					"isEnabled": true,
+					"note":      "Third override",
+					"regex":     "pattern",
+					"value":     "replacement",
+				},
+			},
+			includeTimes: false,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeSuppress,
+					IsEnabled: true,
+					Note:      "First override",
+					OverrideParameters: model.OverrideParameters{
+						IP:    stringPtr("10.0.0.0/8"),
+						Track: stringPtr("by_either"),
+					},
+				},
+				{
+					Type:      model.OverrideTypeThreshold,
+					IsEnabled: false,
+					Note:      "Second override",
+					OverrideParameters: model.OverrideParameters{
+						ThresholdType: stringPtr("both"),
+						Track:         stringPtr("by_src"),
+						Count:         intPtr(5),
+						Seconds:       intPtr(120),
+					},
+				},
+				{
+					Type:      model.OverrideTypeModify,
+					IsEnabled: true,
+					Note:      "Third override",
+					OverrideParameters: model.OverrideParameters{
+						Regex: stringPtr("pattern"),
+						Value: stringPtr("replacement"),
+					},
+				},
+			},
+		},
+		{
+			name: "override with times excluded when includeTimes is false",
+			inputMaps: []map[string]any{
+				{
+					"type":      "suppress",
+					"isEnabled": true,
+					"note":      "Test note",
+					"ip":        "172.16.0.0/12",
+					"track":     "by_dst",
+					"createdAt": "2024-01-15T10:00:00Z",
+					"updatedAt": "2024-01-15T11:00:00Z",
+				},
+			},
+			includeTimes: false,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeSuppress,
+					IsEnabled: true,
+					Note:      "Test note",
+					OverrideParameters: model.OverrideParameters{
+						IP:    stringPtr("172.16.0.0/12"),
+						Track: stringPtr("by_dst"),
+					},
+				},
+			},
+		},
+		{
+			name: "override with invalid time format (should be skipped)",
+			inputMaps: []map[string]any{
+				{
+					"type":      "suppress",
+					"isEnabled": true,
+					"note":      "Test note",
+					"ip":        "192.168.0.0/16",
+					"track":     "by_src",
+					"createdAt": "invalid-time-format",
+					"updatedAt": "2024-01-15T11:00:00Z",
+				},
+			},
+			includeTimes: true,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeSuppress,
+					IsEnabled: true,
+					Note:      "Test note",
+					UpdatedAt: mustParseTime("2024-01-15T11:00:00Z"),
+					OverrideParameters: model.OverrideParameters{
+						IP:    stringPtr("192.168.0.0/16"),
+						Track: stringPtr("by_src"),
+					},
+				},
+			},
+		},
+		{
+			name: "override with missing optional fields",
+			inputMaps: []map[string]any{
+				{
+					"type":      "suppress",
+					"isEnabled": true,
+					// note is missing
+					"ip":    "10.10.10.0/24",
+					"track": "by_src",
+				},
+			},
+			includeTimes: false,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeSuppress,
+					IsEnabled: true,
+					Note:      "",
+					OverrideParameters: model.OverrideParameters{
+						IP:    stringPtr("10.10.10.0/24"),
+						Track: stringPtr("by_src"),
+					},
+				},
+			},
+		},
+		{
+			name: "override with all pointer fields",
+			inputMaps: []map[string]any{
+				{
+					"type":          "threshold",
+					"isEnabled":     true,
+					"note":          "Complete override",
+					"thresholdType": "threshold",
+					"track":         "by_dst",
+					"count":         float64(100),
+					"seconds":       float64(300),
+					"regex":         "should_be_ignored_for_threshold",
+					"value":         "should_be_ignored_for_threshold",
+					"ip":            "should_be_ignored_for_threshold",
+					"customFilter":  "should_be_ignored_for_threshold",
+				},
+			},
+			includeTimes: false,
+			expected: []*model.Override{
+				{
+					Type:      model.OverrideTypeThreshold,
+					IsEnabled: true,
+					Note:      "Complete override",
+					OverrideParameters: model.OverrideParameters{
+						ThresholdType: stringPtr("threshold"),
+						Track:         stringPtr("by_dst"),
+						Count:         intPtr(100),
+						Seconds:       intPtr(300),
+						Regex:         stringPtr("should_be_ignored_for_threshold"),
+						Value:         stringPtr("should_be_ignored_for_threshold"),
+						IP:            stringPtr("should_be_ignored_for_threshold"),
+						CustomFilter:  stringPtr("should_be_ignored_for_threshold"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := populateOverridesFromMaps(tc.inputMaps, tc.includeTimes)
+
+			assert.Equal(t, len(tc.expected), len(result), "Number of overrides should match")
+
+			for i, expectedOverride := range tc.expected {
+				if i >= len(result) {
+					t.Fatalf("Expected override at index %d but result is too short", i)
+				}
+
+				actualOverride := result[i]
+
+				assert.Equal(t, expectedOverride.Type, actualOverride.Type, "Override type should match")
+				assert.Equal(t, expectedOverride.IsEnabled, actualOverride.IsEnabled, "IsEnabled should match")
+				assert.Equal(t, expectedOverride.Note, actualOverride.Note, "Note should match")
+
+				// Check times if includeTimes was true
+				if tc.includeTimes {
+					if !expectedOverride.CreatedAt.IsZero() {
+						assert.Equal(t, expectedOverride.CreatedAt, actualOverride.CreatedAt, "CreatedAt should match")
+					}
+					if !expectedOverride.UpdatedAt.IsZero() {
+						assert.Equal(t, expectedOverride.UpdatedAt, actualOverride.UpdatedAt, "UpdatedAt should match")
+					}
+				} else {
+					// When includeTimes is false, times should be zero
+					assert.True(t, actualOverride.CreatedAt.IsZero(), "CreatedAt should be zero when includeTimes is false")
+					assert.True(t, actualOverride.UpdatedAt.IsZero(), "UpdatedAt should be zero when includeTimes is false")
+				}
+
+				// Check pointer fields
+				assertStringPtrEqual(t, expectedOverride.Regex, actualOverride.Regex, "Regex")
+				assertStringPtrEqual(t, expectedOverride.Value, actualOverride.Value, "Value")
+				assertStringPtrEqual(t, expectedOverride.Track, actualOverride.Track, "Track")
+				assertStringPtrEqual(t, expectedOverride.IP, actualOverride.IP, "IP")
+				assertStringPtrEqual(t, expectedOverride.ThresholdType, actualOverride.ThresholdType, "ThresholdType")
+				assertIntPtrEqual(t, expectedOverride.Count, actualOverride.Count, "Count")
+				assertIntPtrEqual(t, expectedOverride.Seconds, actualOverride.Seconds, "Seconds")
+				assertStringPtrEqual(t, expectedOverride.CustomFilter, actualOverride.CustomFilter, "CustomFilter")
+			}
+		})
+	}
+}
+
+// Helper functions for tests
+func intPtr(i int) *int {
+	return &i
+}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func assertStringPtrEqual(t *testing.T, expected, actual *string, fieldName string) {
+	if expected == nil && actual == nil {
+		return
+	}
+	if expected == nil {
+		assert.Nil(t, actual, "%s should be nil", fieldName)
+		return
+	}
+	if actual == nil {
+		t.Errorf("%s should not be nil, expected: %s", fieldName, *expected)
+		return
+	}
+	assert.Equal(t, *expected, *actual, "%s should match", fieldName)
+}
+
+func assertIntPtrEqual(t *testing.T, expected, actual *int, fieldName string) {
+	if expected == nil && actual == nil {
+		return
+	}
+	if expected == nil {
+		assert.Nil(t, actual, "%s should be nil", fieldName)
+		return
+	}
+	if actual == nil {
+		t.Errorf("%s should not be nil, expected: %d", fieldName, *expected)
+		return
+	}
+	assert.Equal(t, *expected, *actual, "%s should match", fieldName)
 }

--- a/server/modules/assistant/common_test.go
+++ b/server/modules/assistant/common_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -292,8 +293,8 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: true,
 					Note:      "Test suppress note",
 					OverrideParameters: model.OverrideParameters{
-						IP:    stringPtr("192.168.1.0/24"),
-						Track: stringPtr("by_src"),
+						IP:    util.Ptr("192.168.1.0/24"),
+						Track: util.Ptr("by_src"),
 					},
 				},
 			},
@@ -322,10 +323,10 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					CreatedAt: mustParseTime("2024-01-15T10:00:00Z"),
 					UpdatedAt: mustParseTime("2024-01-15T11:00:00Z"),
 					OverrideParameters: model.OverrideParameters{
-						ThresholdType: stringPtr("limit"),
-						Track:         stringPtr("by_dst"),
-						Count:         intPtr(10),
-						Seconds:       intPtr(60),
+						ThresholdType: util.Ptr("limit"),
+						Track:         util.Ptr("by_dst"),
+						Count:         util.Ptr(10),
+						Seconds:       util.Ptr(60),
 					},
 				},
 			},
@@ -348,8 +349,8 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: false,
 					Note:      "Test modify note",
 					OverrideParameters: model.OverrideParameters{
-						Regex: stringPtr("content:xyz"),
-						Value: stringPtr("content:abc"),
+						Regex: util.Ptr("content:xyz"),
+						Value: util.Ptr("content:abc"),
 					},
 				},
 			},
@@ -371,7 +372,7 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: true,
 					Note:      "Test custom filter note",
 					OverrideParameters: model.OverrideParameters{
-						CustomFilter: stringPtr("sofilter:\n  user.name: test"),
+						CustomFilter: util.Ptr("sofilter:\n  user.name: test"),
 					},
 				},
 			},
@@ -410,8 +411,8 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: true,
 					Note:      "First override",
 					OverrideParameters: model.OverrideParameters{
-						IP:    stringPtr("10.0.0.0/8"),
-						Track: stringPtr("by_either"),
+						IP:    util.Ptr("10.0.0.0/8"),
+						Track: util.Ptr("by_either"),
 					},
 				},
 				{
@@ -419,10 +420,10 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: false,
 					Note:      "Second override",
 					OverrideParameters: model.OverrideParameters{
-						ThresholdType: stringPtr("both"),
-						Track:         stringPtr("by_src"),
-						Count:         intPtr(5),
-						Seconds:       intPtr(120),
+						ThresholdType: util.Ptr("both"),
+						Track:         util.Ptr("by_src"),
+						Count:         util.Ptr(5),
+						Seconds:       util.Ptr(120),
 					},
 				},
 				{
@@ -430,8 +431,8 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: true,
 					Note:      "Third override",
 					OverrideParameters: model.OverrideParameters{
-						Regex: stringPtr("pattern"),
-						Value: stringPtr("replacement"),
+						Regex: util.Ptr("pattern"),
+						Value: util.Ptr("replacement"),
 					},
 				},
 			},
@@ -456,8 +457,8 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: true,
 					Note:      "Test note",
 					OverrideParameters: model.OverrideParameters{
-						IP:    stringPtr("172.16.0.0/12"),
-						Track: stringPtr("by_dst"),
+						IP:    util.Ptr("172.16.0.0/12"),
+						Track: util.Ptr("by_dst"),
 					},
 				},
 			},
@@ -483,8 +484,8 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					Note:      "Test note",
 					UpdatedAt: mustParseTime("2024-01-15T11:00:00Z"),
 					OverrideParameters: model.OverrideParameters{
-						IP:    stringPtr("192.168.0.0/16"),
-						Track: stringPtr("by_src"),
+						IP:    util.Ptr("192.168.0.0/16"),
+						Track: util.Ptr("by_src"),
 					},
 				},
 			},
@@ -507,8 +508,8 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: true,
 					Note:      "",
 					OverrideParameters: model.OverrideParameters{
-						IP:    stringPtr("10.10.10.0/24"),
-						Track: stringPtr("by_src"),
+						IP:    util.Ptr("10.10.10.0/24"),
+						Track: util.Ptr("by_src"),
 					},
 				},
 			},
@@ -537,14 +538,14 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					IsEnabled: true,
 					Note:      "Complete override",
 					OverrideParameters: model.OverrideParameters{
-						ThresholdType: stringPtr("threshold"),
-						Track:         stringPtr("by_dst"),
-						Count:         intPtr(100),
-						Seconds:       intPtr(300),
-						Regex:         stringPtr("should_be_ignored_for_threshold"),
-						Value:         stringPtr("should_be_ignored_for_threshold"),
-						IP:            stringPtr("should_be_ignored_for_threshold"),
-						CustomFilter:  stringPtr("should_be_ignored_for_threshold"),
+						ThresholdType: util.Ptr("threshold"),
+						Track:         util.Ptr("by_dst"),
+						Count:         util.Ptr(100),
+						Seconds:       util.Ptr(300),
+						Regex:         util.Ptr("should_be_ignored_for_threshold"),
+						Value:         util.Ptr("should_be_ignored_for_threshold"),
+						IP:            util.Ptr("should_be_ignored_for_threshold"),
+						CustomFilter:  util.Ptr("should_be_ignored_for_threshold"),
 					},
 				},
 			},
@@ -582,59 +583,25 @@ func TestPopulateOverridesFromMaps(t *testing.T) {
 					assert.True(t, actualOverride.UpdatedAt.IsZero(), "UpdatedAt should be zero when includeTimes is false")
 				}
 
-				// Check pointer fields
-				assertStringPtrEqual(t, expectedOverride.Regex, actualOverride.Regex, "Regex")
-				assertStringPtrEqual(t, expectedOverride.Value, actualOverride.Value, "Value")
-				assertStringPtrEqual(t, expectedOverride.Track, actualOverride.Track, "Track")
-				assertStringPtrEqual(t, expectedOverride.IP, actualOverride.IP, "IP")
-				assertStringPtrEqual(t, expectedOverride.ThresholdType, actualOverride.ThresholdType, "ThresholdType")
-				assertIntPtrEqual(t, expectedOverride.Count, actualOverride.Count, "Count")
-				assertIntPtrEqual(t, expectedOverride.Seconds, actualOverride.Seconds, "Seconds")
-				assertStringPtrEqual(t, expectedOverride.CustomFilter, actualOverride.CustomFilter, "CustomFilter")
+				// Check pointer fields using util.Equal
+				assert.True(t, util.Equal(expectedOverride.Regex, actualOverride.Regex), "Regex should match")
+				assert.True(t, util.Equal(expectedOverride.Value, actualOverride.Value), "Value should match")
+				assert.True(t, util.Equal(expectedOverride.Track, actualOverride.Track), "Track should match")
+				assert.True(t, util.Equal(expectedOverride.IP, actualOverride.IP), "IP should match")
+				assert.True(t, util.Equal(expectedOverride.ThresholdType, actualOverride.ThresholdType), "ThresholdType should match")
+				assert.True(t, util.Equal(expectedOverride.Count, actualOverride.Count), "Count should match")
+				assert.True(t, util.Equal(expectedOverride.Seconds, actualOverride.Seconds), "Seconds should match")
+				assert.True(t, util.Equal(expectedOverride.CustomFilter, actualOverride.CustomFilter), "CustomFilter should match")
 			}
 		})
 	}
 }
 
-// Helper functions for tests
-func intPtr(i int) *int {
-	return &i
-}
-
+// Helper function for tests
 func mustParseTime(s string) time.Time {
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
 		panic(err)
 	}
 	return t
-}
-
-func assertStringPtrEqual(t *testing.T, expected, actual *string, fieldName string) {
-	if expected == nil && actual == nil {
-		return
-	}
-	if expected == nil {
-		assert.Nil(t, actual, "%s should be nil", fieldName)
-		return
-	}
-	if actual == nil {
-		t.Errorf("%s should not be nil, expected: %s", fieldName, *expected)
-		return
-	}
-	assert.Equal(t, *expected, *actual, "%s should match", fieldName)
-}
-
-func assertIntPtrEqual(t *testing.T, expected, actual *int, fieldName string) {
-	if expected == nil && actual == nil {
-		return
-	}
-	if expected == nil {
-		assert.Nil(t, actual, "%s should be nil", fieldName)
-		return
-	}
-	if actual == nil {
-		t.Errorf("%s should not be nil, expected: %d", fieldName, *expected)
-		return
-	}
-	assert.Equal(t, *expected, *actual, "%s should match", fieldName)
 }

--- a/server/modules/assistant/create_detection.go
+++ b/server/modules/assistant/create_detection.go
@@ -149,7 +149,7 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 	_, err = engine.ApplyFilters(detect)
 	if err != nil {
 		logger.WithError(err).Error("unable to apply filters for detection")
-		return nil, fmt.Errorf("unable to appy filters for detection: %w", err)
+		return nil, fmt.Errorf("unable to apply filters for detection: %w", err)
 	}
 
 	detect, err = srv.Detectionstore.CreateDetection(ctx, detect)

--- a/server/modules/assistant/create_detection.go
+++ b/server/modules/assistant/create_detection.go
@@ -53,7 +53,6 @@ func (t *CreateDetectionTool) GetSchema() model.JSONSchema {
 					Description: `The underlying detection rule source content. (e.g., "title: CobaltStrike Named Pipe\nid: ...\n logsource:\n ...\ncondition: selection\nfalsepositives:\n...")`,
 				},
 			},
-			Required: []string{"search_filter"},
 		},
 	}
 }
@@ -71,7 +70,7 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 
 	err = srv.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("user is not authorized to write detections: %w", err)
 	}
 
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
@@ -91,7 +90,7 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 
 	err = json.Unmarshal([]byte(params), args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't unmarshal params: %w", err)
 	}
 
 	result.Parameters = args
@@ -125,7 +124,7 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 	engInt, ok := srv.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		logger.WithField("detectionEngine", detect.Engine).Error("unsupported engine")
-		return nil, fmt.Errorf("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine %s", detect.Engine)
 	}
 
 	engine := engInt.(server.DetectionEngine)
@@ -133,7 +132,7 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 	_, err = engine.ValidateRule(detect.Content)
 	if err != nil {
 		logger.WithError(err).WithField("detectionContent", detect.Content).Error("invalid rule")
-		return nil, fmt.Errorf("invalid rule: %w", err)
+		return nil, fmt.Errorf("invalid rule (%s): %w", detect.Content, err)
 	}
 
 	err = engine.ExtractDetails(detect)
@@ -142,36 +141,40 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 			"detectionEngine":   detect.Engine,
 			"detectionPublicId": detect.PublicID,
 		}).Error("unable to extract details from detection")
-		return nil, fmt.Errorf("unable to extract details for detection: %w", err)
+		return nil, fmt.Errorf("unable to extract details for detection with Public ID %s and engine %s: %w", detect.PublicID, detect.Engine, err)
 	}
 
 	user, err := srv.Userstore.GetUserById(ctx, userId)
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve user: %w", err)
+		return nil, fmt.Errorf("unable to retrieve user with ID %s: %w", userId, err)
 	}
 	detect.Author = detections.MakeUser(user)
 
 	_, err = engine.ApplyFilters(detect)
 	if err != nil {
-		logger.WithError(err).Error("unable to apply filters for detection")
-		return nil, fmt.Errorf("unable to apply filters for detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("unable to apply filters for detection")
+		return nil, fmt.Errorf("unable to apply filters for detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
+	tempPublicId := detect.PublicID
 	detect, err = srv.Detectionstore.CreateDetection(ctx, detect)
 	if err != nil {
-		logger.WithError(err).Error("failed to create detection")
-		return nil, fmt.Errorf("failed to create detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", tempPublicId).Error("failed to create detection")
+		return nil, fmt.Errorf("failed to create detection with Public ID %s: %w", tempPublicId, err)
 	}
 
 	errMap, err := engine.SyncLocalDetections(ctx, []*model.Detection{detect})
 	if err != nil {
-		logger.WithError(err).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
 	if len(errMap) != 0 {
-		logger.WithField("errMap", errMap).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection")
+		logger.WithFields(log.Fields{
+			"detectionPublicId": detect.PublicID,
+			"errMap":            errMap,
+		}).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection with Public ID %s: %v", detect.PublicID, errMap)
 	}
 
 	result.Result = detect

--- a/server/modules/assistant/create_detection.go
+++ b/server/modules/assistant/create_detection.go
@@ -69,6 +69,11 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
 
+	err = srv.CheckAuthorized(ctx, "write", "detections")
+	if err != nil {
+		return nil, err
+	}
+
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
 
 	args := &createDetectionArgs{}

--- a/server/modules/assistant/create_detection.go
+++ b/server/modules/assistant/create_detection.go
@@ -100,16 +100,6 @@ func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, p
 	detect.License = args.License
 	detect.Content = args.Content
 
-	for _, over := range detect.Overrides {
-		if over.CreatedAt.IsZero() {
-			over.CreatedAt = time.Now()
-		}
-
-		if over.UpdatedAt.IsZero() {
-			over.UpdatedAt = time.Now()
-		}
-	}
-
 	detect.Ruleset = detections.RULESET_CUSTOM
 
 	switch detect.Language {

--- a/server/modules/assistant/create_detection.go
+++ b/server/modules/assistant/create_detection.go
@@ -1,0 +1,175 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/apex/log"
+)
+
+func init() {
+	t := &CreateDetectionTool{}
+	knownTools[t.GetName()] = t
+}
+
+type CreateDetectionTool struct{}
+
+func (t *CreateDetectionTool) GetName() string {
+	return "create_detection"
+}
+
+func (t *CreateDetectionTool) GetDescription() string {
+	return `Create a new detection for the given alert(s) (or other event(s)/topic(s)) at hand.`
+}
+
+func (t *CreateDetectionTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"language": {
+					Type:        "string",
+					Description: `The language that this detection uses. This must be "sigma", "suricata", or "yara".`,
+				},
+				"license": {
+					Type:        "string",
+					Description: `The license that applies to this detection. (e.g., "DRL")`,
+				},
+				"content": {
+					Type:        "string",
+					Description: `The underlying detection rule source content. (e.g., "title: CobaltStrike Named Pipe\nid: ...\n logsource:\n ...\ncondition: selection\nfalsepositives:\n...")`,
+				},
+			},
+			Required: []string{"search_filter"},
+		},
+	}
+}
+
+type createDetectionArgs struct {
+	Language string `json:"language" enums:"sigma,suricata,yara"`
+	License  string `json:"license" example:"DRL"`
+	Content  string `json:"content" example:"title: CobaltStrike Named Pipe\nid: ...\n logsource:\n ...\ncondition: selection\nfalsepositives:\n..."`
+}
+
+func (t *CreateDetectionTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &createDetectionArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Parameters = args
+
+	detect := &model.Detection{}
+	detect.Language = model.SigLanguage(strings.ToLower(string(args.Language)))
+	detect.License = args.License
+	detect.Content = args.Content
+
+	for _, over := range detect.Overrides {
+		if over.CreatedAt.IsZero() {
+			over.CreatedAt = time.Now()
+		}
+
+		if over.UpdatedAt.IsZero() {
+			over.UpdatedAt = time.Now()
+		}
+	}
+
+	detect.Ruleset = detections.RULESET_CUSTOM
+
+	switch detect.Language {
+	case "sigma":
+		detect.Engine = model.EngineNameElastAlert
+	case "yara":
+		detect.Engine = model.EngineNameStrelka
+	case "suricata":
+		detect.Engine = model.EngineNameSuricata
+	}
+
+	engInt, ok := srv.DetectionEngines.Load(detect.Engine)
+	if !ok {
+		logger.WithField("detectionEngine", detect.Engine).Error("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine")
+	}
+
+	engine := engInt.(server.DetectionEngine)
+
+	_, err = engine.ValidateRule(detect.Content)
+	if err != nil {
+		logger.WithError(err).WithField("detectionContent", detect.Content).Error("invalid rule")
+		return nil, fmt.Errorf("invalid rule: %w", err)
+	}
+
+	err = engine.ExtractDetails(detect)
+	if err != nil {
+		logger.WithError(err).WithFields(log.Fields{
+			"detectionEngine":   detect.Engine,
+			"detectionPublicId": detect.PublicID,
+		}).Error("unable to extract details from detection")
+		return nil, fmt.Errorf("unable to extract details for detection: %w", err)
+	}
+
+	user, err := srv.Userstore.GetUserById(ctx, userId)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve user: %w", err)
+	}
+	detect.Author = detections.MakeUser(user)
+
+	_, err = engine.ApplyFilters(detect)
+	if err != nil {
+		logger.WithError(err).Error("unable to apply filters for detection")
+		return nil, fmt.Errorf("unable to appy filters for detection: %w", err)
+	}
+
+	detect, err = srv.Detectionstore.CreateDetection(ctx, detect)
+	if err != nil {
+		logger.WithError(err).Error("failed to create detection")
+		return nil, fmt.Errorf("failed to create detection: %w", err)
+	}
+
+	errMap, err := engine.SyncLocalDetections(ctx, []*model.Detection{detect})
+	if err != nil {
+		logger.WithError(err).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection: %w", err)
+	}
+
+	if len(errMap) != 0 {
+		logger.WithField("errMap", errMap).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection")
+	}
+
+	result.Result = detect
+
+	return result, nil
+}

--- a/server/modules/assistant/create_detection.go
+++ b/server/modules/assistant/create_detection.go
@@ -46,7 +46,7 @@ func (t *CreateDetectionTool) GetSchema() model.JSONSchema {
 				},
 				"license": {
 					Type:        "string",
-					Description: `The license that applies to this detection. (e.g., "DRL")`,
+					Description: `The license that applies to this detection. (e.g., "DRL") *IMPORTANT*: The license should be left blank unless explicitly instructed by the user what the license should be.`,
 				},
 				"content": {
 					Type:        "string",

--- a/server/modules/assistant/create_detection_test.go
+++ b/server/modules/assistant/create_detection_test.go
@@ -1,0 +1,510 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/mock"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateDetectionTool_GetName(t *testing.T) {
+	tool := &CreateDetectionTool{}
+	assert.Equal(t, "create_detection", tool.GetName())
+}
+
+func TestCreateDetectionTool_GetDescription(t *testing.T) {
+	desc := (&CreateDetectionTool{}).GetDescription()
+	assert.NotEmpty(t, desc)
+	assert.Contains(t, desc, "Create a new detection")
+}
+
+func TestCreateDetectionTool_GetSchema(t *testing.T) {
+	schema := (&CreateDetectionTool{}).GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+	assert.Contains(t, schema.Json.Properties, "language")
+	assert.Equal(t, "string", schema.Json.Properties["language"].Type)
+	assert.Contains(t, schema.Json.Properties["language"].Description, "sigma")
+	assert.Contains(t, schema.Json.Properties["language"].Description, "suricata")
+	assert.Contains(t, schema.Json.Properties["language"].Description, "yara")
+
+	assert.Contains(t, schema.Json.Properties, "license")
+	assert.Equal(t, "string", schema.Json.Properties["license"].Type)
+
+	assert.Contains(t, schema.Json.Properties, "content")
+	assert.Equal(t, "string", schema.Json.Properties["content"].Type)
+
+	assert.Contains(t, schema.Json.Required, "search_filter")
+}
+
+func TestCreateDetectionTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name               string
+		params             string
+		mockDetection      *model.Detection
+		mockUser           *model.User
+		mockDetectionError error
+		mockUserError      error
+		mockEngineError    error
+		mockValidateError  error
+		mockExtractError   error
+		mockApplyError     error
+		mockSyncError      error
+		mockSyncErrMap     map[string]string
+		expectedError      bool
+		expectedEngine     model.EngineName
+		expectedLanguage   model.SigLanguage
+		expectedRuleset    string
+	}{
+		{
+			name:   "successful sigma detection creation",
+			params: `{"language": "sigma", "license": "DRL", "content": "title: Test Rule\nid: 12345\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '.exe'\n  condition: selection"}`,
+			mockDetection: &model.Detection{
+				PublicID: "test-detection-id",
+				Title:    "Test Rule",
+				Content:  "title: Test Rule\nid: 12345\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '.exe'\n  condition: selection",
+			},
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+			expectedRuleset:  detections.RULESET_CUSTOM,
+		},
+		{
+			name:   "successful suricata detection creation",
+			params: `{"language": "suricata", "license": "DRL", "content": "alert tcp any any -> any any (msg:\"Test Rule\"; sid:1000001; rev:1;)"}`,
+			mockDetection: &model.Detection{
+				PublicID: "test-detection-id-2",
+				Title:    "Test Suricata Rule",
+				Content:  "alert tcp any any -> any any (msg:\"Test Rule\"; sid:1000001; rev:1;)",
+			},
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+			expectedEngine:   model.EngineNameSuricata,
+			expectedLanguage: model.SigLangSuricata,
+			expectedRuleset:  detections.RULESET_CUSTOM,
+		},
+		{
+			name:   "successful yara detection creation",
+			params: `{"language": "yara", "license": "DRL", "content": "rule TestRule {\n  meta:\n    description = \"Test YARA rule\"\n  strings:\n    $test = \"malware\"\n  condition:\n    $test\n}"}`,
+			mockDetection: &model.Detection{
+				PublicID: "test-detection-id-3",
+				Title:    "TestRule",
+				Content:  "rule TestRule {\n  meta:\n    description = \"Test YARA rule\"\n  strings:\n    $test = \"malware\"\n  condition:\n    $test\n}",
+			},
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+			expectedEngine:   model.EngineNameStrelka,
+			expectedLanguage: model.SigLangYara,
+			expectedRuleset:  detections.RULESET_CUSTOM,
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"language": "sigma", "license": "DRL", "content": "missing closing brace"`,
+			expectedError: true,
+		},
+		{
+			name:             "unsupported engine",
+			params:           `{"language": "sigma", "license": "DRL", "content": "title: Test"}`,
+			mockEngineError:  errors.New("engine not found"),
+			expectedError:    true,
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+		},
+		{
+			name:              "rule validation error",
+			params:            `{"language": "sigma", "license": "DRL", "content": "invalid rule content"}`,
+			mockValidateError: errors.New("invalid rule syntax"),
+			expectedError:     true,
+			expectedEngine:    model.EngineNameElastAlert,
+			expectedLanguage:  model.SigLangSigma,
+		},
+		{
+			name:             "extract details error",
+			params:           `{"language": "sigma", "license": "DRL", "content": "title: Test"}`,
+			mockExtractError: errors.New("failed to extract details"),
+			expectedError:    true,
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+		},
+		{
+			name:             "user retrieval error",
+			params:           `{"language": "sigma", "license": "DRL", "content": "title: Test"}`,
+			mockUserError:    errors.New("user not found"),
+			expectedError:    true,
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+		},
+		{
+			name:             "apply filters error",
+			params:           `{"language": "sigma", "license": "DRL", "content": "title: Test"}`,
+			mockApplyError:   errors.New("failed to apply filters"),
+			expectedError:    true,
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+		},
+		{
+			name:               "detection store creation error",
+			params:             `{"language": "sigma", "license": "DRL", "content": "title: Test"}`,
+			mockDetectionError: errors.New("failed to create detection"),
+			expectedError:      true,
+			expectedEngine:     model.EngineNameElastAlert,
+			expectedLanguage:   model.SigLangSigma,
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+		},
+		{
+			name:             "sync local detections error",
+			params:           `{"language": "sigma", "license": "DRL", "content": "title: Test"}`,
+			mockSyncError:    errors.New("failed to sync"),
+			expectedError:    true,
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+			mockDetection: &model.Detection{
+				PublicID: "test-detection-id",
+				Title:    "Test Rule",
+				Content:  "title: Test",
+			},
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+		},
+		{
+			name:             "sync local detections error map",
+			params:           `{"language": "sigma", "license": "DRL", "content": "title: Test"}`,
+			mockSyncErrMap:   map[string]string{"test-detection-id": "sync failed"},
+			expectedError:    true,
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+			mockDetection: &model.Detection{
+				PublicID: "test-detection-id",
+				Title:    "Test Rule",
+				Content:  "title: Test",
+			},
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+		},
+		{
+			name:   "case insensitive language handling",
+			params: `{"language": "SIGMA", "license": "DRL", "content": "title: Test Rule"}`,
+			mockDetection: &model.Detection{
+				PublicID: "test-detection-id",
+				Title:    "Test Rule",
+				Content:  "title: Test Rule",
+			},
+			mockUser: &model.User{
+				Id:        "test-user-id",
+				FirstName: "Test",
+				LastName:  "User",
+				Email:     "test@example.com",
+			},
+			expectedEngine:   model.EngineNameElastAlert,
+			expectedLanguage: model.SigLangSigma,
+			expectedRuleset:  detections.RULESET_CUSTOM,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create mock stores
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+			mockUserstore := mock.NewMockUserstore(ctrl)
+			mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+			// Create mock server
+			mockServer := &server.Server{
+				Detectionstore: mockDetectionstore,
+				Userstore:      mockUserstore,
+			}
+
+			// Set up detection engine expectations if not expecting engine error
+			if tc.mockEngineError == nil && !tc.expectedError {
+				mockServer.DetectionEngines.Store(tc.expectedEngine, mockDetectionEngine)
+			} else if tc.mockEngineError == nil && tc.expectedEngine != "" {
+				mockServer.DetectionEngines.Store(tc.expectedEngine, mockDetectionEngine)
+			}
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Set up mock expectations based on test case
+			if !tc.expectedError || tc.mockValidateError != nil || tc.mockExtractError != nil || tc.mockUserError != nil || tc.mockApplyError != nil || tc.mockDetectionError != nil || tc.mockSyncError != nil || tc.mockSyncErrMap != nil {
+				if tc.mockValidateError != nil {
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("", tc.mockValidateError)
+				} else if tc.mockExtractError != nil {
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+					mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(tc.mockExtractError)
+				} else if tc.mockUserError != nil {
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+					mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+					mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(nil, tc.mockUserError)
+				} else if tc.mockApplyError != nil {
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+					mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+					mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(tc.mockUser, nil)
+					mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, tc.mockApplyError)
+				} else if tc.mockDetectionError != nil {
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+					mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+					mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(tc.mockUser, nil)
+					mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+					mockDetectionstore.EXPECT().CreateDetection(ctx, gomock.Any()).Return(nil, tc.mockDetectionError)
+				} else if tc.mockSyncError != nil {
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+					mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+					mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(tc.mockUser, nil)
+					mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+					mockDetectionstore.EXPECT().CreateDetection(ctx, gomock.Any()).Return(tc.mockDetection, nil)
+					mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(nil, tc.mockSyncError)
+				} else if tc.mockSyncErrMap != nil {
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+					mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+					mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(tc.mockUser, nil)
+					mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+					mockDetectionstore.EXPECT().CreateDetection(ctx, gomock.Any()).Return(tc.mockDetection, nil)
+					mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(tc.mockSyncErrMap, nil)
+				} else {
+					// Successful case
+					mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+					mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+					mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(tc.mockUser, nil)
+					mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+					mockDetectionstore.EXPECT().CreateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+						// Verify detection properties
+						assert.Equal(t, tc.expectedLanguage, detect.Language)
+						assert.Equal(t, tc.expectedEngine, detect.Engine)
+						assert.Equal(t, tc.expectedRuleset, detect.Ruleset)
+						assert.Equal(t, "DRL", detect.License)
+						return tc.mockDetection, nil
+					})
+					mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+				}
+			}
+
+			// Create tool and execute
+			tool := &CreateDetectionTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "create_detection", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+			assert.NotZero(t, result.TimeToExecute)
+
+			// Verify result content
+			assert.Equal(t, tc.mockDetection, result.Result)
+
+			// Verify parameters were captured
+			assert.NotNil(t, result.Parameters)
+			args, ok := result.Parameters.(*createDetectionArgs)
+			assert.True(t, ok)
+			assert.NotNil(t, args)
+		})
+	}
+}
+
+func TestCreateDetectionTool_Execute_VerifyContextPropagation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockUserstore := mock.NewMockUserstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+		Userstore:      mockUserstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-123")
+
+	mockUser := &model.User{
+		Id:        "test-user-123",
+		FirstName: "Test",
+		LastName:  "User",
+		Email:     "test@example.com",
+	}
+
+	mockDetection := &model.Detection{
+		PublicID: "test-detection-id",
+		Title:    "Test Rule",
+		Content:  "title: Test Rule",
+	}
+
+	// Set up expectations
+	mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+	mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+	mockUserstore.EXPECT().GetUserById(ctx, "test-user-123").Return(mockUser, nil)
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().CreateDetection(ctx, gomock.Any()).Return(mockDetection, nil)
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+
+	tool := &CreateDetectionTool{}
+	_, err := tool.Execute(ctx, mockServer, `{"language": "sigma", "license": "DRL", "content": "title: Test Rule"}`, "")
+
+	assert.NoError(t, err)
+}
+
+func TestCreateDetectionTool_Execute_OverrideTimestamps(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockUserstore := mock.NewMockUserstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+		Userstore:      mockUserstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+	mockUser := &model.User{
+		Id:        "test-user-id",
+		FirstName: "Test",
+		LastName:  "User",
+		Email:     "test@example.com",
+	}
+
+	// Create a detection with overrides that have zero timestamps
+	mockDetection := &model.Detection{
+		PublicID: "test-detection-id",
+		Title:    "Test Rule",
+		Content:  "title: Test Rule",
+		Overrides: []*model.Override{
+			{
+				Type:      model.OverrideTypeCustomFilter,
+				IsEnabled: true,
+				// CreatedAt and UpdatedAt are zero values
+			},
+		},
+	}
+
+	// Set up expectations
+	mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+	mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+	mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(mockUser, nil)
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().CreateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+		// Verify that timestamps were set for overrides with zero values
+		for _, override := range detect.Overrides {
+			assert.False(t, override.CreatedAt.IsZero(), "CreatedAt should be set")
+			assert.False(t, override.UpdatedAt.IsZero(), "UpdatedAt should be set")
+			assert.WithinDuration(t, time.Now(), override.CreatedAt, time.Second)
+			assert.WithinDuration(t, time.Now(), override.UpdatedAt, time.Second)
+		}
+		return mockDetection, nil
+	})
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+
+	tool := &CreateDetectionTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"language": "sigma", "license": "DRL", "content": "title: Test Rule"}`, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestCreateDetectionTool_Execute_AuthorAssignment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockUserstore := mock.NewMockUserstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+		Userstore:      mockUserstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+	mockUser := &model.User{
+		Id:        "test-user-id",
+		FirstName: "John",
+		LastName:  "Doe",
+		Email:     "john.doe@example.com",
+	}
+
+	mockDetection := &model.Detection{
+		PublicID: "test-detection-id",
+		Title:    "Test Rule",
+		Content:  "title: Test Rule",
+	}
+
+	// Set up expectations
+	mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+	mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+	mockUserstore.EXPECT().GetUserById(ctx, "test-user-id").Return(mockUser, nil)
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().CreateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+		// Verify that author was set using detections.MakeUser
+		expectedAuthor := detections.MakeUser(mockUser)
+		assert.Equal(t, expectedAuthor, detect.Author)
+		return mockDetection, nil
+	})
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+
+	tool := &CreateDetectionTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"language": "sigma", "license": "DRL", "content": "title: Test Rule"}`, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}

--- a/server/modules/assistant/create_detection_test.go
+++ b/server/modules/assistant/create_detection_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/security-onion-solutions/securityonion-soc/config"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/server/mock"
@@ -262,6 +263,9 @@ func TestCreateDetectionTool_Execute(t *testing.T) {
 			mockServer := &server.Server{
 				Detectionstore: mockDetectionstore,
 				Userstore:      mockUserstore,
+				Config: &config.ServerConfig{
+					DeveloperEnabled: true,
+				},
 			}
 
 			// Set up detection engine expectations if not expecting engine error
@@ -367,6 +371,9 @@ func TestCreateDetectionTool_Execute_VerifyContextPropagation(t *testing.T) {
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
 		Userstore:      mockUserstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
 
@@ -410,6 +417,9 @@ func TestCreateDetectionTool_Execute_OverrideTimestamps(t *testing.T) {
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
 		Userstore:      mockUserstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
 
@@ -471,6 +481,9 @@ func TestCreateDetectionTool_Execute_AuthorAssignment(t *testing.T) {
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
 		Userstore:      mockUserstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
 

--- a/server/modules/assistant/create_detection_test.go
+++ b/server/modules/assistant/create_detection_test.go
@@ -49,8 +49,6 @@ func TestCreateDetectionTool_GetSchema(t *testing.T) {
 
 	assert.Contains(t, schema.Json.Properties, "content")
 	assert.Equal(t, "string", schema.Json.Properties["content"].Type)
-
-	assert.Contains(t, schema.Json.Required, "search_filter")
 }
 
 func TestCreateDetectionTool_Execute(t *testing.T) {

--- a/server/modules/assistant/escalate_alerts.go
+++ b/server/modules/assistant/escalate_alerts.go
@@ -112,7 +112,7 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 	if args.RangeFormat != "" {
 		timeFormat = args.RangeFormat
 	} else {
-		timeFormat = "2006-01-02 3:04:05 PM"
+		timeFormat = "2006/01/02 3:04:05 PM"
 	}
 
 	var timeRange string

--- a/server/modules/assistant/escalate_alerts.go
+++ b/server/modules/assistant/escalate_alerts.go
@@ -175,14 +175,14 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 		if err != nil {
 			logger.WithError(err).Error("error creating case for escalated alert")
 
-			return nil, err
+			return nil, fmt.Errorf("error creating case for escalated alert: %w", err)
 		}
 	} else {
 		modelCase, err = server.Casestore.GetCase(ctx, args.CaseId)
 		if err != nil {
 			logger.WithField("caseId", args.CaseId).WithError(err).Error("error fetching case for escalated alert")
 
-			return nil, err
+			return nil, fmt.Errorf("error fetching case for escalated alert: %w", err)
 		}
 	}
 	for _, ev := range relatedEvents {
@@ -195,7 +195,7 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 	if err != nil {
 		logger.WithError(err).Error("error linking alerts to new case")
 
-		return nil, err
+		return nil, fmt.Errorf("error linking alerts to new case: %w", err)
 	}
 
 	logger.WithFields(log.Fields{
@@ -220,7 +220,7 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 	if err != nil {
 		logger.WithError(err).Error("error escalating alert")
 
-		return nil, err
+		return nil, fmt.Errorf("error escalating alert: %w", err)
 	}
 
 	if ackResults.UpdatedCount == 0 {

--- a/server/modules/assistant/escalate_alerts.go
+++ b/server/modules/assistant/escalate_alerts.go
@@ -107,10 +107,18 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 		return nil, err
 	}
 
+	var timeFormat string
+
+	if args.RangeFormat != "" {
+		timeFormat = args.RangeFormat
+	} else {
+		timeFormat = "2006-01-02 3:04:05 PM"
+	}
+
 	var timeRange string
 
 	if args.RangeStart != "" || args.RangeEnd != "" {
-		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, timeFormat)
 	}
 
 	result.Parameters = args
@@ -121,7 +129,7 @@ func (t *EscalateAlertsTool) Execute(ctx context.Context, server *server.Server,
 	err = searchCrit.Populate(
 		"(tags:alert AND NOT event.acknowledged:true AND NOT event.escalated:true) AND ("+args.SearchFilter+")",
 		timeRange,
-		"2006/01/02 3:04:05 PM",
+		timeFormat,
 		zone,
 		"0",
 		"10000",

--- a/server/modules/assistant/escalate_alerts_test.go
+++ b/server/modules/assistant/escalate_alerts_test.go
@@ -328,6 +328,71 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 			mockError:     assert.AnError,
 			expectedError: true,
 		},
+		{
+			name:          "search criteria population error",
+			params:        `{"search_filter": "soc_id:alert-123", "case_title": "Test Case", "range_start": "invalid-date", "range_end": "also-invalid", "range_format": "invalid-format"}`,
+			expectedError: true,
+		},
+		{
+			name:   "case creation error",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Test Case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-123",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+				},
+			},
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
+		{
+			name:   "create related events error",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Test Case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-123",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+				},
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "case-123",
+				},
+				Title: "Test Case",
+			},
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
+		{
+			name:   "eventstore acknowledge error",
+			params: `{"search_filter": "soc_id:alert-123", "case_title": "Test Case"}`,
+			mockSearchResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Id: "alert-123",
+						Payload: map[string]interface{}{
+							"@timestamp": "2024-12-04T10:00:00Z",
+						},
+					},
+				},
+			},
+			mockCase: &model.Case{
+				Auditable: model.Auditable{
+					Id: "case-123",
+				},
+				Title: "Test Case",
+			},
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -343,41 +408,72 @@ func TestEscalateAlertsTool_Execute(t *testing.T) {
 			if tc.mockUpdateResults != nil {
 				mockEventstore.UpdateResults = []*model.EventUpdateResults{tc.mockUpdateResults}
 			}
-			if tc.mockError != nil {
+			// Only set eventstore error for actual eventstore errors
+			if tc.mockError != nil && (tc.name == "eventstore error" || tc.name == "eventstore acknowledge error") {
 				mockEventstore.Err = tc.mockError
 			}
 
 			// Create mock casestore
 			mockCasestore := mock.NewMockCasestore(ctrl)
 
-			// Only set up casestore expectations if we expect to create a case
-			if !tc.expectedError && tc.mockSearchResults != nil && len(tc.mockSearchResults.Events) > 0 {
+			// Set up casestore expectations based on test case
+			if tc.mockSearchResults != nil && len(tc.mockSearchResults.Events) > 0 {
 				// Parse params to determine if we're using case_id or case_title
 				var args escalateAlertArgs
 				json.Unmarshal([]byte(tc.params), &args)
 
-				if args.CaseId != "" {
-					// Expect GetCase call for existing case
-					mockCasestore.EXPECT().
-						GetCase(gomock.Any(), args.CaseId).
-						Return(tc.mockCase, tc.mockError).
-						Times(1)
-				} else {
-					// Expect Create call for new case
-					mockCasestore.EXPECT().
-						Create(gomock.Any(), gomock.Any()).
-						Return(tc.mockCase, nil).
-						Times(1)
-				}
+				// Determine the specific error scenario
+				isCaseCreationError := tc.name == "case creation error"
+				isCaseRetrievalError := tc.name == "case_id not found error"
+				isCreateRelatedEventsError := tc.name == "create related events error"
+				isEventstoreError := tc.name == "eventstore error" || tc.name == "eventstore acknowledge error"
 
-				// Expect CreateRelatedEvents call (only if GetCase/Create succeeds)
-				if tc.mockError == nil {
-					mockCasestore.EXPECT().
-						CreateRelatedEvents(gomock.Any(), gomock.Any()).
-						DoAndReturn(func(ctx context.Context, events []*model.RelatedEvent) (int, map[string]error, error) {
-							return len(events), nil, nil
-						}).
-						Times(1)
+				// Skip casestore setup for eventstore errors and search criteria errors
+				if !isEventstoreError && tc.name != "search criteria population error" {
+					if args.CaseId != "" {
+						// Expect GetCase call for existing case
+						if isCaseRetrievalError {
+							mockCasestore.EXPECT().
+								GetCase(gomock.Any(), args.CaseId).
+								Return(nil, tc.mockError).
+								Times(1)
+						} else {
+							mockCasestore.EXPECT().
+								GetCase(gomock.Any(), args.CaseId).
+								Return(tc.mockCase, nil).
+								Times(1)
+						}
+					} else {
+						// Expect Create call for new case
+						if isCaseCreationError {
+							mockCasestore.EXPECT().
+								Create(gomock.Any(), gomock.Any()).
+								Return(nil, tc.mockError).
+								Times(1)
+						} else {
+							mockCasestore.EXPECT().
+								Create(gomock.Any(), gomock.Any()).
+								Return(tc.mockCase, nil).
+								Times(1)
+						}
+					}
+
+					// Expect CreateRelatedEvents call (only if GetCase/Create succeeds)
+					if !isCaseCreationError && !isCaseRetrievalError {
+						if isCreateRelatedEventsError {
+							mockCasestore.EXPECT().
+								CreateRelatedEvents(gomock.Any(), gomock.Any()).
+								Return(0, nil, tc.mockError).
+								Times(1)
+						} else {
+							mockCasestore.EXPECT().
+								CreateRelatedEvents(gomock.Any(), gomock.Any()).
+								DoAndReturn(func(ctx context.Context, events []*model.RelatedEvent) (int, map[string]error, error) {
+									return len(events), nil, nil
+								}).
+								Times(1)
+						}
+					}
 				}
 			}
 
@@ -659,4 +755,60 @@ func TestEscalateAlertsTool_Execute_NoAlertsEscalated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "No case was created", result.Result)
+}
+
+func TestEscalateAlertsTool_Execute_AcknowledgeError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create a custom eventstore that succeeds on Search but fails on Acknowledge
+	mockEventstore := &CustomEventstoreForAckError{
+		FakeEventstore: server.NewFakeEventstore(),
+	}
+	mockEventstore.SearchResults = []*model.EventSearchResults{
+		{
+			Events: []*model.EventRecord{
+				{
+					Id: "alert-123",
+					Payload: map[string]interface{}{
+						"@timestamp": "2024-12-04T10:00:00Z",
+					},
+				},
+			},
+		},
+	}
+
+	mockCasestore := mock.NewMockCasestore(ctrl)
+	mockCasestore.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Return(&model.Case{Auditable: model.Auditable{Id: "case-123"}, Title: "Test Case"}, nil).
+		Times(1)
+	mockCasestore.EXPECT().
+		CreateRelatedEvents(gomock.Any(), gomock.Any()).
+		Return(1, nil, nil).
+		Times(1)
+
+	mockServer := &server.Server{
+		Eventstore: mockEventstore,
+		Casestore:  mockCasestore,
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+	tool := &EscalateAlertsTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"search_filter": "soc_id:alert-123", "case_title": "Test Case"}`, "")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "error escalating alert")
+}
+
+// CustomEventstoreForAckError wraps FakeEventstore to fail only on Acknowledge
+type CustomEventstoreForAckError struct {
+	*server.FakeEventstore
+}
+
+func (e *CustomEventstoreForAckError) Acknowledge(ctx context.Context, criteria *model.EventAckCriteria) (*model.EventUpdateResults, error) {
+	// Always fail on acknowledge
+	return nil, assert.AnError
 }

--- a/server/modules/assistant/query_cases.go
+++ b/server/modules/assistant/query_cases.go
@@ -43,7 +43,7 @@ func (t *QueryCasesTool) GetDescription() string {
 		"- When searching for cases, specify a date range of 999 days ago.\n" +
 		"- Examples for wild cards in the oql_query:\n" +
 		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
-		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `rule.name:(A B*)` is valid, but `rule.name:\"A B*\"` will not work as expected)\n" +
+		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `so_case.title:(A B*)` is valid, but `so_case.title:\"A B*\"` will not work as expected)\n" +
 		"- In addition to search results, you'll also get the user's most recently viewed cases. This field is called recent_cases.\n" +
 		"- If the most applicable case is clear-cut, explain that to the user. Otherwise, give multiple options, compare them, and let the user choose."
 }

--- a/server/modules/assistant/query_cases.go
+++ b/server/modules/assistant/query_cases.go
@@ -142,7 +142,7 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 	if args.RangeFormat != "" {
 		timeFormat = args.RangeFormat
 	} else {
-		timeFormat = "2006-01-02 3:04:05 PM"
+		timeFormat = "2006/01/02 3:04:05 PM"
 	}
 
 	var timeRange string

--- a/server/modules/assistant/query_cases.go
+++ b/server/modules/assistant/query_cases.go
@@ -137,16 +137,24 @@ func (t *QueryCasesTool) Execute(ctx context.Context, server *server.Server, par
 	}
 	metricLimit = 10000
 
+	var timeFormat string
+
+	if args.RangeFormat != "" {
+		timeFormat = args.RangeFormat
+	} else {
+		timeFormat = "2006-01-02 3:04:05 PM"
+	}
+
 	var timeRange string
 
 	if args.RangeStart != "" || args.RangeEnd != "" {
-		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, timeFormat)
 	}
 
 	criteria := model.NewEventSearchCriteria()
 	err = criteria.Populate(query,
 		timeRange,
-		"2006/01/02 3:04:05 PM",
+		timeFormat,
 		zone,
 		strconv.Itoa(metricLimit),
 		strconv.Itoa(caseLimit))

--- a/server/modules/assistant/query_detections.go
+++ b/server/modules/assistant/query_detections.go
@@ -158,7 +158,7 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 	if args.RangeFormat != "" {
 		timeFormat = args.RangeFormat
 	} else {
-		timeFormat = "2006-01-02 3:04:05 PM"
+		timeFormat = "2006/01/02 3:04:05 PM"
 	}
 
 	var timeRange string

--- a/server/modules/assistant/query_detections.go
+++ b/server/modules/assistant/query_detections.go
@@ -153,16 +153,24 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 	}
 	metricLimit = 10000
 
+	var timeFormat string
+
+	if args.RangeFormat != "" {
+		timeFormat = args.RangeFormat
+	} else {
+		timeFormat = "2006-01-02 3:04:05 PM"
+	}
+
 	var timeRange string
 
 	if args.RangeStart != "" || args.RangeEnd != "" {
-		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, timeFormat)
 	}
 
 	criteria := model.NewEventSearchCriteria()
 	err = criteria.Populate(query,
 		timeRange,
-		"2006/01/02 3:04:05 PM",
+		timeFormat,
 		zone,
 		strconv.Itoa(metricLimit),
 		strconv.Itoa(detectLimit))

--- a/server/modules/assistant/query_detections.go
+++ b/server/modules/assistant/query_detections.go
@@ -112,7 +112,7 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 
 	err = server.CheckAuthorized(ctx, "read", "detections")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("user is not authorized to read detections: %w", err)
 	}
 
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
@@ -132,7 +132,7 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 
 	err = json.Unmarshal([]byte(params), args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't unmarshal params: %w", err)
 	}
 
 	result.Parameters = args
@@ -180,7 +180,7 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 		strconv.Itoa(metricLimit),
 		strconv.Itoa(detectLimit))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error populating search criteria: %w", err)
 	}
 
 	criteria.SortFields = []*model.SortCriteria{
@@ -192,7 +192,7 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 
 	searchResults, err := server.Eventstore.Search(ctx, criteria)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to search for detections: %w", err)
 	}
 
 	detectEvents := searchResults.Events
@@ -214,7 +214,7 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 	// Convert to JSON
 	resultJSON, err := json.MarshalIndent(filteredDetects, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal result: %w", err)
+		return nil, fmt.Errorf("failed to marshal %d filtered detections: %w", len(filteredDetects), err)
 	}
 
 	// Log filtered result size and preview

--- a/server/modules/assistant/query_detections.go
+++ b/server/modules/assistant/query_detections.go
@@ -1,0 +1,275 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+)
+
+func init() {
+	t := &QueryDetectionsTool{}
+	knownTools[t.GetName()] = t
+}
+
+type QueryDetectionsTool struct{}
+
+func (t *QueryDetectionsTool) GetName() string {
+	return "query_detections"
+}
+
+func (t *QueryDetectionsTool) GetDescription() string {
+	return "- Execute OQL queries to retrieve Security Onion detections that are most applicable to the given alert(s) (or other event(s)/topic(s)) at hand.\n" +
+		"- Search for detections by referencing any potentially relevant field(s), whichever you see fit from the ones described to you.\n" +
+		"- *IMPORTANT* All queries should include `AND _index:\"*:so-detection\" AND so_kind:detection` appended to the end. The quotes around *:so-detection MUST be included.\n" +
+		"- When searching for detections, specify a date range of 999 days ago.\n" +
+		"- Examples for wild cards in the oql_query:\n" +
+		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
+		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `so_detection.title:(A B*)` is valid, but `so_detection.title:\"A B*\"` will not work as expected)\n" +
+		"- If the most applicable detection is clear-cut, explain that to the user. Otherwise, give multiple options, compare them, and let the user choose."
+}
+
+func (t *QueryDetectionsTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"oql_query": {
+					Type: "string",
+					Description: "The OQL query string to execute. Here is a run-down of each of the potentially relevant fields you might want to use in your query:\n" +
+						"- so_detection.id: The ID assigned to this detection by the server. This is a read-only field. Example: \"gQKCepgBAWAm-kn2lYs2\"\n" +
+						"- so_detection.createTime: The date and time that this detection was created. This is a read-only field. Example: \"2024-11-14T15:03:22Z\"\n" +
+						"- so_detection.userId: The ID of the user that created this detection. Example: \"dcbe6004-f6e0-4579-9f98-9576201ffb29\"\n" +
+						"- so_detection.publicId: The public ID shared across all Security Onion grids. Example: \"923421c7-9b1e-45d4-80cc-e21d060c8723\"\n" +
+						"- so_detection.title: Summarized title of the detection. Example: \"Security Onion - Grid Node Login Failure (SSH)\"\n" +
+						"- so_detection.severity: The severity classification of this detection. This MUST be either \"unknown\", \"informational\", \"low\", \"medium\", \"high\", or \"critical\".\n" +
+						"- so_detection.author: The original author of this detection. This can be a mixture of email address, organization name, first name, or any freeform value. Example: \"Security Onion Solutions\"\n" +
+						"- so_detection.category: Used for categorizing this detection into a broader grouping such as firewalls or web servers. Example: \"ps_script\"\n" +
+						"- so_detection.description: Brief explanation of this detection. Example: \"Detects when a user fails to login to a grid node via SSH. Review associated logs for username and source IP.\"\n" +
+						"- so_detection.content: The underlying detection rule source content. Example: \"title: CobaltStrike Named Pipe\\nid: ...\\n logsource:\\n ...\\ncondition: selection\\nfalsepositives:\\n...\"\n" +
+						"- so_detection.isEnabled: Indicates whether this detection is currently enabled in the Security Onion grid. Example: true\n" +
+						"- so_detection.isCommunity: Indicates whether this detection originated from a community ruleset. Duplicated detections will show 'false'. Example: true\n" +
+						"- so_detection.engine: The engine that processes this detection.\n" +
+						"- so_detection.language: The language that this detection uses. This MUST be either \"sigma\", \"suricata\", or \"yara\".\n" +
+						"- so_detection.overrides: A list of tuning overrides that apply to this detection.\n" +
+						"- so_detection.tags: An optional list of user-defined tags, useful for grouping similar detections together.\n" +
+						"- so_detection.ruleset: The name of the ruleset from which this detection originated, or __custom__ if the ruleset was created outside of a ruleset. Example: \"__custom__\"\n" +
+						"- so_detection.license: The license that applies to this detection. Example: \"DRL\"\n" +
+						"- so_detection.sourceCreated: The date and time when the underlying detection rule source was created. This is not when the detection was added to this grid.\n" +
+						"- so_detection.sourceUpdated: The date and time when the underlying detection rule source was last updated. This is not when the detection was updated in this grid.\n" +
+						"- so_detection.product: Used by Sigma rules for filtering log outputs to a specific product, such as the Windows eventlog types. Example: \"windows\"\n" +
+						"- so_detection.service: Used by Sigma rules for filtering a subset of log outputs to a specific server. Example: \"sshd\"\n" +
+						"- @timestamp: The date and time when this detection was last created/updated/modified. Example: \"2025-11-12T19:38:17.413984706Z\"",
+				},
+				"range_start": {
+					Type:        "string",
+					Description: "Optional start time for the query range (e.g., \"-1h\", \"2023/10/26 10:00:00 AM\"). Default is 24 hours ago (\"-24h\")",
+				},
+				"range_end": {
+					Type:        "string",
+					Description: "Optional end time for the query range (e.g., \"now\", \"2023/10/26 12:00:00 PM\"). Default is now.",
+				},
+				"range_format": {
+					Type:        "string",
+					Description: "Format of the date range (default: \"2006/01/02 3:04:05 PM\"). The format must be specified using Go's time package's reference layout format. Required if either range_start or range_end is provided.",
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "The maximum number of detections to return",
+					Default:     100,
+				},
+			},
+			Required: []string{"oql_query"},
+		},
+	}
+}
+
+type queryDetectionsArgs struct {
+	OQLQuery    string `json:"oql_query"`
+	Query       string `json:"query"` // Support both query and oql_query
+	RangeStart  string `json:"range_start,omitempty"`
+	RangeEnd    string `json:"range_end,omitempty"`
+	RangeFormat string `json:"range_format,omitempty"`
+	Limit       int    `json:"limit"`
+}
+
+func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &queryDetectionsArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Parameters = args
+
+	var metricLimit, detectLimit int
+	zone := "UTC"
+	query := args.OQLQuery
+
+	if args.Query != "" && args.OQLQuery == "" {
+		query = args.Query
+	}
+
+	if query != "" && !strings.Contains(query, "NOT metadata.raw_index:") {
+		query = fmt.Sprintf(`(%s) AND NOT metadata.raw_index:"logs-soc-so"`, query)
+	} else if query == "" {
+		query = `NOT metadata.raw_index:"logs-soc-so"`
+	}
+
+	if args.Limit > 0 {
+		detectLimit = args.Limit
+	} else {
+		detectLimit = 10
+	}
+	metricLimit = 10000
+
+	var timeRange string
+
+	if args.RangeStart != "" || args.RangeEnd != "" {
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+	}
+
+	criteria := model.NewEventSearchCriteria()
+	err = criteria.Populate(query,
+		timeRange,
+		"2006/01/02 3:04:05 PM",
+		zone,
+		strconv.Itoa(metricLimit),
+		strconv.Itoa(detectLimit))
+	if err != nil {
+		return nil, err
+	}
+
+	criteria.SortFields = []*model.SortCriteria{
+		{
+			Field: "@timestamp",
+			Order: "desc",
+		},
+	}
+
+	err = server.CheckAuthorized(ctx, "read", "detections")
+	if err != nil {
+		return nil, err
+	}
+
+	searchResults, err := server.Eventstore.Search(ctx, criteria)
+	if err != nil {
+		return nil, err
+	}
+
+	detectEvents := searchResults.Events
+
+	if len(detectEvents) == 0 {
+		result.Result = "No detections found"
+		return result, nil
+	}
+
+	logger.WithField("detectionsFound", len(detectEvents)).Info("query executed successfully")
+
+	// Log raw detection size before filtering
+	rawJSON, _ := json.Marshal(detectEvents)
+	logger.WithField("rawDetectionSize", len(rawJSON)).Debug("raw detection size before filtering")
+
+	// Filter detection fields to reduce size
+	filteredDetects := filterDetections(detectEvents)
+
+	// Convert to JSON
+	resultJSON, err := json.MarshalIndent(filteredDetects, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	// Log filtered result size and preview
+	logger.WithField("filteredResultSize", len(resultJSON)).Debug("filtered result size")
+
+	result.Result = filteredDetects
+
+	return result, nil
+}
+
+// filterDetections filters detection event fields to reduce payload size
+func filterDetections(events []*model.EventRecord, extraFields ...string) []map[string]any {
+	// Default fields from Python implementation
+	defaultFields := []string{
+		"@timestamp",
+		"so_detection.id",
+		"so_detection.createTime",
+		"so_detection.userId",
+		"so_detection.publicId",
+		"so_detection.title",
+		"so_detection.severity",
+		"so_detection.author",
+		"so_detection.category",
+		"so_detection.description",
+		"so_detection.content",
+		"so_detection.isEnabled",
+		"so_detection.isCommunity",
+		"so_detection.engine",
+		"so_detection.language",
+		"so_detection.overrides",
+		"so_detection.tags",
+		"so_detection.ruleset",
+		"so_detection.license",
+		"so_detection.sourceCreated",
+		"so_detection.sourceUpdated",
+		"so_detection.product",
+		"so_detection.service",
+	}
+
+	filtered := make([]map[string]any, 0, len(events))
+
+	fields := append(defaultFields, extraFields...)
+
+	for _, event := range events {
+		filteredPayload := map[string]any{
+			"_id": event.Id,
+		}
+
+		// Copy only default fields starting with the Id field
+		for _, field := range fields {
+			// First try the field as-is (for non-nested fields)
+			if val, exists := event.Payload[field]; exists && val != nil {
+				filteredPayload[field] = val
+			} else if value := getNestedField(event.Payload, field); value != nil {
+				// Try nested field lookup
+				setNestedField(filteredPayload, field, value)
+			}
+		}
+
+		filtered = append(filtered, map[string]any{
+			"payload": filteredPayload,
+		})
+	}
+
+	return filtered
+}

--- a/server/modules/assistant/query_detections.go
+++ b/server/modules/assistant/query_detections.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -137,8 +136,6 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 
 	result.Parameters = args
 
-	var metricLimit, detectLimit int
-	zone := "UTC"
 	query := args.OQLQuery
 
 	if args.Query != "" && args.OQLQuery == "" {
@@ -151,48 +148,16 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 		query = `NOT metadata.raw_index:"logs-soc-so"`
 	}
 
+	var detectLimit int
 	if args.Limit > 0 {
 		detectLimit = args.Limit
 	} else {
 		detectLimit = 10
 	}
-	metricLimit = 10000
 
-	var timeFormat string
-
-	if args.RangeFormat != "" {
-		timeFormat = args.RangeFormat
-	} else {
-		timeFormat = "2006/01/02 3:04:05 PM"
-	}
-
-	var timeRange string
-
-	if args.RangeStart != "" || args.RangeEnd != "" {
-		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, timeFormat)
-	}
-
-	criteria := model.NewEventSearchCriteria()
-	err = criteria.Populate(query,
-		timeRange,
-		timeFormat,
-		zone,
-		strconv.Itoa(metricLimit),
-		strconv.Itoa(detectLimit))
+	searchResults, err := server.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
 	if err != nil {
-		return nil, fmt.Errorf("error populating search criteria: %w", err)
-	}
-
-	criteria.SortFields = []*model.SortCriteria{
-		{
-			Field: "@timestamp",
-			Order: "desc",
-		},
-	}
-
-	searchResults, err := server.Eventstore.Search(ctx, criteria)
-	if err != nil {
-		return nil, fmt.Errorf("failed to search for detections: %w", err)
+		return nil, fmt.Errorf("unable to search for detection events with query %s: %w", query, err)
 	}
 
 	detectEvents := searchResults.Events

--- a/server/modules/assistant/query_detections.go
+++ b/server/modules/assistant/query_detections.go
@@ -110,6 +110,11 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
 
+	err = server.CheckAuthorized(ctx, "read", "detections")
+	if err != nil {
+		return nil, err
+	}
+
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
 
 	args := &queryDetectionsArgs{}
@@ -183,11 +188,6 @@ func (t *QueryDetectionsTool) Execute(ctx context.Context, server *server.Server
 			Field: "@timestamp",
 			Order: "desc",
 		},
-	}
-
-	err = server.CheckAuthorized(ctx, "read", "detections")
-	if err != nil {
-		return nil, err
 	}
 
 	searchResults, err := server.Eventstore.Search(ctx, criteria)

--- a/server/modules/assistant/query_detections_test.go
+++ b/server/modules/assistant/query_detections_test.go
@@ -1,0 +1,732 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryDetectionsTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name           string
+		params         string
+		mockResults    *model.EventSearchResults
+		mockError      error
+		expectedResult any
+		expectedError  bool
+	}{
+		{
+			name:   "basic detection query",
+			params: `{"oql_query": "so_detection.title:malware AND _index:\"*:so-detection\" AND so_kind:detection", "limit": 10}`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-detection-index",
+						Id:     "detection-1",
+						Payload: map[string]any{
+							"@timestamp":               "2024-01-01T00:00:00Z",
+							"so_detection.id":          "gQKCepgBAWAm-kn2lYs2",
+							"so_detection.createTime":  "2024-11-14T15:03:22Z",
+							"so_detection.userId":      "dcbe6004-f6e0-4579-9f98-9576201ffb29",
+							"so_detection.publicId":    "923421c7-9b1e-45d4-80cc-e21d060c8723",
+							"so_detection.title":       "Security Onion - Grid Node Login Failure (SSH)",
+							"so_detection.severity":    "high",
+							"so_detection.author":      "Security Onion Solutions",
+							"so_detection.category":    "ps_script",
+							"so_detection.description": "Detects when a user fails to login to a grid node via SSH. Review associated logs for username and source IP.",
+							"so_detection.isEnabled":   true,
+							"so_detection.isCommunity": true,
+							"so_detection.engine":      "sigma",
+							"so_detection.language":    "sigma",
+							"so_detection.ruleset":     "__custom__",
+							"so_detection.license":     "DRL",
+						},
+					},
+					{
+						Source: "so-detection-index",
+						Id:     "detection-2",
+						Payload: map[string]any{
+							"@timestamp":               "2024-01-01T00:01:00Z",
+							"so_detection.id":          "hRLDepgBAWAm-kn2mZt3",
+							"so_detection.title":       "CobaltStrike Named Pipe",
+							"so_detection.severity":    "critical",
+							"so_detection.author":      "Community Contributor",
+							"so_detection.category":    "malware",
+							"so_detection.description": "Detects CobaltStrike named pipe usage",
+							"so_detection.isEnabled":   false,
+							"so_detection.isCommunity": false,
+							"so_detection.language":    "suricata",
+							"so_detection.product":     "windows",
+							"so_detection.service":     "sshd",
+						},
+					},
+				},
+				TotalEvents: 2,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: []map[string]any{
+				{
+					"payload": map[string]any{
+						"_id":                      "detection-1",
+						"@timestamp":               "2024-01-01T00:00:00Z",
+						"so_detection.id":          "gQKCepgBAWAm-kn2lYs2",
+						"so_detection.createTime":  "2024-11-14T15:03:22Z",
+						"so_detection.userId":      "dcbe6004-f6e0-4579-9f98-9576201ffb29",
+						"so_detection.publicId":    "923421c7-9b1e-45d4-80cc-e21d060c8723",
+						"so_detection.title":       "Security Onion - Grid Node Login Failure (SSH)",
+						"so_detection.severity":    "high",
+						"so_detection.author":      "Security Onion Solutions",
+						"so_detection.category":    "ps_script",
+						"so_detection.description": "Detects when a user fails to login to a grid node via SSH. Review associated logs for username and source IP.",
+						"so_detection.isEnabled":   true,
+						"so_detection.isCommunity": true,
+						"so_detection.engine":      "sigma",
+						"so_detection.language":    "sigma",
+						"so_detection.ruleset":     "__custom__",
+						"so_detection.license":     "DRL",
+					},
+				},
+				{
+					"payload": map[string]any{
+						"_id":                      "detection-2",
+						"@timestamp":               "2024-01-01T00:01:00Z",
+						"so_detection.id":          "hRLDepgBAWAm-kn2mZt3",
+						"so_detection.title":       "CobaltStrike Named Pipe",
+						"so_detection.severity":    "critical",
+						"so_detection.author":      "Community Contributor",
+						"so_detection.category":    "malware",
+						"so_detection.description": "Detects CobaltStrike named pipe usage",
+						"so_detection.isEnabled":   false,
+						"so_detection.isCommunity": false,
+						"so_detection.language":    "suricata",
+						"so_detection.product":     "windows",
+						"so_detection.service":     "sshd",
+					},
+				},
+			},
+		},
+		{
+			name:   "query with relative time range",
+			params: `{"oql_query": "so_detection.language:sigma AND _index:\"*:so-detection\" AND so_kind:detection", "range_start": "-999d", "range_end": "now", "limit": 5}`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-detection-index",
+						Id:     "detection-3",
+						Payload: map[string]any{
+							"@timestamp":            "2024-01-01T00:00:00Z",
+							"so_detection.id":       "sigma-detection-1",
+							"so_detection.title":    "Sigma Detection Rule",
+							"so_detection.language": "sigma",
+							"so_detection.severity": "medium",
+							"so_detection.author":   "Sigma Community",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: []map[string]any{
+				{
+					"payload": map[string]any{
+						"_id":                   "detection-3",
+						"@timestamp":            "2024-01-01T00:00:00Z",
+						"so_detection.id":       "sigma-detection-1",
+						"so_detection.title":    "Sigma Detection Rule",
+						"so_detection.language": "sigma",
+						"so_detection.severity": "medium",
+						"so_detection.author":   "Sigma Community",
+					},
+				},
+			},
+		},
+		{
+			name:   "query with absolute time range",
+			params: `{"oql_query": "so_detection.severity:critical AND _index:\"*:so-detection\" AND so_kind:detection", "range_start": "2024/01/01 10:00:00 AM", "range_end": "2024/01/01 11:00:00 AM", "limit": 15}`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-detection-index",
+						Id:     "detection-4",
+						Payload: map[string]any{
+							"@timestamp":            "2024-01-01T10:00:00Z",
+							"so_detection.id":       "critical-detection-1",
+							"so_detection.title":    "Critical Security Detection",
+							"so_detection.severity": "critical",
+							"so_detection.category": "malware",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: []map[string]any{
+				{
+					"payload": map[string]any{
+						"_id":                   "detection-4",
+						"@timestamp":            "2024-01-01T10:00:00Z",
+						"so_detection.id":       "critical-detection-1",
+						"so_detection.title":    "Critical Security Detection",
+						"so_detection.severity": "critical",
+						"so_detection.category": "malware",
+					},
+				},
+			},
+		},
+		{
+			name:   "query with legacy query field",
+			params: `{"query": "so_detection.engine:suricata AND _index:\"*:so-detection\" AND so_kind:detection", "limit": 12}`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-detection-index",
+						Id:     "detection-5",
+						Payload: map[string]any{
+							"@timestamp":            "2024-01-01T00:00:00Z",
+							"so_detection.id":       "suricata-detection-1",
+							"so_detection.title":    "Suricata Network Detection",
+							"so_detection.engine":   "suricata",
+							"so_detection.language": "suricata",
+							"so_detection.category": "network",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: []map[string]any{
+				{
+					"payload": map[string]any{
+						"_id":                   "detection-5",
+						"@timestamp":            "2024-01-01T00:00:00Z",
+						"so_detection.id":       "suricata-detection-1",
+						"so_detection.title":    "Suricata Network Detection",
+						"so_detection.engine":   "suricata",
+						"so_detection.language": "suricata",
+						"so_detection.category": "network",
+					},
+				},
+			},
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"oql_query": "invalid json}`,
+			expectedError: true,
+		},
+		{
+			name:          "eventstore error",
+			params:        `{"oql_query": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "limit": 10}`,
+			mockError:     assert.AnError,
+			expectedError: true,
+		},
+		{
+			name:   "no detections found",
+			params: `{"oql_query": "so_detection.title:nonexistent AND _index:\"*:so-detection\" AND so_kind:detection", "limit": 10}`,
+			mockResults: &model.EventSearchResults{
+				Events:  []*model.EventRecord{},
+				Metrics: make(map[string][]*model.EventMetric),
+			},
+			expectedResult: "No detections found",
+		},
+		{
+			name:   "detection with all so_detection fields",
+			params: `{"oql_query": "so_detection.ruleset:community AND _index:\"*:so-detection\" AND so_kind:detection", "limit": 5}`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-detection-index",
+						Id:     "detection-6",
+						Payload: map[string]any{
+							"@timestamp":                 "2024-01-01T00:00:00Z",
+							"so_detection.id":            "comprehensive-detection-1",
+							"so_detection.createTime":    "2024-11-14T15:03:22Z",
+							"so_detection.userId":        "user-123",
+							"so_detection.publicId":      "public-123",
+							"so_detection.title":         "Comprehensive Detection Rule",
+							"so_detection.severity":      "high",
+							"so_detection.author":        "Security Team",
+							"so_detection.category":      "endpoint",
+							"so_detection.description":   "Comprehensive detection for testing",
+							"so_detection.content":       "title: Test Rule\nid: test-123\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '\\\\test.exe'\n  condition: selection",
+							"so_detection.isEnabled":     true,
+							"so_detection.isCommunity":   false,
+							"so_detection.engine":        "sigma",
+							"so_detection.language":      "sigma",
+							"so_detection.overrides":     []string{"override1", "override2"},
+							"so_detection.tags":          []string{"test", "endpoint", "process"},
+							"so_detection.ruleset":       "community",
+							"so_detection.license":       "MIT",
+							"so_detection.sourceCreated": "2024-01-01T00:00:00Z",
+							"so_detection.sourceUpdated": "2024-01-01T12:00:00Z",
+							"so_detection.product":       "windows",
+							"so_detection.service":       "winlogbeat",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: []map[string]any{
+				{
+					"payload": map[string]any{
+						"_id":                        "detection-6",
+						"@timestamp":                 "2024-01-01T00:00:00Z",
+						"so_detection.id":            "comprehensive-detection-1",
+						"so_detection.createTime":    "2024-11-14T15:03:22Z",
+						"so_detection.userId":        "user-123",
+						"so_detection.publicId":      "public-123",
+						"so_detection.title":         "Comprehensive Detection Rule",
+						"so_detection.severity":      "high",
+						"so_detection.author":        "Security Team",
+						"so_detection.category":      "endpoint",
+						"so_detection.description":   "Comprehensive detection for testing",
+						"so_detection.content":       "title: Test Rule\nid: test-123\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '\\\\test.exe'\n  condition: selection",
+						"so_detection.isEnabled":     true,
+						"so_detection.isCommunity":   false,
+						"so_detection.engine":        "sigma",
+						"so_detection.language":      "sigma",
+						"so_detection.overrides":     []string{"override1", "override2"},
+						"so_detection.tags":          []string{"test", "endpoint", "process"},
+						"so_detection.ruleset":       "community",
+						"so_detection.license":       "MIT",
+						"so_detection.sourceCreated": "2024-01-01T00:00:00Z",
+						"so_detection.sourceUpdated": "2024-01-01T12:00:00Z",
+						"so_detection.product":       "windows",
+						"so_detection.service":       "winlogbeat",
+					},
+				},
+			},
+		},
+		{
+			name:   "detection with custom limit",
+			params: `{"oql_query": "so_detection.language:yara AND _index:\"*:so-detection\" AND so_kind:detection", "limit": 50}`,
+			mockResults: &model.EventSearchResults{
+				Events: []*model.EventRecord{
+					{
+						Source: "so-detection-index",
+						Id:     "detection-7",
+						Payload: map[string]any{
+							"@timestamp":            "2024-01-01T00:00:00Z",
+							"so_detection.id":       "yara-detection-1",
+							"so_detection.title":    "YARA Malware Detection",
+							"so_detection.language": "yara",
+							"so_detection.severity": "medium",
+							"so_detection.category": "malware",
+						},
+					},
+				},
+				TotalEvents: 1,
+				Metrics:     make(map[string][]*model.EventMetric),
+			},
+			expectedResult: []map[string]any{
+				{
+					"payload": map[string]any{
+						"_id":                   "detection-7",
+						"@timestamp":            "2024-01-01T00:00:00Z",
+						"so_detection.id":       "yara-detection-1",
+						"so_detection.title":    "YARA Malware Detection",
+						"so_detection.language": "yara",
+						"so_detection.severity": "medium",
+						"so_detection.category": "malware",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock eventstore
+			mockEventstore := server.NewFakeEventstore()
+			if tc.mockResults != nil {
+				mockEventstore.SearchResults = []*model.EventSearchResults{tc.mockResults}
+			}
+			if tc.mockError != nil {
+				mockEventstore.Err = tc.mockError
+			}
+
+			// Create mock server with proper authorization
+			mockServer := server.NewFakeAuthorizedServer(map[string][]string{
+				"test-user-id": {"detections/read"},
+			})
+			mockServer.Eventstore = mockEventstore
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create tool and execute
+			tool := &QueryDetectionsTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "query_detections", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+
+			// Verify search criteria was populated correctly
+			if !tc.expectedError && tc.mockError == nil {
+				assert.Len(t, mockEventstore.InputSearchCriterias, 1)
+				criteria := mockEventstore.InputSearchCriterias[0]
+				assert.NotNil(t, criteria)
+				assert.Contains(t, criteria.RawQuery, "NOT metadata.raw_index:")
+			}
+
+			// Assert result content
+			if tc.expectedResult != nil {
+				if resultStr, ok := tc.expectedResult.(string); ok {
+					// Handle string results (like "No detections found")
+					assert.Equal(t, resultStr, result.Result)
+				} else {
+					// Handle detection results
+					assert.Equal(t, tc.expectedResult, result.Result)
+				}
+			} else {
+				assert.Nil(t, result.Result)
+			}
+		})
+	}
+}
+
+func TestFilterDetections(t *testing.T) {
+	testCases := []struct {
+		name         string
+		events       []*model.EventRecord
+		extraFields  []string
+		expectedLen  int
+		validateFunc func(t *testing.T, result []map[string]any)
+	}{
+		{
+			name: "basic detection with default fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-detection-1",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":               "2024-01-01T00:00:00Z",
+						"so_detection.id":          "detection-id-1",
+						"so_detection.title":       "Test Detection Rule",
+						"so_detection.severity":    "high",
+						"so_detection.author":      "Security Team",
+						"so_detection.category":    "malware",
+						"so_detection.description": "Test detection description",
+						"so_detection.isEnabled":   true,
+						"so_detection.language":    "sigma",
+						"ignored_field":            "this should not appear",
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-detection-1", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "detection-id-1", payload["so_detection.id"])
+				assert.Equal(t, "Test Detection Rule", payload["so_detection.title"])
+				assert.Equal(t, "high", payload["so_detection.severity"])
+				assert.Equal(t, "Security Team", payload["so_detection.author"])
+				assert.Equal(t, "malware", payload["so_detection.category"])
+				assert.Equal(t, "Test detection description", payload["so_detection.description"])
+				assert.Equal(t, true, payload["so_detection.isEnabled"])
+				assert.Equal(t, "sigma", payload["so_detection.language"])
+				assert.NotContains(t, payload, "ignored_field")
+			},
+		},
+		{
+			name: "detection with all so_detection fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-detection-2",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":                 "2024-01-01T00:00:00Z",
+						"so_detection.id":            "detection-id-2",
+						"so_detection.createTime":    "2024-11-14T15:03:22Z",
+						"so_detection.userId":        "user-456",
+						"so_detection.publicId":      "public-456",
+						"so_detection.title":         "Comprehensive Detection",
+						"so_detection.severity":      "critical",
+						"so_detection.author":        "Advanced Team",
+						"so_detection.category":      "network",
+						"so_detection.description":   "Advanced network detection",
+						"so_detection.content":       "rule content here",
+						"so_detection.isEnabled":     false,
+						"so_detection.isCommunity":   true,
+						"so_detection.engine":        "suricata",
+						"so_detection.language":      "suricata",
+						"so_detection.overrides":     []string{"override1"},
+						"so_detection.tags":          []string{"network", "ids"},
+						"so_detection.ruleset":       "community",
+						"so_detection.license":       "GPL",
+						"so_detection.sourceCreated": "2024-01-01T00:00:00Z",
+						"so_detection.sourceUpdated": "2024-01-01T12:00:00Z",
+						"so_detection.product":       "linux",
+						"so_detection.service":       "suricata",
+						"extra_field":                "should not appear",
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-detection-2", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "detection-id-2", payload["so_detection.id"])
+				assert.Equal(t, "2024-11-14T15:03:22Z", payload["so_detection.createTime"])
+				assert.Equal(t, "user-456", payload["so_detection.userId"])
+				assert.Equal(t, "public-456", payload["so_detection.publicId"])
+				assert.Equal(t, "Comprehensive Detection", payload["so_detection.title"])
+				assert.Equal(t, "critical", payload["so_detection.severity"])
+				assert.Equal(t, "Advanced Team", payload["so_detection.author"])
+				assert.Equal(t, "network", payload["so_detection.category"])
+				assert.Equal(t, "Advanced network detection", payload["so_detection.description"])
+				assert.Equal(t, "rule content here", payload["so_detection.content"])
+				assert.Equal(t, false, payload["so_detection.isEnabled"])
+				assert.Equal(t, true, payload["so_detection.isCommunity"])
+				assert.Equal(t, "suricata", payload["so_detection.engine"])
+				assert.Equal(t, "suricata", payload["so_detection.language"])
+				assert.Equal(t, []string{"override1"}, payload["so_detection.overrides"])
+				assert.Equal(t, []string{"network", "ids"}, payload["so_detection.tags"])
+				assert.Equal(t, "community", payload["so_detection.ruleset"])
+				assert.Equal(t, "GPL", payload["so_detection.license"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["so_detection.sourceCreated"])
+				assert.Equal(t, "2024-01-01T12:00:00Z", payload["so_detection.sourceUpdated"])
+				assert.Equal(t, "linux", payload["so_detection.product"])
+				assert.Equal(t, "suricata", payload["so_detection.service"])
+				assert.NotContains(t, payload, "extra_field")
+			},
+		},
+		{
+			name: "detection with extra fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-detection-3",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":            "2024-01-01T00:00:00Z",
+						"so_detection.id":       "detection-id-3",
+						"so_detection.title":    "Custom Detection",
+						"so_detection.severity": "medium",
+						"custom_field1":         "custom_value1",
+						"custom_field2":         "custom_value2",
+						"ignored_field":         "ignored",
+					},
+				},
+			},
+			extraFields: []string{"custom_field1", "custom_field2"},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-detection-3", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "detection-id-3", payload["so_detection.id"])
+				assert.Equal(t, "Custom Detection", payload["so_detection.title"])
+				assert.Equal(t, "medium", payload["so_detection.severity"])
+				assert.Equal(t, "custom_value1", payload["custom_field1"])
+				assert.Equal(t, "custom_value2", payload["custom_field2"])
+				assert.NotContains(t, payload, "ignored_field")
+			},
+		},
+		{
+			name: "multiple detections",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-detection-4",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":            "2024-01-01T00:00:00Z",
+						"so_detection.id":       "detection-id-4",
+						"so_detection.title":    "First Detection",
+						"so_detection.severity": "high",
+						"so_detection.language": "sigma",
+					},
+				},
+				{
+					Id:     "test-detection-5",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":            "2024-01-01T00:01:00Z",
+						"so_detection.id":       "detection-id-5",
+						"so_detection.title":    "Second Detection",
+						"so_detection.severity": "low",
+						"so_detection.language": "yara",
+					},
+				},
+			},
+			expectedLen: 2,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				assert.Equal(t, "test-detection-4", result[0]["payload"].(map[string]any)["_id"])
+				assert.Equal(t, "test-detection-5", result[1]["payload"].(map[string]any)["_id"])
+				assert.Equal(t, "First Detection", result[0]["payload"].(map[string]any)["so_detection.title"])
+				assert.Equal(t, "Second Detection", result[1]["payload"].(map[string]any)["so_detection.title"])
+				assert.Equal(t, "high", result[0]["payload"].(map[string]any)["so_detection.severity"])
+				assert.Equal(t, "low", result[1]["payload"].(map[string]any)["so_detection.severity"])
+				assert.Equal(t, "sigma", result[0]["payload"].(map[string]any)["so_detection.language"])
+				assert.Equal(t, "yara", result[1]["payload"].(map[string]any)["so_detection.language"])
+			},
+		},
+		{
+			name: "missing fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-detection-6",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":            "2024-01-01T00:00:00Z",
+						"so_detection.id":       "detection-id-6",
+						"so_detection.title":    "Minimal Detection",
+						"so_detection.severity": "medium",
+						// Missing many default fields
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-detection-6", payload["_id"])
+				assert.Equal(t, "2024-01-01T00:00:00Z", payload["@timestamp"])
+				assert.Equal(t, "detection-id-6", payload["so_detection.id"])
+				assert.Equal(t, "Minimal Detection", payload["so_detection.title"])
+				assert.Equal(t, "medium", payload["so_detection.severity"])
+				// Missing fields should not be present
+				assert.NotContains(t, payload, "so_detection.description")
+				assert.NotContains(t, payload, "so_detection.author")
+			},
+		},
+		{
+			name: "nil field values are excluded",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-detection-7",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":               "2024-01-01T00:00:00Z",
+						"so_detection.id":          "detection-id-7",
+						"so_detection.title":       "Detection with Nil Fields",
+						"so_detection.severity":    "low",
+						"so_detection.description": nil,
+						"so_detection.author":      nil,
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-detection-7", payload["_id"])
+				assert.Equal(t, "Detection with Nil Fields", payload["so_detection.title"])
+				assert.Equal(t, "low", payload["so_detection.severity"])
+				// Nil fields should not be included
+				assert.NotContains(t, payload, "so_detection.description")
+				assert.NotContains(t, payload, "so_detection.author")
+			},
+		},
+		{
+			name: "suricata detection with network fields",
+			events: []*model.EventRecord{
+				{
+					Id:     "test-detection-9",
+					Source: "so-detection-index",
+					Payload: map[string]any{
+						"@timestamp":            "2024-01-01T00:00:00Z",
+						"so_detection.id":       "suricata-detection-1",
+						"so_detection.title":    "Suricata Network Rule",
+						"so_detection.language": "suricata",
+						"so_detection.engine":   "suricata",
+						"so_detection.severity": "medium",
+						"so_detection.category": "network",
+						"so_detection.product":  "linux",
+						"so_detection.service":  "suricata",
+						"so_detection.tags":     []string{"network", "intrusion"},
+					},
+				},
+			},
+			expectedLen: 1,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				payload := result[0]["payload"].(map[string]any)
+				assert.Equal(t, "test-detection-9", payload["_id"])
+				assert.Equal(t, "Suricata Network Rule", payload["so_detection.title"])
+				assert.Equal(t, "suricata", payload["so_detection.language"])
+				assert.Equal(t, "suricata", payload["so_detection.engine"])
+				assert.Equal(t, "medium", payload["so_detection.severity"])
+				assert.Equal(t, "network", payload["so_detection.category"])
+				assert.Equal(t, "linux", payload["so_detection.product"])
+				assert.Equal(t, "suricata", payload["so_detection.service"])
+				assert.Equal(t, []string{"network", "intrusion"}, payload["so_detection.tags"])
+			},
+		},
+		{
+			name:        "empty detections list",
+			events:      []*model.EventRecord{},
+			expectedLen: 0,
+			validateFunc: func(t *testing.T, result []map[string]any) {
+				assert.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterDetections(tc.events, tc.extraFields...)
+
+			assert.Len(t, result, tc.expectedLen)
+
+			if tc.validateFunc != nil {
+				tc.validateFunc(t, result)
+			}
+		})
+	}
+}
+
+func TestQueryDetectionsTool_GetName(t *testing.T) {
+	tool := &QueryDetectionsTool{}
+	assert.Equal(t, "query_detections", tool.GetName())
+}
+
+func TestQueryDetectionsTool_GetDescription(t *testing.T) {
+	tool := &QueryDetectionsTool{}
+	description := tool.GetDescription()
+	assert.Contains(t, description, "Execute OQL queries to retrieve Security Onion detections")
+	assert.Contains(t, description, "_index:\"*:so-detection\" AND so_kind:detection")
+	assert.Contains(t, description, "999 days ago")
+}
+
+func TestQueryDetectionsTool_GetSchema(t *testing.T) {
+	tool := &QueryDetectionsTool{}
+	schema := tool.GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+	assert.Contains(t, schema.Json.Required, "oql_query")
+
+	// Check that all expected properties are present
+	expectedProperties := []string{"oql_query", "range_start", "range_end", "range_format", "limit"}
+	for _, prop := range expectedProperties {
+		assert.Contains(t, schema.Json.Properties, prop)
+	}
+
+	// Check oql_query property
+	oqlQuery := schema.Json.Properties["oql_query"]
+	assert.Equal(t, "string", oqlQuery.Type)
+	assert.Contains(t, oqlQuery.Description, "so_detection.id")
+	assert.Contains(t, oqlQuery.Description, "so_detection.title")
+	assert.Contains(t, oqlQuery.Description, "so_detection.severity")
+
+	// Check limit property
+	limit := schema.Json.Properties["limit"]
+	assert.Equal(t, "integer", limit.Type)
+	assert.Equal(t, 100, limit.Default)
+}

--- a/server/modules/assistant/query_detections_test.go
+++ b/server/modules/assistant/query_detections_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/mock"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestQueryDetectionsTool_Execute(t *testing.T) {
@@ -345,20 +347,32 @@ func TestQueryDetectionsTool_Execute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create mock eventstore
-			mockEventstore := server.NewFakeEventstore()
-			if tc.mockResults != nil {
-				mockEventstore.SearchResults = []*model.EventSearchResults{tc.mockResults}
-			}
-			if tc.mockError != nil {
-				mockEventstore.Err = tc.mockError
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create mock detectionstore
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+			if tc.mockResults != nil || tc.mockError != nil {
+				mockDetectionstore.EXPECT().
+					QueryWithRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) (*model.EventSearchResults, error) {
+						// Verify the query contains the metadata filter
+						if !assert.Contains(t, query, `NOT metadata.raw_index:"logs-soc-so"`) {
+							t.Errorf("Query should contain metadata filter, got: %s", query)
+						}
+						if tc.mockError != nil {
+							return nil, tc.mockError
+						}
+						return tc.mockResults, nil
+					}).
+					Times(1)
 			}
 
 			// Create mock server with proper authorization
 			mockServer := server.NewFakeAuthorizedServer(map[string][]string{
 				"test-user-id": {"detections/read"},
 			})
-			mockServer.Eventstore = mockEventstore
+			mockServer.Detectionstore = mockDetectionstore
 
 			// Create context with user ID
 			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
@@ -377,14 +391,6 @@ func TestQueryDetectionsTool_Execute(t *testing.T) {
 			assert.NotNil(t, result)
 			assert.Equal(t, "query_detections", result.ToolName)
 			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
-
-			// Verify search criteria was populated correctly
-			if !tc.expectedError && tc.mockError == nil {
-				assert.Len(t, mockEventstore.InputSearchCriterias, 1)
-				criteria := mockEventstore.InputSearchCriterias[0]
-				assert.NotNil(t, criteria)
-				assert.Contains(t, criteria.RawQuery, "NOT metadata.raw_index:")
-			}
 
 			// Assert result content
 			if tc.expectedResult != nil {

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -153,16 +153,24 @@ func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, pa
 		metricLimit = 10000
 	}
 
+	var timeFormat string
+
+	if args.RangeFormat != "" {
+		timeFormat = args.RangeFormat
+	} else {
+		timeFormat = "2006-01-02 3:04:05 PM"
+	}
+
 	var timeRange string
 
 	if args.RangeStart != "" || args.RangeEnd != "" {
-		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, timeFormat)
 	}
 
 	criteria := model.NewEventSearchCriteria()
 	err = criteria.Populate(query,
 		timeRange,
-		"2006/01/02 3:04:05 PM",
+		timeFormat,
 		zone,
 		strconv.Itoa(metricLimit),
 		strconv.Itoa(eventLimit))

--- a/server/modules/assistant/query_events.go
+++ b/server/modules/assistant/query_events.go
@@ -158,7 +158,7 @@ func (t *QueryEventsTool) Execute(ctx context.Context, server *server.Server, pa
 	if args.RangeFormat != "" {
 		timeFormat = args.RangeFormat
 	} else {
-		timeFormat = "2006-01-02 3:04:05 PM"
+		timeFormat = "2006/01/02 3:04:05 PM"
 	}
 
 	var timeRange string

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -221,7 +221,7 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 	}
 
 	result.Result = fmt.Sprintf(
-		"Successfully %s %d detections.\n%s=%d, Audited=%d, Filtered=%d, Errors=%v, UpdateDuration=%s, SyncDuration=%s",
+		"Successfully %s %d detections. %s=%d, Audited=%d, Filtered=%d, Errors=%v, UpdateDuration=%s, SyncDuration=%s",
 		opString,
 		bulkStats.Updated,
 		opString,

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -161,24 +161,22 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 		detectLimit = 10000
 	}
 
-	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
+	detectEvents, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
 	if err != nil {
 		return nil, fmt.Errorf("unable to search for detections with query %s: %w", query, err)
 	}
 
-	if len(detectObjects) == 0 {
+	detects, err := srv.Detectionstore.ConvertEventsToDetections(ctx, detectEvents)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert events to detections: %w", err)
+	}
+
+	if len(detects) == 0 {
 		result.Result = "No detections found"
 		return result, nil
 	}
 
-	logger.WithField("detectionsFound", len(detectObjects)).Info("query executed successfully")
-
-	detects := []*model.Detection{}
-
-	for _, d := range detectObjects {
-		det := d.(*model.Detection)
-		detects = append(detects, det)
-	}
+	logger.WithField("detectionsFound", len(detects)).Info("query executed successfully")
 
 	bulkStats, err := srv.Detectionstore.BulkUpdateDetections(ctx, enableBool, detects, logger)
 	if err != nil {

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -116,7 +116,7 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 
 	err = srv.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("user is not authorized to write detections: %w", err)
 	}
 
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
@@ -136,14 +136,14 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 
 	err = json.Unmarshal([]byte(params), args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't unmarshal params: %w", err)
 	}
 
 	result.Parameters = args
 
 	enableBool, err := strconv.ParseBool(args.Enable)
 	if err != nil {
-		return nil, fmt.Errorf("invalid value for argument \"enable\": %w", err)
+		return nil, fmt.Errorf("invalid value %s for argument \"enable\": %w", args.Enable, err)
 	}
 
 	query := args.SearchFilter
@@ -163,7 +163,7 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 
 	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to search for detections with query %s: %w", query, err)
 	}
 
 	if len(detectObjects) == 0 {
@@ -221,7 +221,7 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 
 	if len(errMap) != 0 {
 		logger.WithField("errMap", errMap).Error("unable to sync detections")
-		return nil, fmt.Errorf("unable to sync detections")
+		return nil, fmt.Errorf("unable to sync detections: %v", errMap)
 	}
 
 	syncDur := time.Since(syncStart)

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -1,0 +1,136 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+)
+
+func init() {
+	t := &ToggleDetectionsTool{}
+	knownTools[t.GetName()] = t
+}
+
+type ToggleDetectionsTool struct{}
+
+func (t *ToggleDetectionsTool) GetName() string {
+	return "toggle_detections"
+}
+
+func (t *ToggleDetectionsTool) GetDescription() string {
+	return ""
+}
+
+func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"search_filter": {
+					Type:        "string",
+					Description: "OQL search filter to find matching detections.",
+				},
+				"enable": {
+					Type:        "bool",
+					Description: "This is a true/false value based on whether the user wants to enable or disable the detections at hand. A value of true corresponds to the enable operation, and false corresponds to the disable operation.",
+				},
+				"range_start": {
+					Type:        "string",
+					Description: "Optional start time for the query range (e.g., \"-1h\", \"2023/10/26 10:00:00 AM\"). Default is 24 hours ago (\"-24h\")",
+				},
+				"range_end": {
+					Type:        "string",
+					Description: "Optional end time for the query range (e.g., \"now\", \"2023/10/26 12:00:00 PM\"). Default is now.",
+				},
+				"range_format": {
+					Type:        "string",
+					Description: "Format of the date range (default: \"2006/01/02 3:04:05 PM\"). The format must be specified using Go's time package's reference layout format. Required if either range_start or range_end is provided.",
+				},
+			},
+			Required: []string{"search_filter"},
+		},
+	}
+}
+
+type toggleDetectionsArgs struct {
+	SearchFilter string `json:"search_filter"`
+	Enable       bool   `json:"enable"`
+	RangeStart   string `json:"range_start,omitempty"`
+	RangeEnd     string `json:"range_end,omitempty"`
+	RangeFormat  string `json:"range_format,omitempty"`
+}
+
+func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &toggleDetectionsArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Parameters = args
+
+	zone := "UTC"
+	query := args.SearchFilter
+
+	if query != "" && !strings.Contains(query, "NOT metadata.raw_index:") {
+		query = fmt.Sprintf(`(%s) AND NOT metadata.raw_index:"logs-soc-so"`, query)
+	} else if query == "" {
+		query = `NOT metadata.raw_index:"logs-soc-so"`
+	}
+
+	var timeRange string
+
+	if args.RangeStart != "" || args.RangeEnd != "" {
+		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
+	}
+
+	criteria := model.NewEventSearchCriteria()
+	err = criteria.Populate(
+		query,
+		timeRange,
+		"2006/01/02 3:04:05 PM",
+		zone,
+		"0",
+		"10000",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	criteria.SortFields = []*model.SortCriteria{
+		{
+			Field: "@timestamp",
+			Order: "desc",
+		},
+	}
+}

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -103,7 +103,7 @@ type toggleDetectionsArgs struct {
 	RangeFormat  string `json:"range_format,omitempty"`
 }
 
-func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
 	logger := log.FromContext(ctx)
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
@@ -143,12 +143,12 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Serve
 		query = `NOT metadata.raw_index:"logs-soc-so"`
 	}
 
-	err = server.CheckAuthorized(ctx, "write", "detections")
+	err = srv.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
 		return nil, err
 	}
 
-	detectObjects, err := server.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat)
+	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -167,11 +167,51 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Serve
 		detects = append(detects, det)
 	}
 
-	bulkStats, err := server.Detectionstore.BulkUpdateDetections(ctx, enableBool, detects, logger)
+	bulkStats, err := srv.Detectionstore.BulkUpdateDetections(ctx, enableBool, detects, logger)
 	if err != nil {
 		logger.WithError(err).Error("error updating detections")
 		return nil, fmt.Errorf("error updating detections: %w", err)
 	}
+
+	syncDetects := bulkStats.NeedToSync
+	syncStart := time.Now()
+	errMap := map[string]string{}
+
+	byEngine := map[model.EngineName][]*model.Detection{}
+	for _, detectCurr := range syncDetects {
+		byEngine[detectCurr.Engine] = append(byEngine[detectCurr.Engine], detectCurr)
+	}
+
+	srv.DetectionEngines.Range(func(n, engineInt interface{}) bool {
+		name := n.(model.EngineName)
+		engine := engineInt.(server.DetectionEngine)
+
+		if len(byEngine[name]) != 0 {
+			var eMap map[string]string
+
+			eMap, err = engine.SyncLocalDetections(ctx, byEngine[name])
+			for sid, e := range eMap {
+				errMap[sid] = e
+			}
+			if err != nil {
+				return false
+			}
+		}
+
+		return true
+	})
+
+	if err != nil {
+		logger.WithError(err).Error("unable to sync detections")
+		return nil, fmt.Errorf("unable to sync detections: %w", err)
+	}
+
+	if len(errMap) != 0 {
+		logger.WithField("errMap", errMap).Error("unable to sync detections")
+		return nil, fmt.Errorf("unable to sync detections")
+	}
+
+	syncDur := time.Since(syncStart)
 
 	var opString string
 	if enableBool {
@@ -181,13 +221,16 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Serve
 	}
 
 	result.Result = fmt.Sprintf(
-		"%s=%d, Audited=%d, Filtered=%d, Errs=%v, Duration=%s",
+		"Successfully %s %d detections.\n%s=%d, Audited=%d, Filtered=%d, Errors=%v, UpdateDuration=%s, SyncDuration=%s",
+		opString,
+		bulkStats.Updated,
 		opString,
 		bulkStats.Updated,
 		bulkStats.Audited,
 		bulkStats.Filtered,
 		bulkStats.ErrMap,
 		bulkStats.UpdateDuration,
+		syncDur,
 	)
 
 	return result, nil

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -89,6 +89,10 @@ func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
 					Type:        "string",
 					Description: "Format of the date range (default: \"2006/01/02 3:04:05 PM\"). The format must be specified using Go's time package's reference layout format. Required if either range_start or range_end is provided.",
 				},
+				"limit": {
+					Type:        "integer",
+					Description: "The maximum number of detections to return. Unless some kind of limit is applicable to the user's request, this field should be left out.",
+				},
 			},
 			Required: []string{"search_filter"},
 		},
@@ -101,6 +105,7 @@ type toggleDetectionsArgs struct {
 	RangeStart   string `json:"range_start,omitempty"`
 	RangeEnd     string `json:"range_end,omitempty"`
 	RangeFormat  string `json:"range_format,omitempty"`
+	Limit        int    `json:"limit"`
 }
 
 func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
@@ -143,12 +148,19 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 		query = `NOT metadata.raw_index:"logs-soc-so"`
 	}
 
+	var detectLimit int
+	if args.Limit > 0 {
+		detectLimit = args.Limit
+	} else {
+		detectLimit = 10000
+	}
+
 	err = srv.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
 		return nil, err
 	}
 
-	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat)
+	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -187,6 +187,7 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 	syncDetects := bulkStats.NeedToSync
 	syncStart := time.Now()
 	errMap := map[string]string{}
+	errList := []error{}
 
 	byEngine := map[model.EngineName][]*model.Detection{}
 	for _, detectCurr := range syncDetects {
@@ -205,16 +206,16 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 				errMap[sid] = e
 			}
 			if err != nil {
-				return false
+				errList = append(errList, err)
 			}
 		}
 
 		return true
 	})
 
-	if err != nil {
+	if len(errList) != 0 {
 		logger.WithError(err).Error("unable to sync detections")
-		return nil, fmt.Errorf("unable to sync detections: %w", err)
+		return nil, fmt.Errorf("unable to sync detections: %v", errList)
 	}
 
 	if len(errMap) != 0 {

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,8 +73,9 @@ func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
 						"- @timestamp: The date and time when this detection was last created/updated/modified. Example: \"2025-11-12T19:38:17.413984706Z\"",
 				},
 				"enable": {
-					Type:        "bool",
-					Description: "This is a true/false value based on whether the user wants to enable or disable the detections at hand. A value of true corresponds to the enable operation, and false corresponds to the disable operation.",
+					Type: "string",
+					Description: "This is a \"true\"/\"false\" value based on whether the user wants to enable or disable the detections at hand. A value of \"true\" corresponds to the enable operation, and \"false\" corresponds to the disable operation.\n" +
+						"*IMPORTANT* This can only have one of two values: \"true\" or \"false\".",
 				},
 				"range_start": {
 					Type:        "string",
@@ -95,7 +97,7 @@ func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
 
 type toggleDetectionsArgs struct {
 	SearchFilter string `json:"search_filter"`
-	Enable       bool   `json:"enable"`
+	Enable       string `json:"enable" enums:"true,false"`
 	RangeStart   string `json:"range_start,omitempty"`
 	RangeEnd     string `json:"range_end,omitempty"`
 	RangeFormat  string `json:"range_format,omitempty"`
@@ -127,6 +129,11 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Serve
 	}
 
 	result.Parameters = args
+
+	enableBool, err := strconv.ParseBool(args.Enable)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value for argument \"enable\": %w", err)
+	}
 
 	query := args.SearchFilter
 
@@ -160,14 +167,14 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Serve
 		detects = append(detects, det)
 	}
 
-	bulkStats, err := server.Detectionstore.BulkUpdateDetections(ctx, args.Enable, detects, logger)
+	bulkStats, err := server.Detectionstore.BulkUpdateDetections(ctx, enableBool, detects, logger)
 	if err != nil {
 		logger.WithError(err).Error("error updating detections")
 		return nil, fmt.Errorf("error updating detections: %w", err)
 	}
 
 	var opString string
-	if args.Enable {
+	if enableBool {
 		opString = "Enabled"
 	} else {
 		opString = "Disabled"

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -114,6 +114,11 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
 
+	err = srv.CheckAuthorized(ctx, "write", "detections")
+	if err != nil {
+		return nil, err
+	}
+
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
 
 	args := &toggleDetectionsArgs{}
@@ -154,11 +159,6 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, srv *server.Server, 
 		detectLimit = args.Limit
 	} else {
 		detectLimit = 10000
-	}
-
-	err = srv.CheckAuthorized(ctx, "write", "detections")
-	if err != nil {
-		return nil, err
 	}
 
 	detectObjects, err := srv.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat, detectLimit)

--- a/server/modules/assistant/toggle_detections.go
+++ b/server/modules/assistant/toggle_detections.go
@@ -30,7 +30,13 @@ func (t *ToggleDetectionsTool) GetName() string {
 }
 
 func (t *ToggleDetectionsTool) GetDescription() string {
-	return ""
+	return "Enable or disable detections in Security Onion (per the user's request) by querying for them with a search filter.\n" +
+		"- Search for detections by referencing any potentially relevant field(s), whichever you see fit from the ones described to you.\n" +
+		"- *IMPORTANT* All queries should include `AND _index:\"*:so-detection\" AND so_kind:detection` appended to the end. The quotes around *:so-detection MUST be included.\n" +
+		"- When searching for detections, specify a date range of 999 days ago unless advised otherwise.\n" +
+		"- Examples for wild cards in the oql_query:\n" +
+		"  - Search terms cannot begin with a wildcard (e.g., `*xyz` the wildcard is ignored, but `xyz*` is valid)\n" +
+		"  - When using wildcards, do not wrap the value in quotes, instead use parentheses (e.g., `so_detection.title:(A B*)` is valid, but `so_detection.title:\"A B*\"` will not work as expected)\n"
 }
 
 func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
@@ -39,8 +45,31 @@ func (t *ToggleDetectionsTool) GetSchema() model.JSONSchema {
 			Type: "object",
 			Properties: map[string]model.ToolSchemaProperty{
 				"search_filter": {
-					Type:        "string",
-					Description: "OQL search filter to find matching detections.",
+					Type: "string",
+					Description: "OQL search filter to find matching detections. Here is a run-down of each of the potentially relevant fields you might want to use in your query:\n" +
+						"- so_detection.id: The ID assigned to this detection by the server. This is a read-only field. Example: \"gQKCepgBAWAm-kn2lYs2\"\n" +
+						"- so_detection.createTime: The date and time that this detection was created. This is a read-only field. Example: \"2024-11-14T15:03:22Z\"\n" +
+						"- so_detection.userId: The ID of the user that created this detection. Example: \"dcbe6004-f6e0-4579-9f98-9576201ffb29\"\n" +
+						"- so_detection.publicId: The public ID shared across all Security Onion grids. Example: \"923421c7-9b1e-45d4-80cc-e21d060c8723\"\n" +
+						"- so_detection.title: Summarized title of the detection. Example: \"Security Onion - Grid Node Login Failure (SSH)\"\n" +
+						"- so_detection.severity: The severity classification of this detection. This MUST be either \"unknown\", \"informational\", \"low\", \"medium\", \"high\", or \"critical\".\n" +
+						"- so_detection.author: The original author of this detection. This can be a mixture of email address, organization name, first name, or any freeform value. Example: \"Security Onion Solutions\"\n" +
+						"- so_detection.category: Used for categorizing this detection into a broader grouping such as firewalls or web servers. Example: \"ps_script\"\n" +
+						"- so_detection.description: Brief explanation of this detection. Example: \"Detects when a user fails to login to a grid node via SSH. Review associated logs for username and source IP.\"\n" +
+						"- so_detection.content: The underlying detection rule source content. Example: \"title: CobaltStrike Named Pipe\\nid: ...\\n logsource:\\n ...\\ncondition: selection\\nfalsepositives:\\n...\"\n" +
+						"- so_detection.isEnabled: Indicates whether this detection is currently enabled in the Security Onion grid. Example: true\n" +
+						"- so_detection.isCommunity: Indicates whether this detection originated from a community ruleset. Duplicated detections will show 'false'. Example: true\n" +
+						"- so_detection.engine: The engine that processes this detection.\n" +
+						"- so_detection.language: The language that this detection uses. This MUST be either \"sigma\", \"suricata\", or \"yara\".\n" +
+						"- so_detection.overrides: A list of tuning overrides that apply to this detection.\n" +
+						"- so_detection.tags: An optional list of user-defined tags, useful for grouping similar detections together.\n" +
+						"- so_detection.ruleset: The name of the ruleset from which this detection originated, or __custom__ if the ruleset was created outside of a ruleset. Example: \"__custom__\"\n" +
+						"- so_detection.license: The license that applies to this detection. Example: \"DRL\"\n" +
+						"- so_detection.sourceCreated: The date and time when the underlying detection rule source was created. This is not when the detection was added to this grid.\n" +
+						"- so_detection.sourceUpdated: The date and time when the underlying detection rule source was last updated. This is not when the detection was updated in this grid.\n" +
+						"- so_detection.product: Used by Sigma rules for filtering log outputs to a specific product, such as the Windows eventlog types. Example: \"windows\"\n" +
+						"- so_detection.service: Used by Sigma rules for filtering a subset of log outputs to a specific server. Example: \"sshd\"\n" +
+						"- @timestamp: The date and time when this detection was last created/updated/modified. Example: \"2025-11-12T19:38:17.413984706Z\"",
 				},
 				"enable": {
 					Type:        "bool",
@@ -99,7 +128,6 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Serve
 
 	result.Parameters = args
 
-	zone := "UTC"
 	query := args.SearchFilter
 
 	if query != "" && !strings.Contains(query, "NOT metadata.raw_index:") {
@@ -108,29 +136,52 @@ func (t *ToggleDetectionsTool) Execute(ctx context.Context, server *server.Serve
 		query = `NOT metadata.raw_index:"logs-soc-so"`
 	}
 
-	var timeRange string
-
-	if args.RangeStart != "" || args.RangeEnd != "" {
-		timeRange = parseRangeAllowRelative(args.RangeStart, args.RangeEnd, args.RangeFormat)
-	}
-
-	criteria := model.NewEventSearchCriteria()
-	err = criteria.Populate(
-		query,
-		timeRange,
-		"2006/01/02 3:04:05 PM",
-		zone,
-		"0",
-		"10000",
-	)
+	err = server.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
 		return nil, err
 	}
 
-	criteria.SortFields = []*model.SortCriteria{
-		{
-			Field: "@timestamp",
-			Order: "desc",
-		},
+	detectObjects, err := server.Detectionstore.QueryWithRange(ctx, query, args.RangeStart, args.RangeEnd, args.RangeFormat)
+	if err != nil {
+		return nil, err
 	}
+
+	if len(detectObjects) == 0 {
+		result.Result = "No detections found"
+		return result, nil
+	}
+
+	logger.WithField("detectionsFound", len(detectObjects)).Info("query executed successfully")
+
+	detects := []*model.Detection{}
+
+	for _, d := range detectObjects {
+		det := d.(*model.Detection)
+		detects = append(detects, det)
+	}
+
+	bulkStats, err := server.Detectionstore.BulkUpdateDetections(ctx, args.Enable, detects, logger)
+	if err != nil {
+		logger.WithError(err).Error("error updating detections")
+		return nil, fmt.Errorf("error updating detections: %w", err)
+	}
+
+	var opString string
+	if args.Enable {
+		opString = "Enabled"
+	} else {
+		opString = "Disabled"
+	}
+
+	result.Result = fmt.Sprintf(
+		"%s=%d, Audited=%d, Filtered=%d, Errs=%v, Duration=%s",
+		opString,
+		bulkStats.Updated,
+		bulkStats.Audited,
+		bulkStats.Filtered,
+		bulkStats.ErrMap,
+		bulkStats.UpdateDuration,
+	)
+
+	return result, nil
 }

--- a/server/modules/assistant/toggle_detections_test.go
+++ b/server/modules/assistant/toggle_detections_test.go
@@ -8,6 +8,7 @@ package assistant
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apex/log"
@@ -117,6 +118,58 @@ func (f *FakeDetectionstore) ConvertObjectToDocument(ctx context.Context, kind s
 	return nil, "", nil
 }
 
+// FakeDetectionEngine implements the DetectionEngine interface for testing
+type FakeDetectionEngine struct {
+	SyncError    error
+	SyncErrorMap map[string]string
+}
+
+func (f *FakeDetectionEngine) ValidateRule(rule string) (string, error) {
+	return rule, nil
+}
+
+func (f *FakeDetectionEngine) SyncLocalDetections(ctx context.Context, detections []*model.Detection) (map[string]string, error) {
+	if f.SyncError != nil {
+		return nil, f.SyncError
+	}
+	if f.SyncErrorMap != nil {
+		return f.SyncErrorMap, nil
+	}
+	return map[string]string{}, nil
+}
+
+func (f *FakeDetectionEngine) ConvertRule(ctx context.Context, detect *model.Detection) (string, error) {
+	return detect.Content, nil
+}
+
+func (f *FakeDetectionEngine) ExtractDetails(detect *model.Detection) error {
+	return nil
+}
+
+func (f *FakeDetectionEngine) InterruptSync(forceFull bool, notify bool) {
+	// No-op for testing
+}
+
+func (f *FakeDetectionEngine) DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error) {
+	return detection, nil
+}
+
+func (f *FakeDetectionEngine) GetState() *model.EngineState {
+	return &model.EngineState{}
+}
+
+func (f *FakeDetectionEngine) GenerateUnusedPublicId(ctx context.Context) (string, error) {
+	return "test-public-id", nil
+}
+
+func (f *FakeDetectionEngine) ApplyFilters(detect *model.Detection) (bool, error) {
+	return false, nil
+}
+
+func (f *FakeDetectionEngine) MergeAuxiliaryData(detect *model.Detection) error {
+	return nil
+}
+
 func TestToggleDetectionsTool_Execute(t *testing.T) {
 	testCases := []struct {
 		name               string
@@ -153,8 +206,9 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				Filtered:       0,
 				ErrMap:         map[string]string{},
 				UpdateDuration: 100000000, // 100ms in nanoseconds
+				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Enabled=2, Audited=2, Filtered=0, Errs=map[], Duration=100ms",
+			expectedResult:     "Successfully Enabled 2 detections.\nEnabled=2, Audited=2, Filtered=0, Errors=map[], UpdateDuration=100ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 2,
 		},
@@ -175,8 +229,9 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				Filtered:       0,
 				ErrMap:         map[string]string{},
 				UpdateDuration: 50000000, // 50ms in nanoseconds
+				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Disabled=1, Audited=1, Filtered=0, Errs=map[], Duration=50ms",
+			expectedResult:     "Successfully Disabled 1 detections.\nDisabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=50ms, SyncDuration=",
 			expectedEnable:     false,
 			expectedDetections: 1,
 		},
@@ -197,8 +252,9 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				Filtered:       0,
 				ErrMap:         map[string]string{},
 				UpdateDuration: 75000000, // 75ms in nanoseconds
+				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Enabled=1, Audited=1, Filtered=0, Errs=map[], Duration=75ms",
+			expectedResult:     "Successfully Enabled 1 detections.\nEnabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=75ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
 		},
@@ -219,8 +275,9 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				Filtered:       0,
 				ErrMap:         map[string]string{},
 				UpdateDuration: 60000000, // 60ms in nanoseconds
+				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Disabled=1, Audited=1, Filtered=0, Errs=map[], Duration=60ms",
+			expectedResult:     "Successfully Disabled 1 detections.\nDisabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=60ms, SyncDuration=",
 			expectedEnable:     false,
 			expectedDetections: 1,
 		},
@@ -249,8 +306,9 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 					"PUB006": "unsupported engine",
 				},
 				UpdateDuration: 25000000, // 25ms in nanoseconds
+				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Enabled=0, Audited=0, Filtered=0, Errs=map[PUB006:unsupported engine], Duration=25ms",
+			expectedResult:     "Successfully Enabled 0 detections.\nEnabled=0, Audited=0, Filtered=0, Errors=map[PUB006:unsupported engine], UpdateDuration=25ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
 		},
@@ -271,8 +329,9 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				Filtered:       1,
 				ErrMap:         map[string]string{},
 				UpdateDuration: 80000000, // 80ms in nanoseconds
+				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Enabled=1, Audited=1, Filtered=1, Errs=map[], Duration=80ms",
+			expectedResult:     "Successfully Enabled 1 detections.\nEnabled=1, Audited=1, Filtered=1, Errors=map[], UpdateDuration=80ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
 		},
@@ -307,6 +366,38 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 			expectedError:      true,
 			expectedDetections: 1,
 		},
+		{
+			name:   "sync detections successfully",
+			params: `{"search_filter": "so_detection.title:sync AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-sync"},
+					PublicID:  "PUB-SYNC",
+					Title:     "Sync Detection",
+					IsEnabled: false,
+					Engine:    model.EngineNameSuricata,
+				},
+			},
+			mockBulkStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 30000000, // 30ms in nanoseconds
+				NeedToSync: []*model.Detection{
+					{
+						Auditable: model.Auditable{Id: "detection-sync"},
+						PublicID:  "PUB-SYNC",
+						Title:     "Sync Detection",
+						IsEnabled: true,
+						Engine:    model.EngineNameSuricata,
+					},
+				},
+			},
+			expectedResult:     "Successfully Enabled 1 detections.\nEnabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=30ms, SyncDuration=",
+			expectedEnable:     true,
+			expectedDetections: 1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -331,6 +422,17 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				"test-user-id": {"detections/write"},
 			})
 			mockServer.Detectionstore = mockDetectionstore
+			// Add DetectionEngines with mock engine for sync testing
+			mockServer.DetectionEngines = sync.Map{}
+			if tc.name == "sync detections successfully" {
+				mockEngine := &FakeDetectionEngine{}
+				mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockEngine)
+			} else if tc.name == "sync error during detection sync" {
+				mockEngine := &FakeDetectionEngine{
+					SyncError: assert.AnError,
+				}
+				mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockEngine)
+			}
 
 			// Create context with user ID
 			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
@@ -364,9 +466,16 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				assert.Len(t, mockDetectionstore.BulkUpdateDetectionList, tc.expectedDetections)
 			}
 
-			// Assert result content
+			// Assert result content - check if result contains expected parts since sync duration varies
 			if tc.expectedResult != "" {
-				assert.Equal(t, tc.expectedResult, result.Result)
+				resultStr := result.Result.(string)
+				if strings.Contains(tc.expectedResult, "SyncDuration=") {
+					// For results with sync duration, check that it starts correctly and contains expected parts
+					assert.True(t, strings.HasPrefix(resultStr, strings.Split(tc.expectedResult, "SyncDuration=")[0]))
+					assert.Contains(t, resultStr, "SyncDuration=")
+				} else {
+					assert.Equal(t, tc.expectedResult, resultStr)
+				}
 			}
 		})
 	}
@@ -467,6 +576,8 @@ func TestToggleDetectionsTool_QueryFiltering(t *testing.T) {
 				"test-user-id": {"detections/write"},
 			})
 			mockServer.Detectionstore = mockDetectionstore
+			// Add empty DetectionEngines to avoid nil pointer issues
+			mockServer.DetectionEngines = sync.Map{}
 
 			// Create context with user ID
 			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
@@ -533,6 +644,7 @@ func TestToggleDetectionsTool_Authorization(t *testing.T) {
 					Filtered:       0,
 					ErrMap:         map[string]string{},
 					UpdateDuration: 50000000, // 50ms in nanoseconds
+					NeedToSync:     []*model.Detection{},
 				}
 			}
 
@@ -548,6 +660,8 @@ func TestToggleDetectionsTool_Authorization(t *testing.T) {
 				})
 			}
 			mockServer.Detectionstore = mockDetectionstore
+			// Add empty DetectionEngines to avoid nil pointer issues
+			mockServer.DetectionEngines = sync.Map{}
 
 			// Create context with user ID
 			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")

--- a/server/modules/assistant/toggle_detections_test.go
+++ b/server/modules/assistant/toggle_detections_test.go
@@ -1,0 +1,571 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/elastic/go-elasticsearch/v8/esutil"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+)
+
+// FakeDetectionstore implements the Detectionstore interface for testing
+type FakeDetectionstore struct {
+	QueryWithRangeResults []interface{}
+	QueryWithRangeError   error
+	QueryWithRangeCalled  bool
+	QueryWithRangeQuery   string
+
+	BulkUpdateStats         *model.BulkUpdateStats
+	BulkUpdateError         error
+	BulkUpdateCalled        bool
+	BulkUpdateEnable        bool
+	BulkUpdateDetectionList []*model.Detection
+}
+
+func (f *FakeDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string) ([]interface{}, error) {
+	f.QueryWithRangeCalled = true
+	f.QueryWithRangeQuery = query
+	if f.QueryWithRangeError != nil {
+		return nil, f.QueryWithRangeError
+	}
+	return f.QueryWithRangeResults, nil
+}
+
+func (f *FakeDetectionstore) BulkUpdateDetections(ctx context.Context, newStatus bool, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
+	f.BulkUpdateCalled = true
+	f.BulkUpdateEnable = newStatus
+	f.BulkUpdateDetectionList = detects
+	if f.BulkUpdateError != nil {
+		return nil, f.BulkUpdateError
+	}
+	return f.BulkUpdateStats, nil
+}
+
+// Stub implementations for other required methods (not used in toggle_detections)
+func (f *FakeDetectionstore) Query(ctx context.Context, query string, max int) ([]interface{}, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) CreateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) GetDetection(ctx context.Context, detectId string) (*model.Detection, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) GetDetectionByPublicId(ctx context.Context, publicId string) (*model.Detection, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) GetDetectionHistory(ctx context.Context, detectID string) ([]interface{}, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) CreateComment(ctx context.Context, newComment *model.DetectionComment) (*model.DetectionComment, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) GetComment(ctx context.Context, commentId string) (*model.DetectionComment, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) GetComments(ctx context.Context, detectionId string) ([]*model.DetectionComment, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) UpdateComment(ctx context.Context, comment *model.DetectionComment) (*model.DetectionComment, error) {
+	return nil, nil
+}
+func (f *FakeDetectionstore) DeleteComment(ctx context.Context, id string) error {
+	return nil
+}
+func (f *FakeDetectionstore) DoesTemplateExist(ctx context.Context, tmpl string) (bool, error) {
+	return false, nil
+}
+func (f *FakeDetectionstore) BuildBulkIndexer(ctx context.Context, logger log.Interface) (esutil.BulkIndexer, error) {
+	// Return a mock that satisfies the esutil.BulkIndexer interface
+	return &mockBulkIndexer{}, nil
+}
+
+// mockBulkIndexer is a simple mock for the esutil.BulkIndexer interface
+type mockBulkIndexer struct{}
+
+func (m *mockBulkIndexer) Add(ctx context.Context, item esutil.BulkIndexerItem) error {
+	return nil
+}
+
+func (m *mockBulkIndexer) Close(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockBulkIndexer) Stats() esutil.BulkIndexerStats {
+	return esutil.BulkIndexerStats{}
+}
+func (f *FakeDetectionstore) ConvertObjectToDocument(ctx context.Context, kind string, obj interface{}, auditable *model.Auditable, isEdit bool, auditDocId *string, op *string) ([]byte, string, error) {
+	return nil, "", nil
+}
+
+func TestToggleDetectionsTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name               string
+		params             string
+		mockQueryResults   []interface{}
+		mockQueryError     error
+		mockBulkStats      *model.BulkUpdateStats
+		mockBulkError      error
+		expectedResult     string
+		expectedError      bool
+		expectedEnable     bool
+		expectedDetections int
+	}{
+		{
+			name:   "enable detections successfully",
+			params: `{"search_filter": "so_detection.title:malware AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-1"},
+					PublicID:  "PUB001",
+					Title:     "Malware Detection 1",
+					IsEnabled: false,
+				},
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-2"},
+					PublicID:  "PUB002",
+					Title:     "Malware Detection 2",
+					IsEnabled: false,
+				},
+			},
+			mockBulkStats: &model.BulkUpdateStats{
+				Updated:        2,
+				Audited:        2,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 100000000, // 100ms in nanoseconds
+			},
+			expectedResult:     "Enabled=2, Audited=2, Filtered=0, Errs=map[], Duration=100ms",
+			expectedEnable:     true,
+			expectedDetections: 2,
+		},
+		{
+			name:   "disable detections successfully",
+			params: `{"search_filter": "so_detection.severity:high AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "false"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-3"},
+					PublicID:  "PUB003",
+					Title:     "High Severity Detection",
+					IsEnabled: true,
+				},
+			},
+			mockBulkStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 50000000, // 50ms in nanoseconds
+			},
+			expectedResult:     "Disabled=1, Audited=1, Filtered=0, Errs=map[], Duration=50ms",
+			expectedEnable:     false,
+			expectedDetections: 1,
+		},
+		{
+			name:   "toggle with time range",
+			params: `{"search_filter": "so_detection.language:sigma AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true", "range_start": "-999d", "range_end": "now"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-4"},
+					PublicID:  "PUB004",
+					Title:     "Sigma Detection",
+					IsEnabled: false,
+				},
+			},
+			mockBulkStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 75000000, // 75ms in nanoseconds
+			},
+			expectedResult:     "Enabled=1, Audited=1, Filtered=0, Errs=map[], Duration=75ms",
+			expectedEnable:     true,
+			expectedDetections: 1,
+		},
+		{
+			name:   "toggle with absolute time range",
+			params: `{"search_filter": "so_detection.engine:suricata AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "false", "range_start": "2024/01/01 10:00:00 AM", "range_end": "2024/01/01 11:00:00 AM", "range_format": "2006/01/02 3:04:05 PM"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-5"},
+					PublicID:  "PUB005",
+					Title:     "Suricata Detection",
+					IsEnabled: true,
+				},
+			},
+			mockBulkStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       0,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 60000000, // 60ms in nanoseconds
+			},
+			expectedResult:     "Disabled=1, Audited=1, Filtered=0, Errs=map[], Duration=60ms",
+			expectedEnable:     false,
+			expectedDetections: 1,
+		},
+		{
+			name:             "no detections found",
+			params:           `{"search_filter": "so_detection.title:nonexistent AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true"}`,
+			mockQueryResults: []interface{}{},
+			expectedResult:   "No detections found",
+		},
+		{
+			name:   "toggle with errors in bulk update",
+			params: `{"search_filter": "so_detection.title:problematic AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-6"},
+					PublicID:  "PUB006",
+					Title:     "Problematic Detection",
+					IsEnabled: false,
+				},
+			},
+			mockBulkStats: &model.BulkUpdateStats{
+				Updated:  0,
+				Audited:  0,
+				Filtered: 0,
+				ErrMap: map[string]string{
+					"PUB006": "unsupported engine",
+				},
+				UpdateDuration: 25000000, // 25ms in nanoseconds
+			},
+			expectedResult:     "Enabled=0, Audited=0, Filtered=0, Errs=map[PUB006:unsupported engine], Duration=25ms",
+			expectedEnable:     true,
+			expectedDetections: 1,
+		},
+		{
+			name:   "toggle with filtered detections",
+			params: `{"search_filter": "so_detection.title:filtered AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-7"},
+					PublicID:  "PUB007",
+					Title:     "Filtered Detection",
+					IsEnabled: false,
+				},
+			},
+			mockBulkStats: &model.BulkUpdateStats{
+				Updated:        1,
+				Audited:        1,
+				Filtered:       1,
+				ErrMap:         map[string]string{},
+				UpdateDuration: 80000000, // 80ms in nanoseconds
+			},
+			expectedResult:     "Enabled=1, Audited=1, Filtered=1, Errs=map[], Duration=80ms",
+			expectedEnable:     true,
+			expectedDetections: 1,
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"search_filter": "invalid json}`,
+			expectedError: true,
+		},
+		{
+			name:          "invalid enable parameter",
+			params:        `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "maybe"}`,
+			expectedError: true,
+		},
+		{
+			name:           "query error",
+			params:         `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true"}`,
+			mockQueryError: assert.AnError,
+			expectedError:  true,
+		},
+		{
+			name:   "bulk update error",
+			params: `{"search_filter": "so_detection.title:test AND _index:\"*:so-detection\" AND so_kind:detection", "enable": "true"}`,
+			mockQueryResults: []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-8"},
+					PublicID:  "PUB008",
+					Title:     "Test Detection",
+					IsEnabled: false,
+				},
+			},
+			mockBulkError:      assert.AnError,
+			expectedError:      true,
+			expectedDetections: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock detection store
+			mockDetectionstore := &FakeDetectionstore{}
+			if tc.mockQueryResults != nil {
+				mockDetectionstore.QueryWithRangeResults = tc.mockQueryResults
+			}
+			if tc.mockQueryError != nil {
+				mockDetectionstore.QueryWithRangeError = tc.mockQueryError
+			}
+			if tc.mockBulkStats != nil {
+				mockDetectionstore.BulkUpdateStats = tc.mockBulkStats
+			}
+			if tc.mockBulkError != nil {
+				mockDetectionstore.BulkUpdateError = tc.mockBulkError
+			}
+
+			// Create mock server with proper authorization
+			mockServer := server.NewFakeAuthorizedServer(map[string][]string{
+				"test-user-id": {"detections/write"},
+			})
+			mockServer.Detectionstore = mockDetectionstore
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create tool and execute
+			tool := &ToggleDetectionsTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "toggle_detections", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+			assert.True(t, result.TimeToExecute > 0)
+
+			// Verify query was called with correct parameters
+			if tc.mockQueryResults != nil || tc.mockQueryError != nil {
+				assert.True(t, mockDetectionstore.QueryWithRangeCalled)
+				assert.Contains(t, mockDetectionstore.QueryWithRangeQuery, "NOT metadata.raw_index:")
+			}
+
+			// Verify bulk update was called with correct parameters
+			if tc.expectedDetections > 0 && tc.mockBulkError == nil {
+				assert.True(t, mockDetectionstore.BulkUpdateCalled)
+				assert.Equal(t, tc.expectedEnable, mockDetectionstore.BulkUpdateEnable)
+				assert.Len(t, mockDetectionstore.BulkUpdateDetectionList, tc.expectedDetections)
+			}
+
+			// Assert result content
+			if tc.expectedResult != "" {
+				assert.Equal(t, tc.expectedResult, result.Result)
+			}
+		})
+	}
+}
+
+func TestToggleDetectionsTool_GetName(t *testing.T) {
+	tool := &ToggleDetectionsTool{}
+	assert.Equal(t, "toggle_detections", tool.GetName())
+}
+
+func TestToggleDetectionsTool_GetDescription(t *testing.T) {
+	tool := &ToggleDetectionsTool{}
+	description := tool.GetDescription()
+	assert.Contains(t, description, "Enable or disable detections in Security Onion")
+	assert.Contains(t, description, "_index:\"*:so-detection\" AND so_kind:detection")
+	assert.Contains(t, description, "999 days ago")
+	assert.Contains(t, description, "wildcards")
+}
+
+func TestToggleDetectionsTool_GetSchema(t *testing.T) {
+	tool := &ToggleDetectionsTool{}
+	schema := tool.GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+	assert.Contains(t, schema.Json.Required, "search_filter")
+
+	// Check that all expected properties are present
+	expectedProperties := []string{"search_filter", "enable", "range_start", "range_end", "range_format"}
+	for _, prop := range expectedProperties {
+		assert.Contains(t, schema.Json.Properties, prop)
+	}
+
+	// Check search_filter property
+	searchFilter := schema.Json.Properties["search_filter"]
+	assert.Equal(t, "string", searchFilter.Type)
+	assert.Contains(t, searchFilter.Description, "so_detection.id")
+	assert.Contains(t, searchFilter.Description, "so_detection.title")
+	assert.Contains(t, searchFilter.Description, "so_detection.severity")
+	assert.Contains(t, searchFilter.Description, "so_detection.isEnabled")
+
+	// Check enable property
+	enable := schema.Json.Properties["enable"]
+	assert.Equal(t, "string", enable.Type)
+	assert.Contains(t, enable.Description, "true")
+	assert.Contains(t, enable.Description, "false")
+
+	// Check range properties
+	rangeStart := schema.Json.Properties["range_start"]
+	assert.Equal(t, "string", rangeStart.Type)
+	assert.Contains(t, rangeStart.Description, "start time")
+
+	rangeEnd := schema.Json.Properties["range_end"]
+	assert.Equal(t, "string", rangeEnd.Type)
+	assert.Contains(t, rangeEnd.Description, "end time")
+
+	rangeFormat := schema.Json.Properties["range_format"]
+	assert.Equal(t, "string", rangeFormat.Type)
+	assert.Contains(t, rangeFormat.Description, "format")
+}
+
+func TestToggleDetectionsTool_QueryFiltering(t *testing.T) {
+	testCases := []struct {
+		name          string
+		searchFilter  string
+		expectedQuery string
+	}{
+		{
+			name:          "basic query with metadata filter added",
+			searchFilter:  "so_detection.title:malware",
+			expectedQuery: `(so_detection.title:malware) AND NOT metadata.raw_index:"logs-soc-so"`,
+		},
+		{
+			name:          "query already has metadata filter",
+			searchFilter:  `so_detection.title:malware AND NOT metadata.raw_index:"logs-soc-so"`,
+			expectedQuery: `so_detection.title:malware AND NOT metadata.raw_index:"logs-soc-so"`,
+		},
+		{
+			name:          "empty search filter",
+			searchFilter:  "",
+			expectedQuery: `NOT metadata.raw_index:"logs-soc-so"`,
+		},
+		{
+			name:          "complex query with metadata filter added",
+			searchFilter:  `so_detection.severity:high AND so_detection.engine:suricata`,
+			expectedQuery: `(so_detection.severity:high AND so_detection.engine:suricata) AND NOT metadata.raw_index:"logs-soc-so"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock detection store
+			mockDetectionstore := &FakeDetectionstore{}
+			mockDetectionstore.QueryWithRangeResults = []interface{}{} // No results to avoid bulk update
+
+			// Create mock server with proper authorization
+			mockServer := server.NewFakeAuthorizedServer(map[string][]string{
+				"test-user-id": {"detections/write"},
+			})
+			mockServer.Detectionstore = mockDetectionstore
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create parameters - properly escape quotes in JSON
+			escapedFilter := strings.ReplaceAll(tc.searchFilter, `"`, `\"`)
+			params := `{"search_filter": "` + escapedFilter + `", "enable": "true"}`
+
+			// Create tool and execute
+			tool := &ToggleDetectionsTool{}
+			result, err := tool.Execute(ctx, mockServer, params, "")
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "No detections found", result.Result)
+
+			// Verify the query was modified correctly
+			assert.True(t, mockDetectionstore.QueryWithRangeCalled)
+			assert.Equal(t, tc.expectedQuery, mockDetectionstore.QueryWithRangeQuery)
+		})
+	}
+}
+
+func TestToggleDetectionsTool_Authorization(t *testing.T) {
+	testCases := []struct {
+		name        string
+		permissions []string
+		expectError bool
+	}{
+		{
+			name:        "authorized user with write permissions",
+			permissions: []string{"detections/write"},
+			expectError: false,
+		},
+		{
+			name:        "unauthorized user without write permissions",
+			permissions: []string{"detections/read"},
+			expectError: true,
+		},
+		{
+			name:        "unauthorized user with no permissions",
+			permissions: []string{},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock detection store
+			mockDetectionstore := &FakeDetectionstore{}
+			mockDetectionstore.QueryWithRangeResults = []interface{}{
+				&model.Detection{
+					Auditable: model.Auditable{Id: "detection-1"},
+					PublicID:  "PUB001",
+					Title:     "Test Detection",
+					IsEnabled: false,
+				},
+			}
+			// Add mock bulk update stats for successful cases
+			if !tc.expectError {
+				mockDetectionstore.BulkUpdateStats = &model.BulkUpdateStats{
+					Updated:        1,
+					Audited:        1,
+					Filtered:       0,
+					ErrMap:         map[string]string{},
+					UpdateDuration: 50000000, // 50ms in nanoseconds
+				}
+			}
+
+			// Create mock server with specific permissions
+			var mockServer *server.Server
+			if tc.expectError {
+				// For unauthorized tests, use an unauthorized server
+				mockServer = server.NewFakeUnauthorizedServer()
+			} else {
+				// For authorized tests, use an authorized server
+				mockServer = server.NewFakeAuthorizedServer(map[string][]string{
+					"test-user-id": tc.permissions,
+				})
+			}
+			mockServer.Detectionstore = mockDetectionstore
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Create parameters
+			params := `{"search_filter": "so_detection.title:test", "enable": "true"}`
+
+			// Create tool and execute
+			tool := &ToggleDetectionsTool{}
+			result, err := tool.Execute(ctx, mockServer, params, "")
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}

--- a/server/modules/assistant/toggle_detections_test.go
+++ b/server/modules/assistant/toggle_detections_test.go
@@ -33,7 +33,7 @@ type FakeDetectionstore struct {
 	BulkUpdateDetectionList []*model.Detection
 }
 
-func (f *FakeDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string) ([]interface{}, error) {
+func (f *FakeDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]interface{}, error) {
 	f.QueryWithRangeCalled = true
 	f.QueryWithRangeQuery = query
 	if f.QueryWithRangeError != nil {

--- a/server/modules/assistant/toggle_detections_test.go
+++ b/server/modules/assistant/toggle_detections_test.go
@@ -68,6 +68,9 @@ func (f *FakeDetectionstore) GetDetectionByPublicId(ctx context.Context, publicI
 func (f *FakeDetectionstore) UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
 	return nil, nil
 }
+func (f *FakeDetectionstore) BulkAddOverrides(ctx context.Context, newOverrides []*model.Override, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
+	return nil, nil
+}
 func (f *FakeDetectionstore) DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error) {
 	return nil, nil
 }

--- a/server/modules/assistant/toggle_detections_test.go
+++ b/server/modules/assistant/toggle_detections_test.go
@@ -265,7 +265,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 			if tc.mockQueryResults != nil || tc.mockQueryError != nil {
 				mockDetectionstore.EXPECT().
 					QueryWithRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]interface{}, error) {
+					DoAndReturn(func(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) (*model.EventSearchResults, error) {
 						// Verify the query contains the metadata filter
 						if !strings.Contains(query, `NOT metadata.raw_index:"logs-soc-so"`) {
 							t.Errorf("Query should contain metadata filter, got: %s", query)
@@ -273,9 +273,25 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 						if tc.mockQueryError != nil {
 							return nil, tc.mockQueryError
 						}
-						return tc.mockQueryResults, nil
+						// Return EventSearchResults with empty Events slice
+						return &model.EventSearchResults{Events: []*model.EventRecord{}}, nil
 					}).
 					Times(1)
+
+				// Setup ConvertEventsToDetections expectations
+				if tc.mockQueryError == nil {
+					mockDetectionstore.EXPECT().
+						ConvertEventsToDetections(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(ctx context.Context, detectEvents *model.EventSearchResults) ([]*model.Detection, error) {
+							// Convert []interface{} to []*model.Detection
+							detections := make([]*model.Detection, len(tc.mockQueryResults))
+							for i, obj := range tc.mockQueryResults {
+								detections[i] = obj.(*model.Detection)
+							}
+							return detections, nil
+						}).
+						Times(1)
+				}
 			}
 
 			// Setup BulkUpdateDetections expectations
@@ -452,7 +468,12 @@ func TestToggleDetectionsTool_QueryFiltering(t *testing.T) {
 			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
 			mockDetectionstore.EXPECT().
 				QueryWithRange(gomock.Any(), tc.expectedQuery, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return([]interface{}{}, nil).
+				Return(&model.EventSearchResults{Events: []*model.EventRecord{}}, nil).
+				Times(1)
+
+			mockDetectionstore.EXPECT().
+				ConvertEventsToDetections(gomock.Any(), gomock.Any()).
+				Return([]*model.Detection{}, nil).
 				Times(1)
 
 			// Create mock server with proper authorization
@@ -515,8 +536,13 @@ func TestToggleDetectionsTool_Authorization(t *testing.T) {
 				// Setup expectations for authorized case
 				mockDetectionstore.EXPECT().
 					QueryWithRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return([]interface{}{
-						&model.Detection{
+					Return(&model.EventSearchResults{Events: []*model.EventRecord{}}, nil).
+					Times(1)
+
+				mockDetectionstore.EXPECT().
+					ConvertEventsToDetections(gomock.Any(), gomock.Any()).
+					Return([]*model.Detection{
+						{
 							Auditable: model.Auditable{Id: "detection-1"},
 							PublicID:  "PUB001",
 							Title:     "Test Detection",

--- a/server/modules/assistant/toggle_detections_test.go
+++ b/server/modules/assistant/toggle_detections_test.go
@@ -208,7 +208,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				UpdateDuration: 100000000, // 100ms in nanoseconds
 				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Successfully Enabled 2 detections.\nEnabled=2, Audited=2, Filtered=0, Errors=map[], UpdateDuration=100ms, SyncDuration=",
+			expectedResult:     "Successfully Enabled 2 detections. Enabled=2, Audited=2, Filtered=0, Errors=map[], UpdateDuration=100ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 2,
 		},
@@ -231,7 +231,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				UpdateDuration: 50000000, // 50ms in nanoseconds
 				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Successfully Disabled 1 detections.\nDisabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=50ms, SyncDuration=",
+			expectedResult:     "Successfully Disabled 1 detections. Disabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=50ms, SyncDuration=",
 			expectedEnable:     false,
 			expectedDetections: 1,
 		},
@@ -254,7 +254,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				UpdateDuration: 75000000, // 75ms in nanoseconds
 				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Successfully Enabled 1 detections.\nEnabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=75ms, SyncDuration=",
+			expectedResult:     "Successfully Enabled 1 detections. Enabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=75ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
 		},
@@ -277,7 +277,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				UpdateDuration: 60000000, // 60ms in nanoseconds
 				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Successfully Disabled 1 detections.\nDisabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=60ms, SyncDuration=",
+			expectedResult:     "Successfully Disabled 1 detections. Disabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=60ms, SyncDuration=",
 			expectedEnable:     false,
 			expectedDetections: 1,
 		},
@@ -308,7 +308,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				UpdateDuration: 25000000, // 25ms in nanoseconds
 				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Successfully Enabled 0 detections.\nEnabled=0, Audited=0, Filtered=0, Errors=map[PUB006:unsupported engine], UpdateDuration=25ms, SyncDuration=",
+			expectedResult:     "Successfully Enabled 0 detections. Enabled=0, Audited=0, Filtered=0, Errors=map[PUB006:unsupported engine], UpdateDuration=25ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
 		},
@@ -331,7 +331,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				UpdateDuration: 80000000, // 80ms in nanoseconds
 				NeedToSync:     []*model.Detection{},
 			},
-			expectedResult:     "Successfully Enabled 1 detections.\nEnabled=1, Audited=1, Filtered=1, Errors=map[], UpdateDuration=80ms, SyncDuration=",
+			expectedResult:     "Successfully Enabled 1 detections. Enabled=1, Audited=1, Filtered=1, Errors=map[], UpdateDuration=80ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
 		},
@@ -394,7 +394,7 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 					},
 				},
 			},
-			expectedResult:     "Successfully Enabled 1 detections.\nEnabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=30ms, SyncDuration=",
+			expectedResult:     "Successfully Enabled 1 detections. Enabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=30ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
 		},

--- a/server/modules/assistant/toggle_detections_test.go
+++ b/server/modules/assistant/toggle_detections_test.go
@@ -11,167 +11,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/apex/log"
-	"github.com/elastic/go-elasticsearch/v8/esutil"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/mock"
 	"github.com/security-onion-solutions/securityonion-soc/web"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
-
-// FakeDetectionstore implements the Detectionstore interface for testing
-type FakeDetectionstore struct {
-	QueryWithRangeResults []interface{}
-	QueryWithRangeError   error
-	QueryWithRangeCalled  bool
-	QueryWithRangeQuery   string
-
-	BulkUpdateStats         *model.BulkUpdateStats
-	BulkUpdateError         error
-	BulkUpdateCalled        bool
-	BulkUpdateEnable        bool
-	BulkUpdateDetectionList []*model.Detection
-}
-
-func (f *FakeDetectionstore) QueryWithRange(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]interface{}, error) {
-	f.QueryWithRangeCalled = true
-	f.QueryWithRangeQuery = query
-	if f.QueryWithRangeError != nil {
-		return nil, f.QueryWithRangeError
-	}
-	return f.QueryWithRangeResults, nil
-}
-
-func (f *FakeDetectionstore) BulkUpdateDetections(ctx context.Context, newStatus bool, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
-	f.BulkUpdateCalled = true
-	f.BulkUpdateEnable = newStatus
-	f.BulkUpdateDetectionList = detects
-	if f.BulkUpdateError != nil {
-		return nil, f.BulkUpdateError
-	}
-	return f.BulkUpdateStats, nil
-}
-
-// Stub implementations for other required methods (not used in toggle_detections)
-func (f *FakeDetectionstore) Query(ctx context.Context, query string, max int) ([]interface{}, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) CreateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) GetDetection(ctx context.Context, detectId string) (*model.Detection, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) GetDetectionByPublicId(ctx context.Context, publicId string) (*model.Detection, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) UpdateDetection(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) BulkAddOverrides(ctx context.Context, newOverrides []*model.Override, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) DeleteDetection(ctx context.Context, detectID string) (*model.Detection, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) GetAllDetections(ctx context.Context, opts ...model.GetAllOption) (map[string]*model.Detection, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) GetDetectionHistory(ctx context.Context, detectID string) ([]interface{}, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) CreateComment(ctx context.Context, newComment *model.DetectionComment) (*model.DetectionComment, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) GetComment(ctx context.Context, commentId string) (*model.DetectionComment, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) GetComments(ctx context.Context, detectionId string) ([]*model.DetectionComment, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) UpdateComment(ctx context.Context, comment *model.DetectionComment) (*model.DetectionComment, error) {
-	return nil, nil
-}
-func (f *FakeDetectionstore) DeleteComment(ctx context.Context, id string) error {
-	return nil
-}
-func (f *FakeDetectionstore) DoesTemplateExist(ctx context.Context, tmpl string) (bool, error) {
-	return false, nil
-}
-func (f *FakeDetectionstore) BuildBulkIndexer(ctx context.Context, logger log.Interface) (esutil.BulkIndexer, error) {
-	// Return a mock that satisfies the esutil.BulkIndexer interface
-	return &mockBulkIndexer{}, nil
-}
-
-// mockBulkIndexer is a simple mock for the esutil.BulkIndexer interface
-type mockBulkIndexer struct{}
-
-func (m *mockBulkIndexer) Add(ctx context.Context, item esutil.BulkIndexerItem) error {
-	return nil
-}
-
-func (m *mockBulkIndexer) Close(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockBulkIndexer) Stats() esutil.BulkIndexerStats {
-	return esutil.BulkIndexerStats{}
-}
-func (f *FakeDetectionstore) ConvertObjectToDocument(ctx context.Context, kind string, obj interface{}, auditable *model.Auditable, isEdit bool, auditDocId *string, op *string) ([]byte, string, error) {
-	return nil, "", nil
-}
-
-// FakeDetectionEngine implements the DetectionEngine interface for testing
-type FakeDetectionEngine struct {
-	SyncError    error
-	SyncErrorMap map[string]string
-}
-
-func (f *FakeDetectionEngine) ValidateRule(rule string) (string, error) {
-	return rule, nil
-}
-
-func (f *FakeDetectionEngine) SyncLocalDetections(ctx context.Context, detections []*model.Detection) (map[string]string, error) {
-	if f.SyncError != nil {
-		return nil, f.SyncError
-	}
-	if f.SyncErrorMap != nil {
-		return f.SyncErrorMap, nil
-	}
-	return map[string]string{}, nil
-}
-
-func (f *FakeDetectionEngine) ConvertRule(ctx context.Context, detect *model.Detection) (string, error) {
-	return detect.Content, nil
-}
-
-func (f *FakeDetectionEngine) ExtractDetails(detect *model.Detection) error {
-	return nil
-}
-
-func (f *FakeDetectionEngine) InterruptSync(forceFull bool, notify bool) {
-	// No-op for testing
-}
-
-func (f *FakeDetectionEngine) DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error) {
-	return detection, nil
-}
-
-func (f *FakeDetectionEngine) GetState() *model.EngineState {
-	return &model.EngineState{}
-}
-
-func (f *FakeDetectionEngine) GenerateUnusedPublicId(ctx context.Context) (string, error) {
-	return "test-public-id", nil
-}
-
-func (f *FakeDetectionEngine) ApplyFilters(detect *model.Detection) (bool, error) {
-	return false, nil
-}
-
-func (f *FakeDetectionEngine) MergeAuxiliaryData(detect *model.Detection) error {
-	return nil
-}
 
 func TestToggleDetectionsTool_Execute(t *testing.T) {
 	testCases := []struct {
@@ -185,6 +31,9 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 		expectedError      bool
 		expectedEnable     bool
 		expectedDetections int
+		setupEngines       bool
+		syncError          error
+		syncErrorMap       map[string]string
 	}{
 		{
 			name:   "enable detections successfully",
@@ -400,24 +249,55 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 			expectedResult:     "Successfully Enabled 1 detections. Enabled=1, Audited=1, Filtered=0, Errors=map[], UpdateDuration=30ms, SyncDuration=",
 			expectedEnable:     true,
 			expectedDetections: 1,
+			setupEngines:       true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
 			// Create mock detection store
-			mockDetectionstore := &FakeDetectionstore{}
-			if tc.mockQueryResults != nil {
-				mockDetectionstore.QueryWithRangeResults = tc.mockQueryResults
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+
+			// Setup QueryWithRange expectations
+			if tc.mockQueryResults != nil || tc.mockQueryError != nil {
+				mockDetectionstore.EXPECT().
+					QueryWithRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, query, rangeStart, rangeEnd, rangeFormat string, limit int) ([]interface{}, error) {
+						// Verify the query contains the metadata filter
+						if !strings.Contains(query, `NOT metadata.raw_index:"logs-soc-so"`) {
+							t.Errorf("Query should contain metadata filter, got: %s", query)
+						}
+						if tc.mockQueryError != nil {
+							return nil, tc.mockQueryError
+						}
+						return tc.mockQueryResults, nil
+					}).
+					Times(1)
 			}
-			if tc.mockQueryError != nil {
-				mockDetectionstore.QueryWithRangeError = tc.mockQueryError
-			}
-			if tc.mockBulkStats != nil {
-				mockDetectionstore.BulkUpdateStats = tc.mockBulkStats
-			}
-			if tc.mockBulkError != nil {
-				mockDetectionstore.BulkUpdateError = tc.mockBulkError
+
+			// Setup BulkUpdateDetections expectations
+			if tc.expectedDetections > 0 && tc.mockBulkError == nil && !tc.expectedError {
+				mockDetectionstore.EXPECT().
+					BulkUpdateDetections(gomock.Any(), tc.expectedEnable, gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, newStatus bool, detects []*model.Detection, logger interface{}) (*model.BulkUpdateStats, error) {
+						// Verify the correct number of detections
+						if len(detects) != tc.expectedDetections {
+							t.Errorf("Expected %d detections, got %d", tc.expectedDetections, len(detects))
+						}
+						if tc.mockBulkError != nil {
+							return nil, tc.mockBulkError
+						}
+						return tc.mockBulkStats, nil
+					}).
+					Times(1)
+			} else if tc.mockBulkError != nil {
+				mockDetectionstore.EXPECT().
+					BulkUpdateDetections(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, tc.mockBulkError).
+					Times(1)
 			}
 
 			// Create mock server with proper authorization
@@ -425,16 +305,24 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 				"test-user-id": {"detections/write"},
 			})
 			mockServer.Detectionstore = mockDetectionstore
-			// Add DetectionEngines with mock engine for sync testing
 			mockServer.DetectionEngines = sync.Map{}
-			if tc.name == "sync detections successfully" {
-				mockEngine := &FakeDetectionEngine{}
-				mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockEngine)
-			} else if tc.name == "sync error during detection sync" {
-				mockEngine := &FakeDetectionEngine{
-					SyncError: assert.AnError,
-				}
-				mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockEngine)
+
+			// Setup detection engines if needed for sync testing
+			if tc.setupEngines {
+				mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+				mockDetectionEngine.EXPECT().
+					SyncLocalDetections(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, detections []*model.Detection) (map[string]string, error) {
+						if tc.syncError != nil {
+							return nil, tc.syncError
+						}
+						if tc.syncErrorMap != nil {
+							return tc.syncErrorMap, nil
+						}
+						return map[string]string{}, nil
+					}).
+					AnyTimes()
+				mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockDetectionEngine)
 			}
 
 			// Create context with user ID
@@ -455,19 +343,6 @@ func TestToggleDetectionsTool_Execute(t *testing.T) {
 			assert.Equal(t, "toggle_detections", result.ToolName)
 			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
 			assert.True(t, result.TimeToExecute > 0)
-
-			// Verify query was called with correct parameters
-			if tc.mockQueryResults != nil || tc.mockQueryError != nil {
-				assert.True(t, mockDetectionstore.QueryWithRangeCalled)
-				assert.Contains(t, mockDetectionstore.QueryWithRangeQuery, "NOT metadata.raw_index:")
-			}
-
-			// Verify bulk update was called with correct parameters
-			if tc.expectedDetections > 0 && tc.mockBulkError == nil {
-				assert.True(t, mockDetectionstore.BulkUpdateCalled)
-				assert.Equal(t, tc.expectedEnable, mockDetectionstore.BulkUpdateEnable)
-				assert.Len(t, mockDetectionstore.BulkUpdateDetectionList, tc.expectedDetections)
-			}
 
 			// Assert result content - check if result contains expected parts since sync duration varies
 			if tc.expectedResult != "" {
@@ -570,16 +445,21 @@ func TestToggleDetectionsTool_QueryFiltering(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
 			// Create mock detection store
-			mockDetectionstore := &FakeDetectionstore{}
-			mockDetectionstore.QueryWithRangeResults = []interface{}{} // No results to avoid bulk update
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+			mockDetectionstore.EXPECT().
+				QueryWithRange(gomock.Any(), tc.expectedQuery, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return([]interface{}{}, nil).
+				Times(1)
 
 			// Create mock server with proper authorization
 			mockServer := server.NewFakeAuthorizedServer(map[string][]string{
 				"test-user-id": {"detections/write"},
 			})
 			mockServer.Detectionstore = mockDetectionstore
-			// Add empty DetectionEngines to avoid nil pointer issues
 			mockServer.DetectionEngines = sync.Map{}
 
 			// Create context with user ID
@@ -596,10 +476,6 @@ func TestToggleDetectionsTool_QueryFiltering(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, result)
 			assert.Equal(t, "No detections found", result.Result)
-
-			// Verify the query was modified correctly
-			assert.True(t, mockDetectionstore.QueryWithRangeCalled)
-			assert.Equal(t, tc.expectedQuery, mockDetectionstore.QueryWithRangeQuery)
 		})
 	}
 }
@@ -629,26 +505,37 @@ func TestToggleDetectionsTool_Authorization(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
 			// Create mock detection store
-			mockDetectionstore := &FakeDetectionstore{}
-			mockDetectionstore.QueryWithRangeResults = []interface{}{
-				&model.Detection{
-					Auditable: model.Auditable{Id: "detection-1"},
-					PublicID:  "PUB001",
-					Title:     "Test Detection",
-					IsEnabled: false,
-				},
-			}
-			// Add mock bulk update stats for successful cases
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+
 			if !tc.expectError {
-				mockDetectionstore.BulkUpdateStats = &model.BulkUpdateStats{
-					Updated:        1,
-					Audited:        1,
-					Filtered:       0,
-					ErrMap:         map[string]string{},
-					UpdateDuration: 50000000, // 50ms in nanoseconds
-					NeedToSync:     []*model.Detection{},
-				}
+				// Setup expectations for authorized case
+				mockDetectionstore.EXPECT().
+					QueryWithRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]interface{}{
+						&model.Detection{
+							Auditable: model.Auditable{Id: "detection-1"},
+							PublicID:  "PUB001",
+							Title:     "Test Detection",
+							IsEnabled: false,
+						},
+					}, nil).
+					Times(1)
+
+				mockDetectionstore.EXPECT().
+					BulkUpdateDetections(gomock.Any(), true, gomock.Any(), gomock.Any()).
+					Return(&model.BulkUpdateStats{
+						Updated:        1,
+						Audited:        1,
+						Filtered:       0,
+						ErrMap:         map[string]string{},
+						UpdateDuration: 50000000,
+						NeedToSync:     []*model.Detection{},
+					}, nil).
+					Times(1)
 			}
 
 			// Create mock server with specific permissions
@@ -663,7 +550,6 @@ func TestToggleDetectionsTool_Authorization(t *testing.T) {
 				})
 			}
 			mockServer.Detectionstore = mockDetectionstore
-			// Add empty DetectionEngines to avoid nil pointer issues
 			mockServer.DetectionEngines = sync.Map{}
 
 			// Create context with user ID

--- a/server/modules/assistant/update_detection_content.go
+++ b/server/modules/assistant/update_detection_content.go
@@ -95,7 +95,7 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 
 	err = srv.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("user is not authorized to write detections: %w", err)
 	}
 
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
@@ -115,7 +115,7 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 
 	err = json.Unmarshal([]byte(params), args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't unmarshal params: %w", err)
 	}
 
 	result.Parameters = args
@@ -135,21 +135,21 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 	}
 
 	if detect.IsCommunity {
-		return nil, fmt.Errorf("cannot update a community rule")
+		return nil, fmt.Errorf("cannot update a community rule (Public ID %s)", detect.PublicID)
 	}
 
 	detect.Content = args.Content
 
 	err = detect.Validate()
 	if err != nil {
-		logger.WithError(err).Error("invalid detection")
-		return nil, fmt.Errorf("invalid detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("invalid detection")
+		return nil, fmt.Errorf("invalid detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
 	engInt, ok := srv.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		logger.WithField("detectionEngine", detect.Engine).Error("unsupported engine")
-		return nil, fmt.Errorf("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine %s", detect.Engine)
 	}
 
 	engine := engInt.(server.DetectionEngine)
@@ -157,7 +157,7 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 	_, err = engine.ValidateRule(detect.Content)
 	if err != nil {
 		logger.WithError(err).WithField("detectionContent", detect.Content).Error("invalid rule")
-		return nil, fmt.Errorf("invalid rule: %w", err)
+		return nil, fmt.Errorf("invalid rule (%s): %w", detect.Content, err)
 	}
 
 	err = engine.ExtractDetails(detect)
@@ -166,33 +166,37 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 			"detectionEngine":   detect.Engine,
 			"detectionPublicId": detect.PublicID,
 		}).Error("unable to extract details from detection")
-		return nil, fmt.Errorf("unable to extract details for detection: %w", err)
+		return nil, fmt.Errorf("unable to extract details for detection with Public ID %s and engine %s: %w", detect.PublicID, detect.Engine, err)
 	}
 
 	_, err = engine.ApplyFilters(detect)
 	if err != nil {
-		logger.WithError(err).Error("unable to apply filters for detection")
-		return nil, fmt.Errorf("unable to apply filters for detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("unable to apply filters for detection")
+		return nil, fmt.Errorf("unable to apply filters for detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
 	detect.Kind = ""
 	detect.Operation = ""
 
+	tempPublicId := detect.PublicID
 	detect, err = srv.Detectionstore.UpdateDetection(ctx, detect)
 	if err != nil {
-		logger.WithError(err).Error("failed to update detection")
-		return nil, fmt.Errorf("failed to update detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", tempPublicId).Error("failed to update detection")
+		return nil, fmt.Errorf("failed to update detection with Public ID %s: %w", tempPublicId, err)
 	}
 
 	errMap, err := engine.SyncLocalDetections(ctx, []*model.Detection{detect})
 	if err != nil {
-		logger.WithError(err).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
 	if len(errMap) != 0 {
-		logger.WithField("errMap", errMap).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection")
+		logger.WithFields(log.Fields{
+			"detectionPublicId": detect.PublicID,
+			"errMap":            errMap,
+		}).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection with Public ID %s: %v", detect.PublicID, errMap)
 	}
 
 	err = engine.MergeAuxiliaryData(detect)

--- a/server/modules/assistant/update_detection_content.go
+++ b/server/modules/assistant/update_detection_content.go
@@ -78,7 +78,6 @@ func (t *UpdateDetectionContentTool) GetSchema() model.JSONSchema {
 					content field to "high". Then, you will pass the entire updated content field as this argument.`,
 				},
 			},
-			Required: []string{"search_filter"},
 		},
 	}
 }

--- a/server/modules/assistant/update_detection_content.go
+++ b/server/modules/assistant/update_detection_content.go
@@ -168,6 +168,7 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 	}
 
 	detect.Kind = ""
+	detect.Operation = ""
 
 	detect, err = srv.Detectionstore.UpdateDetection(ctx, detect)
 	if err != nil {

--- a/server/modules/assistant/update_detection_content.go
+++ b/server/modules/assistant/update_detection_content.go
@@ -1,0 +1,200 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/apex/log"
+)
+
+func init() {
+	t := &UpdateDetectionContentTool{}
+	knownTools[t.GetName()] = t
+}
+
+type UpdateDetectionContentTool struct{}
+
+func (t *UpdateDetectionContentTool) GetName() string {
+	return "update_detection_content"
+}
+
+func (t *UpdateDetectionContentTool) GetDescription() string {
+	return `Update an existing detection per the user's request by modifying its content field. Note that only custom detections (those with so_detection.isCommunity: false) can be
+	modified in this way. This detection will be accessed with either its SOC Id or Public Id. *IMPORTANT* You MUST provide ONE of soc_id or public_id, but NEVER both.
+	Modifying the content field of a detection can update the values of certain attributes of a detection. These attributes and the ways in which they are specified
+	in the content field can vary for the 3 different languages. Here is a run-down of which attributes can be set/updated in the content field for the 3 different languages:
+	Sigma:
+	- so_detection.title: this will follow "title: " in the sigma rule
+	- so_detection.description: this will follow "description: "
+	- so_detection.sourceCreated: this will follow "date: "
+	- so_detection.severity: this will follow "level: "
+	- so_detection.category: this will be under logsource.category
+	- so_detection.product: this will be under logsource.product
+	Suricata:
+	- so_detection.title: this will follow "msg:"
+	- so_detection.severity: this will follow "signature severity" under the metadata field. Note that "minor" corresponds to low and "major" corresponds to high.
+	- so_detection.sourceCreated: this is under metadata and follows "created_at"
+	- so_detection.sourceUpdated: this is under metadata and follows "updated_at"
+	YARA:
+	- so_detection.title: this will be at the top of the rule block, and will follow "rule ". Note that this must be unique, as it is also the Public Id.
+	- so_detection.description: this will be under metadata and will follow "description = "
+	- so_detection.sourceCreated: this will be under metadata and will follow "date = "
+	*IMPORTANT*: Note that if the user asks you to modify anything else about the content field, such as references, it is totally fine to take a swing at it. The above run-down isn't a strict set of
+	rules, but instead is a loose guide to follow to help you. In fact, the actual behavior of a rule, which is outlined in the content field, is not at all tied to the attributes above.
+	However, it will be very common for users to ask you to modify a rule's behavior, and you should definitely help them out with that by editing the content field, even though the above
+	attributes might not be explicitly modified.`
+}
+
+func (t *UpdateDetectionContentTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"soc_id": {
+					Type:        "string",
+					Description: `The ID assigned to this detection by the server. This is often referred to as the "SOC ID" or "_id". In a detection, this is the "so_detection.id" field.`,
+				},
+				"public_id": {
+					Type:        "string",
+					Description: `The public ID shared across all Security Onion grids. In a detection, this is the "so_detection.publicId" field.`,
+				},
+				"content": {
+					Type: "string",
+					Description: `The underlying detection rule source content. (e.g., "title: CobaltStrike Named Pipe\nid: ...\n logsource:\n ...\ncondition: selection\nfalsepositives:\n...")
+					For a detection, this is the so_detection.content field. This particular content argument will be the updated content field of the original detection that the user wants to update.
+					For instance, if the user wants to update the severity of a suricata rule to "high", you would take the rule's current content field, and change the value of the "level" field inside this
+					content field to "high". Then, you will pass the entire updated content field as this argument.`,
+				},
+			},
+			Required: []string{"search_filter"},
+		},
+	}
+}
+
+type updateDetectionContentArgs struct {
+	SocId    string `json:"soc_id" example:"gQKCepgBAWAm-kn2lYs2"`
+	PublicId string `json:"public_id" example:"dcbe6004-f6e0-4579-9f98-9576201ffb29"`
+	Content  string `json:"content" example:"title: CobaltStrike Named Pipe\nid: ...\n logsource:\n ...\ncondition: selection\nfalsepositives:\n..."`
+}
+
+func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &updateDetectionContentArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Parameters = args
+
+	var detect *model.Detection
+
+	if args.PublicId != "" {
+		detect, err = srv.Detectionstore.GetDetectionByPublicId(ctx, args.PublicId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get detection by Public ID %s: %w", args.PublicId, err)
+		}
+	} else {
+		detect, err = srv.Detectionstore.GetDetection(ctx, args.SocId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get detection by SOC ID %s: %w", args.SocId, err)
+		}
+	}
+
+	detect.Content = args.Content
+
+	err = detect.Validate()
+	if err != nil {
+		logger.WithError(err).Error("invalid detection")
+		return nil, fmt.Errorf("invalid detection")
+	}
+
+	engInt, ok := srv.DetectionEngines.Load(detect.Engine)
+	if !ok {
+		logger.WithField("detectionEngine", detect.Engine).Error("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine")
+	}
+
+	engine := engInt.(server.DetectionEngine)
+
+	_, err = engine.ValidateRule(detect.Content)
+	if err != nil {
+		logger.WithError(err).WithField("detectionContent", detect.Content).Error("invalid rule")
+		return nil, fmt.Errorf("invalid rule: %w", err)
+	}
+
+	err = engine.ExtractDetails(detect)
+	if err != nil {
+		logger.WithError(err).WithFields(log.Fields{
+			"detectionEngine":   detect.Engine,
+			"detectionPublicId": detect.PublicID,
+		}).Error("unable to extract details from detection")
+		return nil, fmt.Errorf("unable to extract details for detection: %w", err)
+	}
+
+	_, err = engine.ApplyFilters(detect)
+	if err != nil {
+		logger.WithError(err).Error("unable to apply filters for detection")
+		return nil, fmt.Errorf("unable to apply filters for detection: %w", err)
+	}
+
+	err = (server.DetectionHandler).PrepareForSave(ctx, detect, engine)
+	if err != nil {
+		if err.Error() == "Object not found" {
+			web.Respond(w, r, http.StatusNotFound, nil)
+		} else if errors.Is(err, errPublicIdExists) {
+			web.Respond(w, r, http.StatusConflict, err)
+		} else if err.Error() == "rule does not contain a public Id" {
+			web.Respond(w, r, http.StatusBadRequest, "missingPublicIdErr")
+		} else {
+			web.Respond(w, r, http.StatusBadRequest, err)
+		}
+
+		return
+	}
+
+	errMap, err := engine.SyncLocalDetections(ctx, []*model.Detection{detect})
+	if err != nil {
+		logger.WithError(err).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection: %w", err)
+	}
+
+	if len(errMap) != 0 {
+		logger.WithField("errMap", errMap).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection")
+	}
+
+	result.Result = detect
+
+	return result, nil
+}

--- a/server/modules/assistant/update_detection_content.go
+++ b/server/modules/assistant/update_detection_content.go
@@ -8,9 +8,7 @@ package assistant
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
@@ -55,7 +53,8 @@ func (t *UpdateDetectionContentTool) GetDescription() string {
 	*IMPORTANT*: Note that if the user asks you to modify anything else about the content field, such as references, it is totally fine to take a swing at it. The above run-down isn't a strict set of
 	rules, but instead is a loose guide to follow to help you. In fact, the actual behavior of a rule, which is outlined in the content field, is not at all tied to the attributes above.
 	However, it will be very common for users to ask you to modify a rule's behavior, and you should definitely help them out with that by editing the content field, even though the above
-	attributes might not be explicitly modified.`
+	attributes might not be explicitly modified.
+	This tool will return the newly-updated detection.`
 }
 
 func (t *UpdateDetectionContentTool) GetSchema() model.JSONSchema {
@@ -136,7 +135,7 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 	err = detect.Validate()
 	if err != nil {
 		logger.WithError(err).Error("invalid detection")
-		return nil, fmt.Errorf("invalid detection")
+		return nil, fmt.Errorf("invalid detection: %w", err)
 	}
 
 	engInt, ok := srv.DetectionEngines.Load(detect.Engine)
@@ -168,19 +167,12 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 		return nil, fmt.Errorf("unable to apply filters for detection: %w", err)
 	}
 
-	err = (server.DetectionHandler).PrepareForSave(ctx, detect, engine)
-	if err != nil {
-		if err.Error() == "Object not found" {
-			web.Respond(w, r, http.StatusNotFound, nil)
-		} else if errors.Is(err, errPublicIdExists) {
-			web.Respond(w, r, http.StatusConflict, err)
-		} else if err.Error() == "rule does not contain a public Id" {
-			web.Respond(w, r, http.StatusBadRequest, "missingPublicIdErr")
-		} else {
-			web.Respond(w, r, http.StatusBadRequest, err)
-		}
+	detect.Kind = ""
 
-		return
+	detect, err = srv.Detectionstore.UpdateDetection(ctx, detect)
+	if err != nil {
+		logger.WithError(err).Error("failed to update detection")
+		return nil, fmt.Errorf("failed to update detection: %w", err)
 	}
 
 	errMap, err := engine.SyncLocalDetections(ctx, []*model.Detection{detect})
@@ -192,6 +184,14 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 	if len(errMap) != 0 {
 		logger.WithField("errMap", errMap).Error("unable to sync detection")
 		return nil, fmt.Errorf("unable to sync detection")
+	}
+
+	err = engine.MergeAuxiliaryData(detect)
+	if err != nil {
+		logger.WithError(err).WithFields(log.Fields{
+			"detectionEngine": detect.Engine,
+			"detectionId":     detect.Id,
+		}).Error("unable to merge auxiliary data into detection")
 	}
 
 	result.Result = detect

--- a/server/modules/assistant/update_detection_content.go
+++ b/server/modules/assistant/update_detection_content.go
@@ -130,6 +130,10 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 		}
 	}
 
+	if detect.IsCommunity {
+		return nil, fmt.Errorf("cannot update a community rule")
+	}
+
 	detect.Content = args.Content
 
 	err = detect.Validate()

--- a/server/modules/assistant/update_detection_content.go
+++ b/server/modules/assistant/update_detection_content.go
@@ -93,6 +93,11 @@ func (t *UpdateDetectionContentTool) Execute(ctx context.Context, srv *server.Se
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
 
+	err = srv.CheckAuthorized(ctx, "write", "detections")
+	if err != nil {
+		return nil, err
+	}
+
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
 
 	args := &updateDetectionContentArgs{}

--- a/server/modules/assistant/update_detection_content_test.go
+++ b/server/modules/assistant/update_detection_content_test.go
@@ -332,6 +332,21 @@ func TestUpdateDetectionContentTool_Execute(t *testing.T) {
 			mockMergeAuxError: errors.New("failed to merge auxiliary data"),
 			expectedError:     false, // This error is logged but not fatal
 		},
+		{
+			name:   "community detection cannot be updated",
+			params: `{"soc_id": "community-detection-id", "content": "title: Updated Community Rule"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "community-detection-id",
+				},
+				PublicID:    "community-public-id",
+				Title:       "Community Rule",
+				Content:     "original community content",
+				Engine:      model.EngineNameElastAlert,
+				IsCommunity: true, // This should trigger the error
+			},
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -373,7 +388,10 @@ func TestUpdateDetectionContentTool_Execute(t *testing.T) {
 					}
 
 					// Set up subsequent expectations based on error type
-					if tc.mockValidateError != nil {
+					// Skip all engine expectations for community detection error since it returns early
+					if tc.name == "community detection cannot be updated" {
+						// Don't set up any engine expectations since the function returns early with community error
+					} else if tc.mockValidateError != nil {
 						// Detection.Validate() is called on the detection object itself, so we can't mock it directly
 						// This would require the detection to have invalid fields
 						// For this test case, we need to set up the engine but not expect any calls since validation fails early

--- a/server/modules/assistant/update_detection_content_test.go
+++ b/server/modules/assistant/update_detection_content_test.go
@@ -1,0 +1,631 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/mock"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUpdateDetectionContentTool_GetName(t *testing.T) {
+	tool := &UpdateDetectionContentTool{}
+	assert.Equal(t, "update_detection_content", tool.GetName())
+}
+
+func TestUpdateDetectionContentTool_GetDescription(t *testing.T) {
+	desc := (&UpdateDetectionContentTool{}).GetDescription()
+	assert.NotEmpty(t, desc)
+	assert.Contains(t, desc, "Update an existing detection")
+	assert.Contains(t, desc, "modifying its content field")
+	assert.Contains(t, desc, "custom detections")
+	assert.Contains(t, desc, "isCommunity: false")
+	assert.Contains(t, desc, "soc_id or public_id")
+	assert.Contains(t, desc, "Sigma:")
+	assert.Contains(t, desc, "Suricata:")
+	assert.Contains(t, desc, "YARA:")
+}
+
+func TestUpdateDetectionContentTool_GetSchema(t *testing.T) {
+	schema := (&UpdateDetectionContentTool{}).GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+
+	// Check required properties
+	assert.Contains(t, schema.Json.Properties, "soc_id")
+	assert.Equal(t, "string", schema.Json.Properties["soc_id"].Type)
+	assert.Contains(t, schema.Json.Properties["soc_id"].Description, "SOC ID")
+
+	assert.Contains(t, schema.Json.Properties, "public_id")
+	assert.Equal(t, "string", schema.Json.Properties["public_id"].Type)
+	assert.Contains(t, schema.Json.Properties["public_id"].Description, "public ID")
+
+	assert.Contains(t, schema.Json.Properties, "content")
+	assert.Equal(t, "string", schema.Json.Properties["content"].Type)
+	assert.Contains(t, schema.Json.Properties["content"].Description, "detection rule source content")
+
+	assert.Contains(t, schema.Json.Required, "search_filter")
+}
+
+func TestUpdateDetectionContentTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		params                string
+		mockDetection         *model.Detection
+		mockUpdatedDetection  *model.Detection
+		mockGetDetectionError error
+		mockValidateError     error
+		mockEngineError       error
+		mockRuleValidateError error
+		mockExtractError      error
+		mockApplyFiltersError error
+		mockUpdateError       error
+		mockSyncError         error
+		mockSyncErrMap        map[string]string
+		mockMergeAuxError     error
+		expectedError         bool
+		usePublicId           bool
+	}{
+		{
+			name:   "successful update with soc_id",
+			params: `{"soc_id": "gQKCepgBAWAm-kn2lYs2", "content": "title: Updated Test Rule\nid: 12345\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '.exe'\n  condition: selection"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "gQKCepgBAWAm-kn2lYs2",
+				},
+				PublicID: "test-detection-public-id",
+				Title:    "Original Test Rule",
+				Content:  "title: Original Test Rule\nid: 12345\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '.exe'\n  condition: selection",
+				Engine:   model.EngineNameElastAlert,
+				Language: model.SigLangSigma,
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "gQKCepgBAWAm-kn2lYs2",
+				},
+				PublicID: "test-detection-public-id",
+				Title:    "Updated Test Rule",
+				Content:  "title: Updated Test Rule\nid: 12345\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '.exe'\n  condition: selection",
+				Engine:   model.EngineNameElastAlert,
+				Language: model.SigLangSigma,
+			},
+		},
+		{
+			name:   "successful update with public_id",
+			params: `{"public_id": "dcbe6004-f6e0-4579-9f98-9576201ffb29", "content": "alert tcp any any -> any any (msg:\"Updated Test Rule\"; sid:1000001; rev:2;)"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "hRLDepgBAWAm-kn2mZt3",
+				},
+				PublicID: "dcbe6004-f6e0-4579-9f98-9576201ffb29",
+				Title:    "Original Suricata Rule",
+				Content:  "alert tcp any any -> any any (msg:\"Original Test Rule\"; sid:1000001; rev:1;)",
+				Engine:   model.EngineNameSuricata,
+				Language: model.SigLangSuricata,
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "hRLDepgBAWAm-kn2mZt3",
+				},
+				PublicID: "dcbe6004-f6e0-4579-9f98-9576201ffb29",
+				Title:    "Updated Suricata Rule",
+				Content:  "alert tcp any any -> any any (msg:\"Updated Test Rule\"; sid:1000001; rev:2;)",
+				Engine:   model.EngineNameSuricata,
+				Language: model.SigLangSuricata,
+			},
+			usePublicId: true,
+		},
+		{
+			name:   "successful yara detection update",
+			params: `{"soc_id": "yara-detection-id", "content": "rule UpdatedTestRule {\n  meta:\n    description = \"Updated YARA rule\"\n  strings:\n    $test = \"updated_malware\"\n  condition:\n    $test\n}"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "yara-detection-id",
+				},
+				PublicID: "yara-public-id",
+				Title:    "OriginalTestRule",
+				Content:  "rule OriginalTestRule {\n  meta:\n    description = \"Original YARA rule\"\n  strings:\n    $test = \"malware\"\n  condition:\n    $test\n}",
+				Engine:   model.EngineNameStrelka,
+				Language: model.SigLangYara,
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "yara-detection-id",
+				},
+				PublicID: "yara-public-id",
+				Title:    "UpdatedTestRule",
+				Content:  "rule UpdatedTestRule {\n  meta:\n    description = \"Updated YARA rule\"\n  strings:\n    $test = \"updated_malware\"\n  condition:\n    $test\n}",
+				Engine:   model.EngineNameStrelka,
+				Language: model.SigLangYara,
+			},
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"soc_id": "test-id", "content": "missing closing brace"`,
+			expectedError: true,
+		},
+		{
+			name:                  "detection not found by soc_id",
+			params:                `{"soc_id": "nonexistent-id", "content": "title: Test"}`,
+			mockGetDetectionError: errors.New("detection not found"),
+			expectedError:         true,
+		},
+		{
+			name:                  "detection not found by public_id",
+			params:                `{"public_id": "nonexistent-public-id", "content": "title: Test"}`,
+			mockGetDetectionError: errors.New("detection not found"),
+			expectedError:         true,
+			usePublicId:           true,
+		},
+		{
+			name:   "detection validation error",
+			params: `{"soc_id": "test-id", "content": "invalid content"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   "invalid-engine", // This will cause validation to fail
+			},
+			mockValidateError: errors.New("invalid detection"),
+			expectedError:     true,
+		},
+		{
+			name:   "unsupported engine",
+			params: `{"soc_id": "test-id", "content": "title: Test"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockEngineError: errors.New("engine not found"),
+			expectedError:   true,
+		},
+		{
+			name:   "rule validation error",
+			params: `{"soc_id": "test-id", "content": "invalid rule syntax"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockRuleValidateError: errors.New("invalid rule syntax"),
+			expectedError:         true,
+		},
+		{
+			name:   "extract details error",
+			params: `{"soc_id": "test-id", "content": "title: Test"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockExtractError: errors.New("failed to extract details"),
+			expectedError:    true,
+		},
+		{
+			name:   "apply filters error",
+			params: `{"soc_id": "test-id", "content": "title: Test"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockApplyFiltersError: errors.New("failed to apply filters"),
+			expectedError:         true,
+		},
+		{
+			name:   "update detection error",
+			params: `{"soc_id": "test-id", "content": "title: Test"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockUpdateError: errors.New("failed to update detection"),
+			expectedError:   true,
+		},
+		{
+			name:   "sync local detections error",
+			params: `{"soc_id": "test-id", "content": "title: Test"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "title: Test",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockSyncError: errors.New("failed to sync"),
+			expectedError: true,
+		},
+		{
+			name:   "sync local detections error map",
+			params: `{"soc_id": "test-id", "content": "title: Test"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "title: Test",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockSyncErrMap: map[string]string{"test-id": "sync failed"},
+			expectedError:  true,
+		},
+		{
+			name:   "merge auxiliary data error (non-fatal)",
+			params: `{"soc_id": "test-id", "content": "title: Test"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "original content",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{
+					Id: "test-id",
+				},
+				PublicID: "test-public-id",
+				Title:    "Test Rule",
+				Content:  "title: Test",
+				Engine:   model.EngineNameElastAlert,
+			},
+			mockMergeAuxError: errors.New("failed to merge auxiliary data"),
+			expectedError:     false, // This error is logged but not fatal
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create mock stores
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+			mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+			// Create mock server
+			mockServer := &server.Server{
+				Detectionstore: mockDetectionstore,
+			}
+
+			// Set up detection engine expectations if not expecting engine error
+			if tc.mockEngineError == nil && tc.mockDetection != nil {
+				mockServer.DetectionEngines.Store(tc.mockDetection.Engine, mockDetectionEngine)
+			}
+
+			// Create context with user ID
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Set up mock expectations based on test case
+			// Always set up GetDetection or GetDetectionByPublicId expectations unless it's just a JSON parsing error
+			if tc.params != `{"soc_id": "test-id", "content": "missing closing brace"` {
+				if tc.mockGetDetectionError != nil {
+					if tc.usePublicId {
+						mockDetectionstore.EXPECT().GetDetectionByPublicId(ctx, gomock.Any()).Return(nil, tc.mockGetDetectionError)
+					} else {
+						mockDetectionstore.EXPECT().GetDetection(ctx, gomock.Any()).Return(nil, tc.mockGetDetectionError)
+					}
+				} else if tc.mockDetection != nil {
+					if tc.usePublicId {
+						mockDetectionstore.EXPECT().GetDetectionByPublicId(ctx, gomock.Any()).Return(tc.mockDetection, nil)
+					} else {
+						mockDetectionstore.EXPECT().GetDetection(ctx, gomock.Any()).Return(tc.mockDetection, nil)
+					}
+
+					// Set up subsequent expectations based on error type
+					if tc.mockValidateError != nil {
+						// Detection.Validate() is called on the detection object itself, so we can't mock it directly
+						// This would require the detection to have invalid fields
+						// For this test case, we need to set up the engine but not expect any calls since validation fails early
+						if tc.mockEngineError == nil {
+							// Don't set up any engine expectations since validation fails before engine calls
+						}
+					} else if tc.mockEngineError != nil {
+						// For unsupported engine test, don't set up any engine expectations
+					} else if tc.mockRuleValidateError != nil {
+						mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("", tc.mockRuleValidateError)
+					} else if tc.mockExtractError != nil {
+						mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+						mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(tc.mockExtractError)
+					} else if tc.mockApplyFiltersError != nil {
+						mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+						mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, tc.mockApplyFiltersError)
+					} else if tc.mockUpdateError != nil {
+						mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+						mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(nil, tc.mockUpdateError)
+					} else if tc.mockSyncError != nil {
+						mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+						mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(tc.mockUpdatedDetection, nil)
+						mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(nil, tc.mockSyncError)
+					} else if tc.mockSyncErrMap != nil {
+						mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+						mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(tc.mockUpdatedDetection, nil)
+						mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(tc.mockSyncErrMap, nil)
+					} else {
+						// Successful case
+						mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+						mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+							// Verify that content was updated and Kind/Operation were cleared
+							assert.Equal(t, "", detect.Kind)
+							assert.Equal(t, "", detect.Operation)
+							return tc.mockUpdatedDetection, nil
+						})
+						mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+
+						if tc.mockMergeAuxError != nil {
+							mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(tc.mockMergeAuxError)
+						} else {
+							mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
+						}
+					}
+				}
+			}
+
+			// Create tool and execute
+			tool := &UpdateDetectionContentTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
+
+			// Assert error expectations
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "update_detection_content", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+			assert.NotZero(t, result.TimeToExecute)
+
+			// Verify result content
+			if tc.mockUpdatedDetection != nil {
+				assert.Equal(t, tc.mockUpdatedDetection, result.Result)
+			}
+
+			// Verify parameters were captured
+			assert.NotNil(t, result.Parameters)
+			args, ok := result.Parameters.(*updateDetectionContentArgs)
+			assert.True(t, ok)
+			assert.NotNil(t, args)
+		})
+	}
+}
+
+func TestUpdateDetectionContentTool_Execute_VerifyContextPropagation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-123")
+
+	mockDetection := &model.Detection{
+		Auditable: model.Auditable{
+			Id: "test-detection-id",
+		},
+		PublicID: "test-public-id",
+		Title:    "Test Rule",
+		Content:  "original content",
+		Engine:   model.EngineNameElastAlert,
+	}
+
+	mockUpdatedDetection := &model.Detection{
+		Auditable: model.Auditable{
+			Id: "test-detection-id",
+		},
+		PublicID: "test-public-id",
+		Title:    "Updated Test Rule",
+		Content:  "title: Updated Test Rule",
+		Engine:   model.EngineNameElastAlert,
+	}
+
+	// Set up expectations
+	mockDetectionstore.EXPECT().GetDetection(ctx, "test-detection-id").Return(mockDetection, nil)
+	mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+	mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(mockUpdatedDetection, nil)
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+	mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
+
+	tool := &UpdateDetectionContentTool{}
+	_, err := tool.Execute(ctx, mockServer, `{"soc_id": "test-detection-id", "content": "title: Updated Test Rule"}`, "")
+
+	assert.NoError(t, err)
+}
+
+func TestUpdateDetectionContentTool_Execute_ContentUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+	originalContent := "title: Original Rule\nid: test-123\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '\\\\original.exe'\n  condition: selection"
+	updatedContent := "title: Updated Rule\nid: test-123\nlogsource:\n  category: process_creation\ndetection:\n  selection:\n    Image|endswith: '\\\\updated.exe'\n  condition: selection"
+
+	mockDetection := &model.Detection{
+		Auditable: model.Auditable{
+			Id:        "test-detection-id",
+			Kind:      "original-kind",
+			Operation: "original-operation",
+		},
+		PublicID: "test-public-id",
+		Title:    "Original Rule",
+		Content:  originalContent,
+		Engine:   model.EngineNameElastAlert,
+	}
+
+	mockUpdatedDetection := &model.Detection{
+		Auditable: model.Auditable{
+			Id:        "test-detection-id",
+			Kind:      "", // Should be cleared
+			Operation: "", // Should be cleared
+		},
+		PublicID: "test-public-id",
+		Title:    "Updated Rule",
+		Content:  updatedContent,
+		Engine:   model.EngineNameElastAlert,
+	}
+
+	// Set up expectations
+	mockDetectionstore.EXPECT().GetDetection(ctx, "test-detection-id").Return(mockDetection, nil)
+	mockDetectionEngine.EXPECT().ValidateRule(updatedContent).Return("validated", nil)
+	mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).DoAndReturn(func(detect *model.Detection) error {
+		// Verify content was updated before ExtractDetails is called
+		assert.Equal(t, updatedContent, detect.Content)
+		return nil
+	})
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+		// Verify that content was updated and Kind/Operation were cleared
+		assert.Equal(t, updatedContent, detect.Content)
+		assert.Equal(t, "", detect.Kind)
+		assert.Equal(t, "", detect.Operation)
+		return mockUpdatedDetection, nil
+	})
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+	mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
+
+	tool := &UpdateDetectionContentTool{}
+	// Use fmt.Sprintf with %q to properly escape the JSON content
+	params := fmt.Sprintf(`{"soc_id": "test-detection-id", "content": %q}`, updatedContent)
+	result, err := tool.Execute(ctx, mockServer, params, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, mockUpdatedDetection, result.Result)
+}
+
+func TestUpdateDetectionContentTool_Execute_TimeToExecute(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+	mockDetection := &model.Detection{
+		Auditable: model.Auditable{
+			Id: "test-detection-id",
+		},
+		PublicID: "test-public-id",
+		Title:    "Test Rule",
+		Content:  "original content",
+		Engine:   model.EngineNameElastAlert,
+	}
+
+	mockUpdatedDetection := &model.Detection{
+		Auditable: model.Auditable{
+			Id: "test-detection-id",
+		},
+		PublicID: "test-public-id",
+		Title:    "Updated Test Rule",
+		Content:  "title: Updated Test Rule",
+		Engine:   model.EngineNameElastAlert,
+	}
+
+	// Set up expectations
+	mockDetectionstore.EXPECT().GetDetection(ctx, "test-detection-id").Return(mockDetection, nil)
+	mockDetectionEngine.EXPECT().ValidateRule(gomock.Any()).Return("validated", nil)
+	mockDetectionEngine.EXPECT().ExtractDetails(gomock.Any()).Return(nil)
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(mockUpdatedDetection, nil)
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+	mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
+
+	tool := &UpdateDetectionContentTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"soc_id": "test-detection-id", "content": "title: Updated Test Rule"}`, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotZero(t, result.TimeToExecute)
+}

--- a/server/modules/assistant/update_detection_content_test.go
+++ b/server/modules/assistant/update_detection_content_test.go
@@ -56,8 +56,6 @@ func TestUpdateDetectionContentTool_GetSchema(t *testing.T) {
 	assert.Contains(t, schema.Json.Properties, "content")
 	assert.Equal(t, "string", schema.Json.Properties["content"].Type)
 	assert.Contains(t, schema.Json.Properties["content"].Description, "detection rule source content")
-
-	assert.Contains(t, schema.Json.Required, "search_filter")
 }
 
 func TestUpdateDetectionContentTool_Execute(t *testing.T) {

--- a/server/modules/assistant/update_detection_content_test.go
+++ b/server/modules/assistant/update_detection_content_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/security-onion-solutions/securityonion-soc/config"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/server/mock"
@@ -359,6 +360,9 @@ func TestUpdateDetectionContentTool_Execute(t *testing.T) {
 			// Create mock server
 			mockServer := &server.Server{
 				Detectionstore: mockDetectionstore,
+				Config: &config.ServerConfig{
+					DeveloperEnabled: true,
+				},
 			}
 
 			// Set up detection engine expectations if not expecting engine error
@@ -485,6 +489,9 @@ func TestUpdateDetectionContentTool_Execute_VerifyContextPropagation(t *testing.
 
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
 
@@ -534,6 +541,9 @@ func TestUpdateDetectionContentTool_Execute_ContentUpdate(t *testing.T) {
 
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
 
@@ -604,6 +614,9 @@ func TestUpdateDetectionContentTool_Execute_TimeToExecute(t *testing.T) {
 
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameElastAlert, mockDetectionEngine)
 

--- a/server/modules/assistant/update_overrides.go
+++ b/server/modules/assistant/update_overrides.go
@@ -165,6 +165,11 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	logger.WithField("toolParameters", params).Info("running tool for assistant")
 
+	err = srv.CheckAuthorized(ctx, "write", "detections")
+	if err != nil {
+		return nil, err
+	}
+
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
 
 	args := &updateOverridesArgs{}

--- a/server/modules/assistant/update_overrides.go
+++ b/server/modules/assistant/update_overrides.go
@@ -189,14 +189,55 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	var updatedOverrides []*model.Override
 
-	overridesBytes, err := json.Marshal(args.Overrides)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't marshal overrides param: %w", err)
-	}
+	for _, overrideMap := range args.Overrides {
+		override := &model.Override{}
 
-	err = json.Unmarshal(overridesBytes, &updatedOverrides)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't unmarshal overrides param: %w", err)
+		if v, ok := overrideMap["type"].(string); ok {
+			override.Type = model.OverrideType(v)
+		}
+		if v, ok := overrideMap["isEnabled"].(bool); ok {
+			override.IsEnabled = v
+		}
+		if v, ok := overrideMap["note"].(string); ok {
+			override.Note = v
+		}
+		if v, ok := overrideMap["createdAt"].(string); ok {
+			if t, err := time.Parse(time.RFC3339, v); err == nil {
+				override.CreatedAt = t
+			}
+		}
+		if v, ok := overrideMap["updatedAt"].(string); ok {
+			if t, err := time.Parse(time.RFC3339, v); err == nil {
+				override.UpdatedAt = t
+			}
+		}
+		if v, ok := overrideMap["regex"].(string); ok {
+			override.Regex = &v
+		}
+		if v, ok := overrideMap["value"].(string); ok {
+			override.Value = &v
+		}
+		if v, ok := overrideMap["track"].(string); ok {
+			override.Track = &v
+		}
+		if v, ok := overrideMap["ip"].(string); ok {
+			override.IP = &v
+		}
+		if v, ok := overrideMap["thresholdType"].(string); ok {
+			override.ThresholdType = &v
+		}
+		if v, ok := overrideMap["count"].(float64); ok {
+			count := int(v)
+			override.Count = &count
+		}
+		if v, ok := overrideMap["seconds"].(float64); ok {
+			seconds := int(v)
+			override.Seconds = &seconds
+		}
+		if v, ok := overrideMap["customFilter"].(string); ok {
+			override.CustomFilter = &v
+		}
+		updatedOverrides = append(updatedOverrides, override)
 	}
 
 	var detect *model.Detection

--- a/server/modules/assistant/update_overrides.go
+++ b/server/modules/assistant/update_overrides.go
@@ -1,0 +1,223 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+)
+
+func init() {
+	t := &UpdateOverridesTool{}
+	knownTools[t.GetName()] = t
+}
+
+type UpdateOverridesTool struct{}
+
+func (t *UpdateOverridesTool) GetName() string {
+	return "update_overrides"
+}
+
+func (t *UpdateOverridesTool) GetDescription() string {
+	return `Update an existing detection's overrides per the user's request by modifying its overrides field. This detection will be accessed with either its SOC Id or Public Id.
+	*IMPORTANT* You MUST provide ONE of soc_id or public_id, but NEVER both. The types of overrides and the fields for each override can vary between the Suricata and Sigma languages.
+	YARA does not have overrides. The 5 fields that all overrides do share in common, no matter the language, are "isEnabled", "createdAt", "updatedAt", "type", and "note".
+	The "note" field is the only one that can be empty. Here is a run-down of the language-specific override types and their respective fields and potential values:
+	Suricata:
+	- 3 different values for "type": "modify", "suppress", and "threshold"
+	  - "modify" overrides also have the fields "regex" and "value".
+	  - "suppress" overrides also have the fields "track" and "ip". The "track" field can ONLY take ONE of the following 3 values: "by_dst", "by_src", or "by_either". The "ip" field can be in CIDR notation or a Suricata variable.
+	  - "threshold" overrides also have the fields "thresholdType", "track", "count", and "seconds". The "track" field can only take one of 2 values: "by_dst" or "by_src". The "thresholdType" field can only take one of 3 values: "threshold", "limit", or "both".
+	Sigma:
+	- Only 1 value for "type": "customFilter"
+	  - "customFilter" overrides also have a field called "customFilter", where you put the actual filter.
+	Here are a couple important things to note. This tool only operates on a single detection, not multiple at once. This tool can be used to accomplish tasks such as adding a new override to a detection,
+	enabling/disabling an existing override, modifying a particular field inside of an override, and deleting an override, among other tasks. Note that you can also perform multiple of these tasks at once
+	if the user's request warrants it.
+	*IMPORTANT* When updating an override, DO NOT modify the createdAt or updatedAt fields. Additionally, when creating a new override, DO NOT include createdAt or updatedAt fields for the new override.`
+}
+
+func (t *UpdateOverridesTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"soc_id": {
+					Type:        "string",
+					Description: `The ID assigned to this detection by the server. This is often referred to as the "SOC ID" or "_id". In a detection, this is the "so_detection.id" field.`,
+				},
+				"public_id": {
+					Type:        "string",
+					Description: `The public ID shared across all Security Onion grids. In a detection, this is the "so_detection.publicId" field.`,
+				},
+				"overrides": {
+					Type: "string",
+					Description: `The entire updated overrides block for the detection, in string format. Here's an example overrides block:
+[
+	{
+		"note": "",
+		"createdAt": "2025-06-11T11:32:33.528762983-04:00",
+		"seconds": 60,
+		"isEnabled": true,
+		"count": 10,
+		"type": "threshold",
+		"track": "by_src",
+		"thresholdType": "both",
+		"updatedAt": "2025-06-11T11:32:33.528762983-04:00"
+	},
+	{
+		"note": "Override Note",
+		"createdAt": "2025-06-11T11:32:39.70697702-04:00",
+		"regex": "rev:1;",
+		"isEnabled": true,
+		"type": "modify",
+		"value": "rev:2;",
+		"updatedAt": "2025-06-11T11:32:39.70697702-04:00"
+	}
+]
+					The overrides block is located at the so_detection.overrides field of a detection. This particular overrides argument will be the updated overrides field of the original detection that the user wants to update.
+					For instance, if the user wants to update the first override above to track by destination instead of by source, you would take the current overrides block, find the first override, and change the value of the "track"
+					field in that override to "by_dst". Then, you will pass the entire updated overrides block, including the overrides that weren't actually updated, as this argument, in string format.`,
+				},
+			},
+		},
+	}
+}
+
+type updateOverridesArgs struct {
+	SocId     string `json:"soc_id" example:"gQKCepgBAWAm-kn2lYs2"`
+	PublicId  string `json:"public_id" example:"dcbe6004-f6e0-4579-9f98-9576201ffb29"`
+	Overrides string `json:"overrides" example:"[{\"note\":\"\",\"createdAt\":\"2025-06-11T11:32:33.528762983-04:00\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\",\"updatedAt\":\"2025-06-11T11:32:33.528762983-04:00\"},{\"note\":\"Override Note\",\"createdAt\":\"2025-06-11T11:32:39.70697702-04:00\",\"regex\":\"rev:1;\",\"isEnabled\":true,\"type\":\"modify\",\"value\":\"rev:2;\",\"updatedAt\":\"2025-06-11T11:32:39.70697702-04:00\"}]"`
+}
+
+func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &updateOverridesArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Parameters = args
+
+	var updatedOverrides []*model.Override
+
+	err = json.Unmarshal([]byte(args.Overrides), &updatedOverrides)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal overrides param: %w", err)
+	}
+
+	var detect *model.Detection
+
+	if args.PublicId != "" {
+		detect, err = srv.Detectionstore.GetDetectionByPublicId(ctx, args.PublicId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get detection by Public ID %s: %w", args.PublicId, err)
+		}
+	} else {
+		detect, err = srv.Detectionstore.GetDetection(ctx, args.SocId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get detection by SOC ID %s: %w", args.SocId, err)
+		}
+	}
+
+	now := time.Now()
+
+	for _, over := range updatedOverrides {
+		if over.CreatedAt.IsZero() {
+			over.CreatedAt = now
+		}
+		update := true
+		for i, oldOver := range detect.Overrides {
+			if over.Equal(oldOver) {
+				update = false
+				detect.Overrides = append(detect.Overrides[:i], detect.Overrides[i+1:]...)
+				break
+			}
+		}
+		if over.UpdatedAt.IsZero() || update {
+			over.UpdatedAt = now
+		}
+	}
+
+	detect.Overrides = updatedOverrides
+
+	err = detect.Validate()
+	if err != nil {
+		logger.WithError(err).Error("invalid override")
+		return nil, fmt.Errorf("invalid override: %w", err)
+	}
+
+	engInt, ok := srv.DetectionEngines.Load(detect.Engine)
+	if !ok {
+		logger.WithField("detectionEngine", detect.Engine).Error("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine")
+	}
+
+	engine := engInt.(server.DetectionEngine)
+
+	_, err = engine.ApplyFilters(detect)
+	if err != nil {
+		logger.WithError(err).Error("unable to apply filters for detection")
+		return nil, fmt.Errorf("unable to apply filters for detection: %w", err)
+	}
+
+	detect.Kind = ""
+	detect.Operation = ""
+
+	detect, err = srv.Detectionstore.UpdateDetection(ctx, detect)
+	if err != nil {
+		logger.WithError(err).Error("failed to update overrides")
+		return nil, fmt.Errorf("failed to update overrides: %w", err)
+	}
+
+	errMap, err := engine.SyncLocalDetections(ctx, []*model.Detection{detect})
+	if err != nil {
+		logger.WithError(err).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection: %w", err)
+	}
+
+	if len(errMap) != 0 {
+		logger.WithField("errMap", errMap).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection")
+	}
+
+	err = engine.MergeAuxiliaryData(detect)
+	if err != nil {
+		logger.WithError(err).WithFields(log.Fields{
+			"detectionEngine": detect.Engine,
+			"detectionId":     detect.Id,
+		}).Error("unable to merge auxiliary data into detection")
+	}
+
+	result.Result = detect
+
+	return result, nil
+}

--- a/server/modules/assistant/update_overrides.go
+++ b/server/modules/assistant/update_overrides.go
@@ -61,8 +61,68 @@ func (t *UpdateOverridesTool) GetSchema() model.JSONSchema {
 					Description: `The public ID shared across all Security Onion grids. In a detection, this is the "so_detection.publicId" field.`,
 				},
 				"overrides": {
-					Type: "string",
-					Description: `The entire updated overrides block for the detection, in string format. Here's an example overrides block:
+					Type: "array",
+					Items: map[string]model.ToolSchemaProperty{
+						"override": {
+							Description: "Each of these objects represents an individual override.",
+							Type:        "object",
+							Items: map[string]model.ToolSchemaProperty{
+								"isEnabled": {
+									Type:        "boolean",
+									Description: "Indicates whether this override is enabled.",
+								},
+								"createdAt": {
+									Type:        "string",
+									Description: "The date and time when this override was created. This field should not be included for newly created overrides, and it also should not be modified.",
+								},
+								"updatedAt": {
+									Type:        "string",
+									Description: "The date and time when this override was last modified. This field should not be included for newly created overrides, and it also should not be modified.",
+								},
+								"type": {
+									Type:        "string",
+									Description: "The type of override; available values vary between detection engines.",
+								},
+								"note": {
+									Type:        "string",
+									Description: "An optional operational note for this override.",
+								},
+								"regex": {
+									Type:        "string",
+									Description: "(suricata only) Regular expression for matching modify overrides.",
+								},
+								"value": {
+									Type:        "string",
+									Description: "(suricata only) The value needing to match the regex in order for this override to apply.",
+								},
+								"track": {
+									Type:        "string",
+									Description: "(suricata only) Track type for suppress and threshold overrides (by_either only applies to suppress overrides).",
+								},
+								"ip": {
+									Type:        "string",
+									Description: "(suricata only) The IP address or network value.",
+								},
+								"thresholdType": {
+									Type:        "string",
+									Description: "(suricata only) Threshold type, for threshold overrides.",
+								},
+								"count": {
+									Type:        "integer",
+									Description: "(suricata only) For treshold overrides, this is the number of occurrences allowed, within the given seconds interval, before this detection triggers an alert. Must be non-negative and greater than 0.",
+								},
+								"seconds": {
+									Type:        "integer",
+									Description: "(suricata only) For treshold overrides, this is the number of seconds that the occurrence threshold must occur within. Must be non-negative and greater than 0.",
+								},
+								"customFilter": {
+									Type:        "string",
+									Description: "(elastalert only) The custom filter applied to Sigma detections before the detection will trigger an alert.",
+								},
+							},
+						},
+					},
+					Description: `The entire updated overrides block for the detection, as an array of objects. Here's an example overrides block:
 [
 	{
 		"note": "",
@@ -87,7 +147,7 @@ func (t *UpdateOverridesTool) GetSchema() model.JSONSchema {
 ]
 					The overrides block is located at the so_detection.overrides field of a detection. This particular overrides argument will be the updated overrides field of the original detection that the user wants to update.
 					For instance, if the user wants to update the first override above to track by destination instead of by source, you would take the current overrides block, find the first override, and change the value of the "track"
-					field in that override to "by_dst". Then, you will pass the entire updated overrides block, including the overrides that weren't actually updated, as this argument, in string format.`,
+					field in that override to "by_dst". Then, you will pass the entire updated overrides block, including the overrides that weren't actually updated, as this argument, as an array of objects.`,
 				},
 			},
 		},
@@ -95,9 +155,9 @@ func (t *UpdateOverridesTool) GetSchema() model.JSONSchema {
 }
 
 type updateOverridesArgs struct {
-	SocId     string `json:"soc_id" example:"gQKCepgBAWAm-kn2lYs2"`
-	PublicId  string `json:"public_id" example:"dcbe6004-f6e0-4579-9f98-9576201ffb29"`
-	Overrides string `json:"overrides" example:"[{\"note\":\"\",\"createdAt\":\"2025-06-11T11:32:33.528762983-04:00\",\"seconds\":60,\"isEnabled\":true,\"count\":10,\"type\":\"threshold\",\"track\":\"by_src\",\"thresholdType\":\"both\",\"updatedAt\":\"2025-06-11T11:32:33.528762983-04:00\"},{\"note\":\"Override Note\",\"createdAt\":\"2025-06-11T11:32:39.70697702-04:00\",\"regex\":\"rev:1;\",\"isEnabled\":true,\"type\":\"modify\",\"value\":\"rev:2;\",\"updatedAt\":\"2025-06-11T11:32:39.70697702-04:00\"}]"`
+	SocId     string           `json:"soc_id" example:"gQKCepgBAWAm-kn2lYs2"`
+	PublicId  string           `json:"public_id" example:"dcbe6004-f6e0-4579-9f98-9576201ffb29"`
+	Overrides []map[string]any `json:"overrides"`
 }
 
 func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
@@ -129,7 +189,12 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	var updatedOverrides []*model.Override
 
-	err = json.Unmarshal([]byte(args.Overrides), &updatedOverrides)
+	overridesBytes, err := json.Marshal(args.Overrides)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal overrides param: %w", err)
+	}
+
+	err = json.Unmarshal(overridesBytes, &updatedOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't unmarshal overrides param: %w", err)
 	}

--- a/server/modules/assistant/update_overrides.go
+++ b/server/modules/assistant/update_overrides.go
@@ -167,7 +167,7 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	err = srv.CheckAuthorized(ctx, "write", "detections")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("user is not authorized to write detections: %w", err)
 	}
 
 	userId := ctx.Value(web.ContextKeyRequestorId).(string)
@@ -187,7 +187,7 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	err = json.Unmarshal([]byte(params), args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't unmarshal params: %w", err)
 	}
 
 	result.Parameters = args
@@ -282,42 +282,46 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	err = detect.Validate()
 	if err != nil {
-		logger.WithError(err).Error("invalid override")
-		return nil, fmt.Errorf("invalid override: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("invalid override")
+		return nil, fmt.Errorf("invalid override for detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
 	engInt, ok := srv.DetectionEngines.Load(detect.Engine)
 	if !ok {
 		logger.WithField("detectionEngine", detect.Engine).Error("unsupported engine")
-		return nil, fmt.Errorf("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine %s", detect.Engine)
 	}
 
 	engine := engInt.(server.DetectionEngine)
 
 	_, err = engine.ApplyFilters(detect)
 	if err != nil {
-		logger.WithError(err).Error("unable to apply filters for detection")
-		return nil, fmt.Errorf("unable to apply filters for detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("unable to apply filters for detection")
+		return nil, fmt.Errorf("unable to apply filters for detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
 	detect.Kind = ""
 	detect.Operation = ""
 
+	tempPublicId := detect.PublicID
 	detect, err = srv.Detectionstore.UpdateDetection(ctx, detect)
 	if err != nil {
-		logger.WithError(err).Error("failed to update overrides")
-		return nil, fmt.Errorf("failed to update overrides: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", tempPublicId).Error("failed to update overrides")
+		return nil, fmt.Errorf("failed to update overrides for detection with Public ID %s: %w", tempPublicId, err)
 	}
 
 	errMap, err := engine.SyncLocalDetections(ctx, []*model.Detection{detect})
 	if err != nil {
-		logger.WithError(err).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection: %w", err)
+		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection with Public ID %s: %w", detect.PublicID, err)
 	}
 
 	if len(errMap) != 0 {
-		logger.WithField("errMap", errMap).Error("unable to sync detection")
-		return nil, fmt.Errorf("unable to sync detection")
+		logger.WithFields(log.Fields{
+			"detectionPublicId": detect.PublicID,
+			"errMap":            errMap,
+		}).Error("unable to sync detection")
+		return nil, fmt.Errorf("unable to sync detection with Public ID %s: %v", detect.PublicID, errMap)
 	}
 
 	err = engine.MergeAuxiliaryData(detect)

--- a/server/modules/assistant/update_overrides.go
+++ b/server/modules/assistant/update_overrides.go
@@ -294,12 +294,6 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	engine := engInt.(server.DetectionEngine)
 
-	_, err = engine.ApplyFilters(detect)
-	if err != nil {
-		logger.WithError(err).WithField("detectionPublicId", detect.PublicID).Error("unable to apply filters for detection")
-		return nil, fmt.Errorf("unable to apply filters for detection with Public ID %s: %w", detect.PublicID, err)
-	}
-
 	detect.Kind = ""
 	detect.Operation = ""
 

--- a/server/modules/assistant/update_overrides.go
+++ b/server/modules/assistant/update_overrides.go
@@ -192,58 +192,7 @@ func (t *UpdateOverridesTool) Execute(ctx context.Context, srv *server.Server, p
 
 	result.Parameters = args
 
-	var updatedOverrides []*model.Override
-
-	for _, overrideMap := range args.Overrides {
-		override := &model.Override{}
-
-		if v, ok := overrideMap["type"].(string); ok {
-			override.Type = model.OverrideType(v)
-		}
-		if v, ok := overrideMap["isEnabled"].(bool); ok {
-			override.IsEnabled = v
-		}
-		if v, ok := overrideMap["note"].(string); ok {
-			override.Note = v
-		}
-		if v, ok := overrideMap["createdAt"].(string); ok {
-			if t, err := time.Parse(time.RFC3339, v); err == nil {
-				override.CreatedAt = t
-			}
-		}
-		if v, ok := overrideMap["updatedAt"].(string); ok {
-			if t, err := time.Parse(time.RFC3339, v); err == nil {
-				override.UpdatedAt = t
-			}
-		}
-		if v, ok := overrideMap["regex"].(string); ok {
-			override.Regex = &v
-		}
-		if v, ok := overrideMap["value"].(string); ok {
-			override.Value = &v
-		}
-		if v, ok := overrideMap["track"].(string); ok {
-			override.Track = &v
-		}
-		if v, ok := overrideMap["ip"].(string); ok {
-			override.IP = &v
-		}
-		if v, ok := overrideMap["thresholdType"].(string); ok {
-			override.ThresholdType = &v
-		}
-		if v, ok := overrideMap["count"].(float64); ok {
-			count := int(v)
-			override.Count = &count
-		}
-		if v, ok := overrideMap["seconds"].(float64); ok {
-			seconds := int(v)
-			override.Seconds = &seconds
-		}
-		if v, ok := overrideMap["customFilter"].(string); ok {
-			override.CustomFilter = &v
-		}
-		updatedOverrides = append(updatedOverrides, override)
-	}
+	updatedOverrides := populateOverridesFromMaps(args.Overrides, true)
 
 	var detect *model.Detection
 

--- a/server/modules/assistant/update_overrides_test.go
+++ b/server/modules/assistant/update_overrides_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/security-onion-solutions/securityonion-soc/config"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	"github.com/security-onion-solutions/securityonion-soc/server/mock"
@@ -247,6 +248,9 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 
 			mockServer := &server.Server{
 				Detectionstore: mockDetectionstore,
+				Config: &config.ServerConfig{
+					DeveloperEnabled: true,
+				},
 			}
 
 			if tc.mockEngineError == nil && tc.mockDetection != nil {
@@ -332,6 +336,9 @@ func TestUpdateOverridesTool_Execute_TimestampHandling(t *testing.T) {
 
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockDetectionEngine)
 
@@ -414,6 +421,9 @@ func TestUpdateOverridesTool_Execute_EmptyOverrides(t *testing.T) {
 
 	mockServer := &server.Server{
 		Detectionstore: mockDetectionstore,
+		Config: &config.ServerConfig{
+			DeveloperEnabled: true,
+		},
 	}
 	mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockDetectionEngine)
 

--- a/server/modules/assistant/update_overrides_test.go
+++ b/server/modules/assistant/update_overrides_test.go
@@ -1,0 +1,467 @@
+// Copyright 2020-2025 Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/mock"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUpdateOverridesTool_GetName(t *testing.T) {
+	tool := &UpdateOverridesTool{}
+	assert.Equal(t, "update_overrides", tool.GetName())
+}
+
+func TestUpdateOverridesTool_GetDescription(t *testing.T) {
+	desc := (&UpdateOverridesTool{}).GetDescription()
+	assert.NotEmpty(t, desc)
+	assert.Contains(t, desc, "Update an existing detection's overrides")
+	assert.Contains(t, desc, "soc_id or public_id")
+	assert.Contains(t, desc, "Suricata:")
+	assert.Contains(t, desc, "Sigma:")
+	assert.Contains(t, desc, "YARA does not have overrides")
+}
+
+func TestUpdateOverridesTool_GetSchema(t *testing.T) {
+	schema := (&UpdateOverridesTool{}).GetSchema()
+
+	assert.NotNil(t, schema.Json)
+	assert.Equal(t, "object", schema.Json.Type)
+
+	// Check required properties
+	assert.Contains(t, schema.Json.Properties, "soc_id")
+	assert.Contains(t, schema.Json.Properties, "public_id")
+	assert.Contains(t, schema.Json.Properties, "overrides")
+}
+
+func TestUpdateOverridesTool_Execute(t *testing.T) {
+	// Helper function to create string pointers
+	strPtr := func(s string) *string { return &s }
+	intPtr := func(i int) *int { return &i }
+
+	testCases := []struct {
+		name                  string
+		params                string
+		mockDetection         *model.Detection
+		mockUpdatedDetection  *model.Detection
+		mockGetDetectionError error
+		mockEngineError       error
+		mockApplyFiltersError error
+		mockUpdateError       error
+		mockSyncError         error
+		expectedError         bool
+		usePublicId           bool
+	}{
+		{
+			name:   "successful update with suricata threshold override",
+			params: `{"soc_id": "test-id", "overrides": "[{\"note\":\"\",\"isEnabled\":true,\"type\":\"threshold\",\"thresholdType\":\"both\",\"track\":\"by_src\",\"count\":10,\"seconds\":60}]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				PublicID:  "test-public-id",
+				Title:     "Test Suricata Rule",
+				Engine:    model.EngineNameSuricata,
+				Language:  model.SigLangSuricata,
+				Overrides: []*model.Override{},
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				PublicID:  "test-public-id",
+				Title:     "Test Suricata Rule",
+				Engine:    model.EngineNameSuricata,
+				Language:  model.SigLangSuricata,
+				Overrides: []*model.Override{
+					{
+						Type:      model.OverrideTypeThreshold,
+						IsEnabled: true,
+						Note:      "",
+						CreatedAt: time.Now(),
+						UpdatedAt: time.Now(),
+						OverrideParameters: model.OverrideParameters{
+							ThresholdType: strPtr("both"),
+							Track:         strPtr("by_src"),
+							Count:         intPtr(10),
+							Seconds:       intPtr(60),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "successful update with sigma custom filter override",
+			params: `{"public_id": "test-public-id", "overrides": "[{\"note\":\"Custom filter\",\"isEnabled\":true,\"type\":\"customFilter\",\"customFilter\":\"sofilter:\\n  user.name: test_user\"}]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				PublicID:  "test-public-id",
+				Title:     "Test Sigma Rule",
+				Engine:    model.EngineNameElastAlert,
+				Language:  model.SigLangSigma,
+				Overrides: []*model.Override{},
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				PublicID:  "test-public-id",
+				Title:     "Test Sigma Rule",
+				Engine:    model.EngineNameElastAlert,
+				Language:  model.SigLangSigma,
+				Overrides: []*model.Override{
+					{
+						Type:      model.OverrideTypeCustomFilter,
+						IsEnabled: true,
+						Note:      "Custom filter",
+						CreatedAt: time.Now(),
+						UpdatedAt: time.Now(),
+						OverrideParameters: model.OverrideParameters{
+							CustomFilter: strPtr("sofilter:\n  user.name: test_user"),
+						},
+					},
+				},
+			},
+			usePublicId: true,
+		},
+		{
+			name:   "multiple overrides update",
+			params: `{"soc_id": "test-id", "overrides": "[{\"note\":\"First\",\"isEnabled\":true,\"type\":\"threshold\",\"thresholdType\":\"limit\",\"track\":\"by_src\",\"count\":5,\"seconds\":30},{\"note\":\"Second\",\"isEnabled\":false,\"type\":\"modify\",\"regex\":\"sid:1000001;\",\"value\":\"sid:1000002;\"}]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				PublicID:  "test-public-id",
+				Engine:    model.EngineNameSuricata,
+				Overrides: []*model.Override{},
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				PublicID:  "test-public-id",
+				Engine:    model.EngineNameSuricata,
+				Overrides: []*model.Override{
+					{
+						Type:      model.OverrideTypeThreshold,
+						IsEnabled: true,
+						Note:      "First",
+						OverrideParameters: model.OverrideParameters{
+							ThresholdType: strPtr("limit"),
+							Track:         strPtr("by_src"),
+							Count:         intPtr(5),
+							Seconds:       intPtr(30),
+						},
+					},
+					{
+						Type:      model.OverrideTypeModify,
+						IsEnabled: false,
+						Note:      "Second",
+						OverrideParameters: model.OverrideParameters{
+							Regex: strPtr("sid:1000001;"),
+							Value: strPtr("sid:1000002;"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "invalid JSON parameters",
+			params:        `{"soc_id": "test-id", "overrides": "invalid json"}`,
+			expectedError: true,
+		},
+		{
+			name:                  "detection not found",
+			params:                `{"soc_id": "nonexistent-id", "overrides": "[]"}`,
+			mockGetDetectionError: errors.New("detection not found"),
+			expectedError:         true,
+		},
+		{
+			name:   "validation error - missing required parameters",
+			params: `{"soc_id": "test-id", "overrides": "[{\"type\":\"threshold\",\"isEnabled\":true,\"track\":\"by_src\"}]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				PublicID:  "test-public-id",
+				Engine:    model.EngineNameSuricata,
+			},
+			expectedError: true,
+		},
+		{
+			name:   "unsupported engine",
+			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				Engine:    model.EngineNameSuricata,
+			},
+			mockEngineError: errors.New("engine not found"),
+			expectedError:   true,
+		},
+		{
+			name:   "apply filters error",
+			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				Engine:    model.EngineNameSuricata,
+			},
+			mockApplyFiltersError: errors.New("failed to apply filters"),
+			expectedError:         true,
+		},
+		{
+			name:   "update detection error",
+			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				Engine:    model.EngineNameSuricata,
+			},
+			mockUpdateError: errors.New("failed to update detection"),
+			expectedError:   true,
+		},
+		{
+			name:   "sync error",
+			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			mockDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				Engine:    model.EngineNameSuricata,
+			},
+			mockUpdatedDetection: &model.Detection{
+				Auditable: model.Auditable{Id: "test-id"},
+				Engine:    model.EngineNameSuricata,
+				Overrides: []*model.Override{},
+			},
+			mockSyncError: errors.New("failed to sync"),
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+			mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+			mockServer := &server.Server{
+				Detectionstore: mockDetectionstore,
+			}
+
+			if tc.mockEngineError == nil && tc.mockDetection != nil {
+				mockServer.DetectionEngines.Store(tc.mockDetection.Engine, mockDetectionEngine)
+			}
+
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			// Set up mock expectations
+			if tc.params != `{"soc_id": "test-id", "overrides": "invalid json"}` {
+				if tc.mockGetDetectionError != nil {
+					if tc.usePublicId {
+						mockDetectionstore.EXPECT().GetDetectionByPublicId(ctx, gomock.Any()).Return(nil, tc.mockGetDetectionError)
+					} else {
+						mockDetectionstore.EXPECT().GetDetection(ctx, gomock.Any()).Return(nil, tc.mockGetDetectionError)
+					}
+				} else if tc.mockDetection != nil {
+					if tc.usePublicId {
+						mockDetectionstore.EXPECT().GetDetectionByPublicId(ctx, gomock.Any()).Return(tc.mockDetection, nil)
+					} else {
+						mockDetectionstore.EXPECT().GetDetection(ctx, gomock.Any()).Return(tc.mockDetection, nil)
+					}
+
+					if tc.name == "validation error - missing required parameters" {
+						// Don't set up engine expectations since validation fails early
+					} else if tc.mockEngineError != nil {
+						// Don't set up engine expectations for unsupported engine
+					} else if tc.mockApplyFiltersError != nil {
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, tc.mockApplyFiltersError)
+					} else if tc.mockUpdateError != nil {
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(nil, tc.mockUpdateError)
+					} else if tc.mockSyncError != nil {
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(tc.mockUpdatedDetection, nil)
+						mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(nil, tc.mockSyncError)
+					} else {
+						// Successful case
+						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+							assert.Equal(t, "", detect.Kind)
+							assert.Equal(t, "", detect.Operation)
+							return tc.mockUpdatedDetection, nil
+						})
+						mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+						mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
+					}
+				}
+			}
+
+			tool := &UpdateOverridesTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, "")
+
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "update_overrides", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+			assert.NotZero(t, result.TimeToExecute)
+
+			if tc.mockUpdatedDetection != nil {
+				assert.Equal(t, tc.mockUpdatedDetection, result.Result)
+			}
+
+			assert.NotNil(t, result.Parameters)
+			args, ok := result.Parameters.(*updateOverridesArgs)
+			assert.True(t, ok)
+			assert.NotNil(t, args)
+		})
+	}
+}
+
+func TestUpdateOverridesTool_Execute_TimestampHandling(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+	strPtr := func(s string) *string { return &s }
+	intPtr := func(i int) *int { return &i }
+
+	existingTime := time.Now().Add(-time.Hour)
+	mockDetection := &model.Detection{
+		Auditable: model.Auditable{Id: "test-id"},
+		PublicID:  "test-public-id",
+		Engine:    model.EngineNameSuricata,
+		Overrides: []*model.Override{
+			{
+				Type:      model.OverrideTypeThreshold,
+				IsEnabled: true,
+				CreatedAt: existingTime,
+				UpdatedAt: existingTime,
+				OverrideParameters: model.OverrideParameters{
+					ThresholdType: strPtr("limit"),
+					Track:         strPtr("by_src"),
+					Count:         intPtr(5),
+					Seconds:       intPtr(30),
+				},
+			},
+		},
+	}
+
+	mockUpdatedDetection := &model.Detection{
+		Auditable: model.Auditable{Id: "test-id"},
+		PublicID:  "test-public-id",
+		Engine:    model.EngineNameSuricata,
+		Overrides: []*model.Override{
+			{
+				Type:      model.OverrideTypeThreshold,
+				IsEnabled: true,
+				CreatedAt: existingTime,
+				UpdatedAt: time.Now(),
+				OverrideParameters: model.OverrideParameters{
+					ThresholdType: strPtr("both"),
+					Track:         strPtr("by_dst"),
+					Count:         intPtr(10),
+					Seconds:       intPtr(60),
+				},
+			},
+		},
+	}
+
+	mockDetectionstore.EXPECT().GetDetection(ctx, "test-id").Return(mockDetection, nil)
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+		if len(detect.Overrides) > 0 {
+			override := detect.Overrides[0]
+			// CreatedAt should be preserved, UpdatedAt should be updated
+			assert.Equal(t, existingTime.Unix(), override.CreatedAt.Unix())
+			assert.True(t, override.UpdatedAt.After(existingTime))
+		}
+		return mockUpdatedDetection, nil
+	})
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+	mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
+
+	tool := &UpdateOverridesTool{}
+	params := fmt.Sprintf(`{"soc_id": "test-id", "overrides": "[{\"isEnabled\":true,\"type\":\"threshold\",\"thresholdType\":\"both\",\"track\":\"by_dst\",\"count\":10,\"seconds\":60,\"createdAt\":\"%s\",\"updatedAt\":\"%s\"}]"}`,
+		existingTime.Format(time.RFC3339), existingTime.Format(time.RFC3339))
+	result, err := tool.Execute(ctx, mockServer, params, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, mockUpdatedDetection, result.Result)
+}
+
+func TestUpdateOverridesTool_Execute_EmptyOverrides(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDetectionstore := mock.NewMockDetectionstore(ctrl)
+	mockDetectionEngine := mock.NewMockDetectionEngine(ctrl)
+
+	mockServer := &server.Server{
+		Detectionstore: mockDetectionstore,
+	}
+	mockServer.DetectionEngines.Store(model.EngineNameSuricata, mockDetectionEngine)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+	strPtr := func(s string) *string { return &s }
+	intPtr := func(i int) *int { return &i }
+
+	mockDetection := &model.Detection{
+		Auditable: model.Auditable{Id: "test-id"},
+		PublicID:  "test-public-id",
+		Engine:    model.EngineNameSuricata,
+		Overrides: []*model.Override{
+			{
+				Type:      model.OverrideTypeThreshold,
+				IsEnabled: true,
+				CreatedAt: time.Now().Add(-time.Hour),
+				UpdatedAt: time.Now().Add(-time.Hour),
+				OverrideParameters: model.OverrideParameters{
+					ThresholdType: strPtr("limit"),
+					Track:         strPtr("by_src"),
+					Count:         intPtr(5),
+					Seconds:       intPtr(30),
+				},
+			},
+		},
+	}
+
+	mockUpdatedDetection := &model.Detection{
+		Auditable: model.Auditable{Id: "test-id"},
+		PublicID:  "test-public-id",
+		Engine:    model.EngineNameSuricata,
+		Overrides: []*model.Override{}, // All overrides removed
+	}
+
+	mockDetectionstore.EXPECT().GetDetection(ctx, "test-id").Return(mockDetection, nil)
+	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
+	mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
+		assert.Len(t, detect.Overrides, 0)
+		return mockUpdatedDetection, nil
+	})
+	mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(map[string]string{}, nil)
+	mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
+
+	tool := &UpdateOverridesTool{}
+	result, err := tool.Execute(ctx, mockServer, `{"soc_id": "test-id", "overrides": "[]"}`, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, mockUpdatedDetection, result.Result)
+}

--- a/server/modules/assistant/update_overrides_test.go
+++ b/server/modules/assistant/update_overrides_test.go
@@ -61,7 +61,6 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		mockUpdatedDetection  *model.Detection
 		mockGetDetectionError error
 		mockEngineError       error
-		mockApplyFiltersError error
 		mockUpdateError       error
 		mockSyncError         error
 		expectedError         bool
@@ -202,16 +201,6 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 			expectedError:   true,
 		},
 		{
-			name:   "apply filters error",
-			params: `{"soc_id": "test-id", "overrides": []}`,
-			mockDetection: &model.Detection{
-				Auditable: model.Auditable{Id: "test-id"},
-				Engine:    model.EngineNameSuricata,
-			},
-			mockApplyFiltersError: errors.New("failed to apply filters"),
-			expectedError:         true,
-		},
-		{
 			name:   "update detection error",
 			params: `{"soc_id": "test-id", "overrides": []}`,
 			mockDetection: &model.Detection{
@@ -278,18 +267,13 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 						// Don't set up engine expectations since validation fails early
 					} else if tc.mockEngineError != nil {
 						// Don't set up engine expectations for unsupported engine
-					} else if tc.mockApplyFiltersError != nil {
-						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, tc.mockApplyFiltersError)
 					} else if tc.mockUpdateError != nil {
-						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
 						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(nil, tc.mockUpdateError)
 					} else if tc.mockSyncError != nil {
-						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
 						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).Return(tc.mockUpdatedDetection, nil)
 						mockDetectionEngine.EXPECT().SyncLocalDetections(ctx, gomock.Any()).Return(nil, tc.mockSyncError)
 					} else {
 						// Successful case
-						mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
 						mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
 							assert.Equal(t, "", detect.Kind)
 							assert.Equal(t, "", detect.Operation)
@@ -389,7 +373,6 @@ func TestUpdateOverridesTool_Execute_TimestampHandling(t *testing.T) {
 	}
 
 	mockDetectionstore.EXPECT().GetDetection(ctx, "test-id").Return(mockDetection, nil)
-	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
 	mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
 		if len(detect.Overrides) > 0 {
 			override := detect.Overrides[0]
@@ -460,7 +443,6 @@ func TestUpdateOverridesTool_Execute_EmptyOverrides(t *testing.T) {
 	}
 
 	mockDetectionstore.EXPECT().GetDetection(ctx, "test-id").Return(mockDetection, nil)
-	mockDetectionEngine.EXPECT().ApplyFilters(gomock.Any()).Return(false, nil)
 	mockDetectionstore.EXPECT().UpdateDetection(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, detect *model.Detection) (*model.Detection, error) {
 		assert.Len(t, detect.Overrides, 0)
 		return mockUpdatedDetection, nil

--- a/server/modules/assistant/update_overrides_test.go
+++ b/server/modules/assistant/update_overrides_test.go
@@ -68,7 +68,7 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 	}{
 		{
 			name:   "successful update with suricata threshold override",
-			params: `{"soc_id": "test-id", "overrides": "[{\"note\":\"\",\"isEnabled\":true,\"type\":\"threshold\",\"thresholdType\":\"both\",\"track\":\"by_src\",\"count\":10,\"seconds\":60}]"}`,
+			params: `{"soc_id": "test-id", "overrides": [{"note":"","isEnabled":true,"type":"threshold","thresholdType":"both","track":"by_src","count":10,"seconds":60}]}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				PublicID:  "test-public-id",
@@ -102,7 +102,7 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "successful update with sigma custom filter override",
-			params: `{"public_id": "test-public-id", "overrides": "[{\"note\":\"Custom filter\",\"isEnabled\":true,\"type\":\"customFilter\",\"customFilter\":\"sofilter:\\n  user.name: test_user\"}]"}`,
+			params: `{"public_id": "test-public-id", "overrides": [{"note":"Custom filter","isEnabled":true,"type":"customFilter","customFilter":"sofilter:\n  user.name: test_user"}]}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				PublicID:  "test-public-id",
@@ -134,7 +134,7 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "multiple overrides update",
-			params: `{"soc_id": "test-id", "overrides": "[{\"note\":\"First\",\"isEnabled\":true,\"type\":\"threshold\",\"thresholdType\":\"limit\",\"track\":\"by_src\",\"count\":5,\"seconds\":30},{\"note\":\"Second\",\"isEnabled\":false,\"type\":\"modify\",\"regex\":\"sid:1000001;\",\"value\":\"sid:1000002;\"}]"}`,
+			params: `{"soc_id": "test-id", "overrides": [{"note":"First","isEnabled":true,"type":"threshold","thresholdType":"limit","track":"by_src","count":5,"seconds":30},{"note":"Second","isEnabled":false,"type":"modify","regex":"sid:1000001;","value":"sid:1000002;"}]}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				PublicID:  "test-public-id",
@@ -176,13 +176,13 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:                  "detection not found",
-			params:                `{"soc_id": "nonexistent-id", "overrides": "[]"}`,
+			params:                `{"soc_id": "nonexistent-id", "overrides": []}`,
 			mockGetDetectionError: errors.New("detection not found"),
 			expectedError:         true,
 		},
 		{
 			name:   "validation error - missing required parameters",
-			params: `{"soc_id": "test-id", "overrides": "[{\"type\":\"threshold\",\"isEnabled\":true,\"track\":\"by_src\"}]"}`,
+			params: `{"soc_id": "test-id", "overrides": [{"type":"threshold","isEnabled":true,"track":"by_src"}]}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				PublicID:  "test-public-id",
@@ -192,7 +192,7 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "unsupported engine",
-			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			params: `{"soc_id": "test-id", "overrides": []}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				Engine:    model.EngineNameSuricata,
@@ -202,7 +202,7 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "apply filters error",
-			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			params: `{"soc_id": "test-id", "overrides": []}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				Engine:    model.EngineNameSuricata,
@@ -212,7 +212,7 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "update detection error",
-			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			params: `{"soc_id": "test-id", "overrides": []}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				Engine:    model.EngineNameSuricata,
@@ -222,7 +222,7 @@ func TestUpdateOverridesTool_Execute(t *testing.T) {
 		},
 		{
 			name:   "sync error",
-			params: `{"soc_id": "test-id", "overrides": "[]"}`,
+			params: `{"soc_id": "test-id", "overrides": []}`,
 			mockDetection: &model.Detection{
 				Auditable: model.Auditable{Id: "test-id"},
 				Engine:    model.EngineNameSuricata,
@@ -396,7 +396,7 @@ func TestUpdateOverridesTool_Execute_TimestampHandling(t *testing.T) {
 	mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
 
 	tool := &UpdateOverridesTool{}
-	params := fmt.Sprintf(`{"soc_id": "test-id", "overrides": "[{\"isEnabled\":true,\"type\":\"threshold\",\"thresholdType\":\"both\",\"track\":\"by_dst\",\"count\":10,\"seconds\":60,\"createdAt\":\"%s\",\"updatedAt\":\"%s\"}]"}`,
+	params := fmt.Sprintf(`{"soc_id": "test-id", "overrides": [{"isEnabled":true,"type":"threshold","thresholdType":"both","track":"by_dst","count":10,"seconds":60,"createdAt":"%s","updatedAt":"%s"}]}`,
 		existingTime.Format(time.RFC3339), existingTime.Format(time.RFC3339))
 	result, err := tool.Execute(ctx, mockServer, params, "")
 
@@ -459,7 +459,7 @@ func TestUpdateOverridesTool_Execute_EmptyOverrides(t *testing.T) {
 	mockDetectionEngine.EXPECT().MergeAuxiliaryData(gomock.Any()).Return(nil)
 
 	tool := &UpdateOverridesTool{}
-	result, err := tool.Execute(ctx, mockServer, `{"soc_id": "test-id", "overrides": "[]"}`, "")
+	result, err := tool.Execute(ctx, mockServer, `{"soc_id": "test-id", "overrides": []}`, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -839,13 +839,11 @@ func (store *ElasticDetectionstore) BulkAddOverrides(ctx context.Context, newOve
 		currLang = det.Language
 	}
 
-	engInt, ok := store.server.DetectionEngines.Load(detects[0].Engine)
+	_, ok := store.server.DetectionEngines.Load(detects[0].Engine)
 	if !ok {
 		logger.WithField("detectionEngine", detects[0].Engine).Error("unsupported engine")
-		return nil, fmt.Errorf("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine %s", detects[0].Engine)
 	}
-
-	engine := engInt.(server.DetectionEngine)
 
 	for i := range detects {
 		detect := detects[i]
@@ -857,12 +855,6 @@ func (store *ElasticDetectionstore) BulkAddOverrides(ctx context.Context, newOve
 		if err != nil {
 			logger.WithError(err).Error("invalid override")
 			return nil, fmt.Errorf("invalid override for detection with Public ID %s: %w", detect.PublicID, err)
-		}
-
-		_, err = engine.ApplyFilters(detect)
-		if err != nil {
-			logger.WithError(err).Error("unable to apply filters for detection")
-			return nil, fmt.Errorf("unable to apply filters for detection with Public ID %s: %w", detect.PublicID, err)
 		}
 
 		document, index, err := store.ConvertObjectToDocument(ctx, "detection", detect, &detect.Auditable, true, nil, nil)

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -801,6 +801,177 @@ func (store *ElasticDetectionstore) BulkUpdateDetections(ctx context.Context, ne
 	return bulkStats, nil
 }
 
+func (store *ElasticDetectionstore) BulkAddOverrides(ctx context.Context, newOverrides []*model.Override, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
+	bulkStats := &model.BulkUpdateStats{}
+	errMap := map[string]string{}
+	updated := 0
+	audited := 0
+
+	start := time.Now()
+
+	bulk, err := store.BuildBulkIndexer(ctx, logger)
+	if err != nil {
+		logger.WithError(err).Error("failed to create bulk indexer")
+		return nil, fmt.Errorf("failed to create bulk indexer: %w", err)
+	}
+
+	createAudit := []model.AuditInfo{} // Object => *model.Detection
+	auditMut := sync.Mutex{}
+	errMut := sync.Mutex{}
+
+	currLang := detects[0].Language
+
+	for _, det := range detects {
+		if det.Language != currLang {
+			return nil, fmt.Errorf("detections must be of the same engine")
+		}
+		currLang = det.Language
+	}
+
+	engInt, ok := store.server.DetectionEngines.Load(detects[0].Engine)
+	if !ok {
+		logger.WithField("detectionEngine", detects[0].Engine).Error("unsupported engine")
+		return nil, fmt.Errorf("unsupported engine")
+	}
+
+	engine := engInt.(server.DetectionEngine)
+
+	for i := range detects {
+		detect := detects[i]
+		id := detect.Id
+
+		detect.Overrides = append(detect.Overrides, newOverrides...)
+
+		err = detect.Validate()
+		if err != nil {
+			logger.WithError(err).Error("invalid override")
+			return nil, fmt.Errorf("invalid override for detection with Public ID %s: %w", detect.PublicID, err)
+		}
+
+		_, err = engine.ApplyFilters(detect)
+		if err != nil {
+			logger.WithError(err).Error("unable to apply filters for detection")
+			return nil, fmt.Errorf("unable to apply filters for detection with Public ID %s: %w", detect.PublicID, err)
+		}
+
+		document, index, err := store.ConvertObjectToDocument(ctx, "detection", detect, &detect.Auditable, true, nil, nil)
+		if err != nil {
+			errMap[detect.PublicID] = err.Error()
+			continue
+		}
+
+		work := esutil.BulkIndexerItem{
+			Index:      index,
+			Action:     "update",
+			DocumentID: id,
+			OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem) {
+				auditMut.Lock()
+				defer auditMut.Unlock()
+				updated++
+				createAudit = append(createAudit, model.AuditInfo{
+					DocId:  resp.DocumentID,
+					Op:     "update",
+					Object: detect,
+				})
+			},
+			OnFailure: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
+				errMut.Lock()
+				defer errMut.Unlock()
+
+				if err != nil {
+					errMap[detect.PublicID] = err.Error()
+				} else {
+					errMap[detect.PublicID] = resp.Error.Reason
+				}
+			},
+		}
+
+		work.Body = bytes.NewReader(document)
+
+		err = bulk.Add(ctx, work)
+		if err != nil {
+			errMap[detect.PublicID] = err.Error()
+			continue
+		}
+	}
+
+	err = bulk.Close(ctx)
+	if err != nil {
+		logger.WithError(err).Error("unable to close bulk indexer for detection changes")
+		return nil, fmt.Errorf("unable to close bulk indexer for detection changes: %w", err)
+	}
+
+	bulk, err = store.BuildBulkIndexer(ctx, logger)
+	if err != nil {
+		logger.WithError(err).Error("unable to create audit bulk indexer")
+		return nil, fmt.Errorf("unable to create audit bulk indexer: %w", err)
+	}
+
+	dirty := make([]*model.Detection, 0, len(createAudit))
+
+	for _, audit := range createAudit {
+		det := audit.Object.(*model.Detection)
+
+		document, index, err := store.ConvertObjectToDocument(ctx, "detection", audit.Object, &det.Auditable, false, &audit.DocId, &audit.Op)
+		if err != nil {
+			errMap[det.PublicID] = err.Error()
+			continue
+		}
+
+		err = bulk.Add(ctx, esutil.BulkIndexerItem{
+			Index:  index,
+			Action: "create",
+			Body:   bytes.NewReader(document),
+			OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem) {
+				auditMut.Lock()
+				defer auditMut.Unlock()
+
+				audited++
+			},
+			OnFailure: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
+				errMut.Lock()
+				defer errMut.Unlock()
+
+				if err != nil {
+					errMap[det.PublicID] = fmt.Sprintf("AUDIT: %s", err.Error())
+				} else {
+					errMap[det.PublicID] = fmt.Sprintf("AUDIT: %s", resp.Error.Reason)
+				}
+			},
+		})
+		if err != nil {
+			errMap[det.PublicID] = err.Error()
+			continue
+		}
+
+		det.PersistChange = true
+
+		dirty = append(dirty, det)
+	}
+
+	err = bulk.Close(ctx)
+	if err != nil {
+		logger.WithError(err).Error("unable to close bulk indexer for audit history")
+		return nil, fmt.Errorf("unable to close bulk indexer for audit history: %w", err)
+	}
+
+	updateDur := time.Since(start)
+
+	logger.WithFields(log.Fields{
+		"bulkUpdated": updated,
+		"bulkAudited": audited,
+		"errMap":      util.TruncateMap(errMap, 5),
+	}).Info("bulk operation complete")
+
+	bulkStats.Updated = updated
+	bulkStats.Audited = audited
+	bulkStats.ErrMap = errMap
+	bulkStats.UpdateDuration = updateDur
+	bulkStats.NeedToSync = dirty
+
+	return bulkStats, nil
+}
+
 func (store *ElasticDetectionstore) DeleteDetection(ctx context.Context, id string) (*model.Detection, error) {
 	logger := log.FromContext(ctx)
 

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -6,6 +6,7 @@
 package elastic
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
@@ -423,6 +425,70 @@ func (store *ElasticDetectionstore) Query(ctx context.Context, query string, max
 	return objects, err
 }
 
+func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string) (objects []interface{}, err error) {
+	logger := log.FromContext(ctx)
+
+	err = store.server.CheckAuthorized(ctx, "read", "detections")
+	if err != nil {
+		return nil, err
+	}
+
+	var timeFormat string
+
+	if rangeFormat != "" {
+		timeFormat = rangeFormat
+	} else {
+		timeFormat = "2006-01-02 3:04:05 PM"
+	}
+
+	var timeRange string
+
+	if rangeStart != "" || rangeEnd != "" {
+		timeRange = parseRangeAllowRelative(rangeStart, rangeEnd, timeFormat)
+	}
+
+	zone := "UTC"
+
+	var results *model.EventSearchResults
+
+	criteria := model.NewEventSearchCriteria()
+	err = criteria.Populate(query,
+		timeRange,  // timeframe range
+		timeFormat, // timeframe format
+		zone,       // timezone
+		"0",        // no metrics
+		"10000")
+
+	if err != nil {
+		return nil, err
+	}
+
+	criteria.SortFields = []*model.SortCriteria{
+		{
+			Field: "@timestamp",
+			Order: "desc",
+		},
+	}
+
+	results, err = store.DetectionSearch(ctx, criteria)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, event := range results.Events {
+		var obj interface{}
+
+		obj, err = convertElasticEventToObject(event, store.schemaPrefix)
+		if err == nil {
+			objects = append(objects, obj)
+		} else {
+			logger.WithField("returnedEvent", event).WithError(err).Error("Unable to convert detection object")
+		}
+	}
+
+	return objects, err
+}
+
 func (store *ElasticDetectionstore) DetectionSearch(ctx context.Context, criteria *model.EventSearchCriteria) (*model.EventSearchResults, error) {
 	err := store.server.CheckAuthorized(ctx, "read", "detections")
 	if err != nil {
@@ -555,6 +621,183 @@ func (store *ElasticDetectionstore) UpdateDetection(ctx context.Context, detect 
 
 	// Read object back to get new modify date, etc
 	return store.GetDetection(ctx, results.DocumentId)
+}
+
+func (store *ElasticDetectionstore) BulkUpdateDetections(ctx context.Context, newStatus bool, detects []*model.Detection, logger log.Interface) (*model.BulkUpdateStats, error) {
+	bulkStats := &model.BulkUpdateStats{}
+	errMap := map[string]string{}
+	updated := 0
+	audited := 0
+	filtered := 0
+
+	start := time.Now()
+
+	bulk, err := store.BuildBulkIndexer(ctx, logger)
+	if err != nil {
+		logger.WithError(err).Error("failed to create bulk indexer")
+		return nil, fmt.Errorf("failed to create bulk indexer: %w", err)
+	}
+
+	createAudit := []model.AuditInfo{} // Object => *model.Detection
+	auditMut := sync.Mutex{}
+	errMut := sync.Mutex{}
+
+	for i := range detects {
+		detect := detects[i]
+		id := detect.Id
+
+		engineInt, ok := store.server.DetectionEngines.Load(detect.Engine)
+		if !ok {
+			logger.WithFields(log.Fields{
+				"publicId": detect.PublicID,
+				"engine":   detect.Engine,
+			}).Error("detection has unsupported engine, skipping")
+			errMap[detect.PublicID] = "unsupported engine"
+
+			continue
+		}
+
+		engine := engineInt.(server.DetectionEngine)
+
+		detect.IsEnabled = newStatus
+
+		filterApplied, err := engine.ApplyFilters(detect)
+		if err != nil {
+			logger.WithError(err).WithFields(log.Fields{
+				"detectionPublicId": detect.PublicID,
+				"detectionEngine":   detect.Engine,
+			}).Error("unable to apply engine filters to detection")
+
+			return nil, fmt.Errorf("unable to apply filters to detection with Public ID %s: %w", detect.PublicID, err)
+		}
+
+		if filterApplied && detect.IsEnabled != newStatus {
+			filtered++
+		}
+
+		exErr := engine.ExtractDetails(detect)
+		if exErr != nil {
+			logger.WithField("publicId", detect.PublicID).WithError(exErr).Warn("unable to extract details from detection, skipping")
+			errMap[detect.PublicID] = fmt.Sprintf("unable to extract details: %s", exErr.Error())
+			continue
+		}
+
+		document, index, err := store.ConvertObjectToDocument(ctx, "detection", detect, &detect.Auditable, true, nil, nil)
+		if err != nil {
+			errMap[detect.PublicID] = err.Error()
+			continue
+		}
+
+		work := esutil.BulkIndexerItem{
+			Index:      index,
+			Action:     "update",
+			DocumentID: id,
+			OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem) {
+				auditMut.Lock()
+				defer auditMut.Unlock()
+				updated++
+				createAudit = append(createAudit, model.AuditInfo{
+					DocId:  resp.DocumentID,
+					Op:     "update",
+					Object: detect,
+				})
+			},
+			OnFailure: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
+				errMut.Lock()
+				defer errMut.Unlock()
+
+				if err != nil {
+					errMap[detect.PublicID] = err.Error()
+				} else {
+					errMap[detect.PublicID] = resp.Error.Reason
+				}
+			},
+		}
+
+		work.Body = bytes.NewReader(document)
+
+		err = bulk.Add(ctx, work)
+		if err != nil {
+			errMap[detect.PublicID] = err.Error()
+			continue
+		}
+	}
+
+	err = bulk.Close(ctx)
+	if err != nil {
+		logger.WithError(err).Error("unable to close bulk indexer for detection changes")
+		return nil, fmt.Errorf("unable to close bulk indexer for detection changes: %w", err)
+	}
+
+	bulk, err = store.BuildBulkIndexer(ctx, logger)
+	if err != nil {
+		logger.WithError(err).Error("unable to create audit bulk indexer")
+		return nil, fmt.Errorf("unable to create audit bulk indexer: %w", err)
+	}
+
+	dirty := make([]*model.Detection, 0, len(createAudit))
+
+	for _, audit := range createAudit {
+		det := audit.Object.(*model.Detection)
+
+		document, index, err := store.ConvertObjectToDocument(ctx, "detection", audit.Object, &det.Auditable, false, &audit.DocId, &audit.Op)
+		if err != nil {
+			errMap[det.PublicID] = err.Error()
+			continue
+		}
+
+		err = bulk.Add(ctx, esutil.BulkIndexerItem{
+			Index:  index,
+			Action: "create",
+			Body:   bytes.NewReader(document),
+			OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem) {
+				auditMut.Lock()
+				defer auditMut.Unlock()
+
+				audited++
+			},
+			OnFailure: func(ctx context.Context, item esutil.BulkIndexerItem, resp esutil.BulkIndexerResponseItem, err error) {
+				errMut.Lock()
+				defer errMut.Unlock()
+
+				if err != nil {
+					errMap[det.PublicID] = fmt.Sprintf("AUDIT: %s", err.Error())
+				} else {
+					errMap[det.PublicID] = fmt.Sprintf("AUDIT: %s", resp.Error.Reason)
+				}
+			},
+		})
+		if err != nil {
+			errMap[det.PublicID] = err.Error()
+			continue
+		}
+
+		det.PersistChange = true
+
+		dirty = append(dirty, det)
+	}
+
+	err = bulk.Close(ctx)
+	if err != nil {
+		logger.WithError(err).Error("unable to close bulk indexer for audit history")
+		return nil, fmt.Errorf("unable to close bulk indexer for audit history: %w", err)
+	}
+
+	updateDur := time.Since(start)
+
+	logger.WithFields(log.Fields{
+		"bulkUpdated": updated,
+		"bulkAudited": audited,
+		"errMap":      util.TruncateMap(errMap, 5),
+	}).Info("bulk operation complete")
+
+	bulkStats.Updated = updated
+	bulkStats.Audited = audited
+	bulkStats.Filtered = filtered
+	bulkStats.ErrMap = errMap
+	bulkStats.UpdateDuration = updateDur
+
+	return bulkStats, nil
 }
 
 func (store *ElasticDetectionstore) DeleteDetection(ctx context.Context, id string) (*model.Detection, error) {
@@ -859,4 +1102,35 @@ func (store *ElasticDetectionstore) ConvertObjectToDocument(ctx context.Context,
 	rawDoc, err := json.Marshal(document)
 
 	return rawDoc, index, err
+}
+
+func parseRangeAllowRelative(rangeStart string, rangeEnd string, format string) string {
+	start := "-24h"
+	end := "now"
+
+	if rangeStart != "" {
+		start = rangeStart
+	}
+	if rangeEnd != "" {
+		end = rangeEnd
+	}
+
+	var startFormatted, endFormatted string
+
+	// Parse and format times
+	startParsed, err := time.Parse(format, start)
+	if err != nil {
+		startFormatted = util.ParseRelativeTimeString(start)
+	} else {
+		startFormatted = util.FormatSOTime(startParsed)
+	}
+
+	endParsed, err := time.Parse(format, end)
+	if err != nil {
+		endFormatted = util.ParseRelativeTimeString(end)
+	} else {
+		endFormatted = util.FormatSOTime(endParsed)
+	}
+
+	return fmt.Sprintf("%s - %s", startFormatted, endFormatted)
 }

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -425,7 +425,7 @@ func (store *ElasticDetectionstore) Query(ctx context.Context, query string, max
 	return objects, err
 }
 
-func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string) (objects []interface{}, err error) {
+func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string, limit int) (objects []interface{}, err error) {
 	logger := log.FromContext(ctx)
 
 	err = store.server.CheckAuthorized(ctx, "read", "detections")
@@ -457,7 +457,7 @@ func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query st
 		timeFormat, // timeframe format
 		zone,       // timezone
 		"0",        // no metrics
-		"10000")
+		strconv.Itoa(limit))
 
 	if err != nil {
 		return nil, err

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -796,6 +796,7 @@ func (store *ElasticDetectionstore) BulkUpdateDetections(ctx context.Context, ne
 	bulkStats.Filtered = filtered
 	bulkStats.ErrMap = errMap
 	bulkStats.UpdateDuration = updateDur
+	bulkStats.NeedToSync = dirty
 
 	return bulkStats, nil
 }

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -438,7 +438,7 @@ func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query st
 	if rangeFormat != "" {
 		timeFormat = rangeFormat
 	} else {
-		timeFormat = "2006-01-02 3:04:05 PM"
+		timeFormat = "2006/01/02 3:04:05 PM"
 	}
 
 	var timeRange string

--- a/server/modules/elastic/elasticdetectionstore.go
+++ b/server/modules/elastic/elasticdetectionstore.go
@@ -425,9 +425,7 @@ func (store *ElasticDetectionstore) Query(ctx context.Context, query string, max
 	return objects, err
 }
 
-func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string, limit int) (objects []interface{}, err error) {
-	logger := log.FromContext(ctx)
-
+func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query string, rangeStart string, rangeEnd string, rangeFormat string, limit int) (detectEvents *model.EventSearchResults, err error) {
 	err = store.server.CheckAuthorized(ctx, "read", "detections")
 	if err != nil {
 		return nil, err
@@ -449,8 +447,6 @@ func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query st
 
 	zone := "UTC"
 
-	var results *model.EventSearchResults
-
 	criteria := model.NewEventSearchCriteria()
 	err = criteria.Populate(query,
 		timeRange,  // timeframe range
@@ -470,12 +466,20 @@ func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query st
 		},
 	}
 
-	results, err = store.DetectionSearch(ctx, criteria)
+	detectEvents, err = store.DetectionSearch(ctx, criteria)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, event := range results.Events {
+	return detectEvents, err
+}
+
+func (store *ElasticDetectionstore) ConvertEventsToDetections(ctx context.Context, events *model.EventSearchResults) (detects []*model.Detection, err error) {
+	logger := log.FromContext(ctx)
+
+	objects := make([]interface{}, 0, len(events.Events))
+
+	for _, event := range events.Events {
 		var obj interface{}
 
 		obj, err = convertElasticEventToObject(event, store.schemaPrefix)
@@ -486,7 +490,14 @@ func (store *ElasticDetectionstore) QueryWithRange(ctx context.Context, query st
 		}
 	}
 
-	return objects, err
+	detects = make([]*model.Detection, 0, len(objects))
+
+	for _, d := range objects {
+		det := d.(*model.Detection)
+		detects = append(detects, det)
+	}
+
+	return detects, err
 }
 
 func (store *ElasticDetectionstore) DetectionSearch(ctx context.Context, criteria *model.EventSearchCriteria) (*model.EventSearchResults, error) {

--- a/server/modules/elastic/elasticdetectionstore_test.go
+++ b/server/modules/elastic/elasticdetectionstore_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	modcontext "github.com/security-onion-solutions/securityonion-soc/server/modules/context"
@@ -1674,4 +1675,213 @@ func TestConvertObjectToDocument(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBulkUpdateDetections(t *testing.T) {
+	t.Parallel()
+
+	client, _ := modmock.NewMockClient(t)
+	fakesrv := server.NewFakeAuthorizedServer(nil)
+	fakeStore := server.NewFakeEventstore()
+
+	// Create a simple mock detection engine that implements the interface
+	mockEngine := &mockDetectionEngine{}
+	fakesrv.DetectionEngines.Store(model.EngineName("suricata"), mockEngine)
+
+	fakesrv.Eventstore = fakeStore
+	store := NewElasticDetectionstore(fakesrv, client, 100)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, 2)
+
+	detections := []*model.Detection{
+		{
+			Auditable: model.Auditable{
+				Id: "detection1",
+			},
+			PublicID:  "PUB001",
+			Engine:    "suricata",
+			IsEnabled: false,
+		},
+		{
+			Auditable: model.Auditable{
+				Id: "detection2",
+			},
+			PublicID:  "PUB002",
+			Engine:    "suricata",
+			IsEnabled: false,
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
+	logger := log.WithField("test", "BulkUpdateDetections")
+
+	stats, err := store.BulkUpdateDetections(ctx, true, detections, logger)
+
+	// The bulk operation completes but with no actual updates due to mock client limitations
+	assert.NoError(t, err)
+	assert.NotNil(t, stats)
+	assert.True(t, stats.UpdateDuration > 0)
+	assert.Equal(t, 0, stats.Updated) // No actual updates due to mock limitations
+	assert.Equal(t, 0, stats.Audited) // No actual audits due to mock limitations
+
+	// Verify detections were processed and status updated in memory
+	assert.True(t, detections[0].IsEnabled)
+	assert.True(t, detections[1].IsEnabled)
+}
+
+func TestBulkUpdateDetectionsWithErrors(t *testing.T) {
+	t.Parallel()
+
+	client, _ := modmock.NewMockClient(t)
+	fakesrv := server.NewFakeAuthorizedServer(nil)
+	fakeStore := server.NewFakeEventstore()
+
+	fakesrv.Eventstore = fakeStore
+	store := NewElasticDetectionstore(fakesrv, client, 100)
+	store.Init("myIndex", "myAuditIndex", 45, DEFAULT_CASE_SCHEMA_PREFIX, 2)
+
+	detections := []*model.Detection{
+		{
+			Auditable: model.Auditable{
+				Id: "detection1",
+			},
+			PublicID: "PUB001",
+			Engine:   "unsupported_engine", // This should cause an error
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "myRequestorId")
+	logger := log.WithField("test", "BulkUpdateDetectionsWithErrors")
+
+	stats, err := store.BulkUpdateDetections(ctx, true, detections, logger)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, stats)
+	assert.Equal(t, 0, stats.Updated)
+	assert.Equal(t, 0, stats.Audited)
+	assert.Contains(t, stats.ErrMap, "PUB001")
+	assert.Equal(t, "unsupported engine", stats.ErrMap["PUB001"])
+}
+
+// Simple mock detection engine for testing
+type mockDetectionEngine struct{}
+
+func (m *mockDetectionEngine) ValidateRule(rule string) (string, error) {
+	return rule, nil
+}
+
+func (m *mockDetectionEngine) ConvertRule(ctx context.Context, detect *model.Detection) (string, error) {
+	return detect.Content, nil
+}
+
+func (m *mockDetectionEngine) ExtractDetails(detect *model.Detection) error {
+	return nil
+}
+
+func (m *mockDetectionEngine) ApplyFilters(detect *model.Detection) (bool, error) {
+	return false, nil
+}
+
+func (m *mockDetectionEngine) MergeAuxiliaryData(detect *model.Detection) error {
+	return nil
+}
+
+func (m *mockDetectionEngine) DuplicateDetection(ctx context.Context, detection *model.Detection) (*model.Detection, error) {
+	return detection, nil
+}
+
+func (m *mockDetectionEngine) GenerateUnusedPublicId(ctx context.Context) (string, error) {
+	return "unused-id", nil
+}
+
+func (m *mockDetectionEngine) SyncLocalDetections(ctx context.Context, detections []*model.Detection) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func (m *mockDetectionEngine) GetState() *model.EngineState {
+	return &model.EngineState{}
+}
+
+func (m *mockDetectionEngine) InterruptSync(forceFull, notify bool) {}
+
+func TestParseRangeAllowRelative(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		rangeStart  string
+		rangeEnd    string
+		format      string
+		expected    string
+		description string
+	}{
+		{
+			name:        "Empty inputs use defaults",
+			rangeStart:  "",
+			rangeEnd:    "",
+			format:      "2006/01/02 3:04:05 PM",
+			description: "Should use default -24h to now",
+		},
+		{
+			name:        "Relative time strings",
+			rangeStart:  "-1h",
+			rangeEnd:    "now",
+			format:      "2006/01/02 3:04:05 PM",
+			description: "Should handle relative time strings",
+		},
+		{
+			name:        "Absolute time strings",
+			rangeStart:  "2023/01/01 12:00:00 PM",
+			rangeEnd:    "2023/01/01 1:00:00 PM",
+			format:      "2006/01/02 3:04:05 PM",
+			expected:    "2023/01/01 12:00:00 PM - 2023/01/01 1:00:00 PM",
+			description: "Should parse and format absolute times",
+		},
+		{
+			name:        "Mixed absolute and relative",
+			rangeStart:  "2023/01/01 12:00:00 PM",
+			rangeEnd:    "now",
+			format:      "2006/01/02 3:04:05 PM",
+			description: "Should handle mix of absolute start and relative end",
+		},
+		{
+			name:        "Custom format",
+			rangeStart:  "2023-01-01T12:00:00Z",
+			rangeEnd:    "2023-01-01T13:00:00Z",
+			format:      "2006-01-02T15:04:05Z",
+			expected:    "2023/01/01 12:00:00 PM - 2023/01/01 1:00:00 PM",
+			description: "Should work with custom time format",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result := parseRangeAllowRelative(test.rangeStart, test.rangeEnd, test.format)
+
+			if test.expected != "" {
+				assert.Equal(t, test.expected, result)
+			} else {
+				// For relative times, just verify the format is correct (contains " - ")
+				assert.Contains(t, result, " - ")
+				assert.NotEmpty(t, result)
+			}
+		})
+	}
+}
+
+func TestParseRangeAllowRelativeDefaults(t *testing.T) {
+	t.Parallel()
+
+	// Test that empty inputs use the expected defaults
+	result := parseRangeAllowRelative("", "", "2006/01/02 3:04:05 PM")
+
+	// Should contain the default pattern with relative times
+	assert.Contains(t, result, " - ")
+	assert.NotEmpty(t, result)
+
+	// The result should be parseable as a time range
+	parts := strings.Split(result, " - ")
+	assert.Equal(t, 2, len(parts))
+	assert.NotEmpty(t, parts[0])
+	assert.NotEmpty(t, parts[1])
 }


### PR DESCRIPTION
- Added the following Detections-based tools for the Assistant page ([#346](https://github.com/Security-Onion-Solutions/sos/issues/346)):
  - query_detections: Searches for detections based on the user's request. For instance, it can look for detections that are relevant to a given alert and decide which is most applicable.
  - create_detection: Creates a new detection per the user's request.
  - update_detection_content: Modifies the content block of a single detection.
  - toggle_detections: Enables or disables one or more detections in bulk, based on the user's request.
  - update_overrides: Modifies the overrides block of a single detection. It can enable, disable, add, delete, and edit multiple overrides at once.
  - add_overrides: Creates and adds one or more overrides to multiple detections in bulk, per the user's request.
- Added comprehensive test coverage for each of these tools.