### PR TITLE
Assistant: Outage Error Message

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -156,6 +156,12 @@
               </v-btn>
             </template>
             {{ errorMessage }}
+            <div v-if="errorExtraMsg" class="mt-2 no-underline">
+              {{ errorExtraMsg }}
+              <a v-if="errorExtraLink" :target="$root.target('so-help')" :href="errorExtraLink" class="text-decoration-none" data-aid="nav_docs_error">
+                <v-icon color="white">fa-life-ring</v-icon>
+              </a>
+            </div>
             <div class="mt-2 no-underline">
               {{ i18n.errorHelp }}
               <a :target="$root.target('so-help')" :href="parameters.docsUrl + 'help.html'" class="text-decoration-none" data-aid="nav_docs_error">

--- a/html/index.html
+++ b/html/index.html
@@ -155,13 +155,7 @@
                 <v-icon>fa-times</v-icon>
               </v-btn>
             </template>
-            {{ errorMessage }}
-            <div v-if="errorExtraMsg" class="mt-2 no-underline">
-              {{ errorExtraMsg }}
-              <a v-if="errorExtraLink" :target="$root.target('so-help')" :href="errorExtraLink" class="text-decoration-none" data-aid="nav_docs_error">
-                <v-icon color="white">fa-life-ring</v-icon>
-              </a>
-            </div>
+            <div v-html="errorMessage"></div>
             <div class="mt-2 no-underline">
               {{ i18n.errorHelp }}
               <a :target="$root.target('so-help')" :href="parameters.docsUrl + 'help.html'" class="text-decoration-none" data-aid="nav_docs_error">

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -142,6 +142,8 @@ $(document).ready(function () {
           tip: false,
           disclaimer: false,
           errorMessage: "",
+          errorExtraMsg: "",
+          errorExtraLink: "",
           warningMessage: "",
           infoMessage: "",
           tipMessage: "",
@@ -959,11 +961,18 @@ $(document).ready(function () {
             this.showTip(this.i18n.requestCanceled);
             return;
           }
+          this.errorExtraMsg = "";
+          this.errorExtraLink = "";
           this.error = true;
           this.errorMessage = this.localizeMessage(msg);
           if (this.debug && msg && msg.stack) {
             console.log(msg.stack);
           }
+        },
+        showErrorExtraHtml(msg, extraMsg, extraLink) {
+          this.showError(msg);
+          this.errorExtraMsg = extraMsg;
+          this.errorExtraLink = extraLink;
         },
         showWarning(msg, skipLocalization) {
           this.warning = true;

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -142,8 +142,6 @@ $(document).ready(function () {
           tip: false,
           disclaimer: false,
           errorMessage: "",
-          errorExtraMsg: "",
-          errorExtraLink: "",
           warningMessage: "",
           infoMessage: "",
           tipMessage: "",
@@ -920,6 +918,12 @@ $(document).ready(function () {
               msg = msg.error.reason;
             }
           }
+
+          // Remove encapsulating quotes
+          if (msg.startsWith != undefined && msg.startsWith("\"") && msg.endsWith("\"")) {
+            msg = msg.substring(1, msg.length - 1);
+          }
+
           var localized = this.i18n[msg];
           if (!localized) {
             if (origMsg.message) {
@@ -961,18 +965,11 @@ $(document).ready(function () {
             this.showTip(this.i18n.requestCanceled);
             return;
           }
-          this.errorExtraMsg = "";
-          this.errorExtraLink = "";
           this.error = true;
           this.errorMessage = this.localizeMessage(msg);
           if (this.debug && msg && msg.stack) {
             console.log(msg.stack);
           }
-        },
-        showErrorExtraHtml(msg, extraMsg, extraLink) {
-          this.showError(msg);
-          this.errorExtraMsg = extraMsg;
-          this.errorExtraLink = extraLink;
         },
         showWarning(msg, skipLocalization) {
           this.warning = true;

--- a/html/js/app.test.js
+++ b/html/js/app.test.js
@@ -1206,6 +1206,48 @@ describe('export', () => {
   });
 });
 
+test('showErrorExtraHtml', () => {
+  const oldShowError = app.showError;
+  app.showError = origShowError;
+  try {
+    const mockShowError = jest.fn();
+    app.showError = mockShowError;
+    
+    const errorMsg = 'Test error message';
+    const extraMsg = 'Additional information';
+    const extraLink = 'https://example.com/help';
+    
+    app.showErrorExtraHtml(errorMsg, extraMsg, extraLink);
+    
+    expect(mockShowError).toHaveBeenCalledWith(errorMsg);
+    expect(app.errorExtraMsg).toBe(extraMsg);
+    expect(app.errorExtraLink).toBe(extraLink);
+  } finally {
+    app.showError = oldShowError;
+  }
+});
+
+test('showErrorExtraHtml with empty extra message', () => {
+  const oldShowError = app.showError;
+  app.showError = origShowError;
+  try {
+    const mockShowError = jest.fn();
+    app.showError = mockShowError;
+    
+    const errorMsg = 'Test error';
+    const extraMsg = '';
+    const extraLink = '';
+    
+    app.showErrorExtraHtml(errorMsg, extraMsg, extraLink);
+    
+    expect(mockShowError).toHaveBeenCalledWith(errorMsg);
+    expect(app.errorExtraMsg).toBe('');
+    expect(app.errorExtraLink).toBe('');
+  } finally {
+    app.showError = oldShowError;
+  }
+});
+
 test('performMermaidRegexes', () => {
   expect(app.performMermaidRegexes('regular text')).toBe('regular text');
   expect(app.performMermaidRegexes('')).toBe('');

--- a/html/js/app.test.js
+++ b/html/js/app.test.js
@@ -230,6 +230,10 @@ test('loadServerSettings', async () => {
 test('localizeMessage', () => {
   expect(app.localizeMessage(null)).toBe("");
   expect(app.localizeMessage('create')).toBe("Create");
+  expect(app.localizeMessage('"quoted message"')).toBe("quoted message");
+  expect(app.localizeMessage('"error with quotes"')).toBe("error with quotes");
+  expect(app.localizeMessage('no quotes')).toBe("no quotes");
+  expect(app.localizeMessage('"single quote"')).toBe("single quote");
 });
 
 test('localizeMessageWithArgs', () => {
@@ -1204,48 +1208,6 @@ describe('export', () => {
       app.showError = oldShowError;
     } 
   });
-});
-
-test('showErrorExtraHtml', () => {
-  const oldShowError = app.showError;
-  app.showError = origShowError;
-  try {
-    const mockShowError = jest.fn();
-    app.showError = mockShowError;
-    
-    const errorMsg = 'Test error message';
-    const extraMsg = 'Additional information';
-    const extraLink = 'https://example.com/help';
-    
-    app.showErrorExtraHtml(errorMsg, extraMsg, extraLink);
-    
-    expect(mockShowError).toHaveBeenCalledWith(errorMsg);
-    expect(app.errorExtraMsg).toBe(extraMsg);
-    expect(app.errorExtraLink).toBe(extraLink);
-  } finally {
-    app.showError = oldShowError;
-  }
-});
-
-test('showErrorExtraHtml with empty extra message', () => {
-  const oldShowError = app.showError;
-  app.showError = origShowError;
-  try {
-    const mockShowError = jest.fn();
-    app.showError = mockShowError;
-    
-    const errorMsg = 'Test error';
-    const extraMsg = '';
-    const extraLink = '';
-    
-    app.showErrorExtraHtml(errorMsg, extraMsg, extraLink);
-    
-    expect(mockShowError).toHaveBeenCalledWith(errorMsg);
-    expect(app.errorExtraMsg).toBe('');
-    expect(app.errorExtraLink).toBe('');
-  } finally {
-    app.showError = oldShowError;
-  }
 });
 
 test('performMermaidRegexes', () => {

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -174,7 +174,6 @@ const i18n = {
       assistantNoResponse: 'Failed to get AI response',
       assistantNotAvailable: 'Onion AI is not enabled or is otherwise unavailable.',
       assistantOutOfCredits: 'Insufficient credits. Please contact your administrator to purchase more credits.',
-      assistantPotentialOutage: 'There may be a network or upstream provider issue. Refer to the Security Onion status page for current state updates.',
       assistantSaveContextError: 'Failed to save context theshold setting',
       assistantSaveRecentError: 'Failed to save restore last active setting',
       assistantSaveReadApprovalError: 'Failed to save read request approval setting',
@@ -1238,6 +1237,8 @@ const i18n = {
       ERROR_SALT_ALREADY_RUNNING: 'Another synchronization operation is already running. Wait for it to complete and try again.',
       ERROR_BULK_COMMUNITY: 'Unable to complete bulk delete. Batch contains Community rules. No rules were deleted.',
       ERROR_DELETE_COMMUNITY: 'Unable to delete Community rule.',
+      ERROR_SERVICE_NOT_AVAILABLE: 'The configuration of this grid does not support the requested operation. Contact your administrator for assistance with enabling additional features.',
+      ERROR_UPSTREAM_SERVICE_ERROR: 'Error while communicating with remote, upstream service. Check the <a target="sos" href="https://status.securityonion.net">Security Onion status page</a> for any known incidents.',
 
       // correct casing
       cc_elastalert: 'ElastAlert',

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -174,6 +174,7 @@ const i18n = {
       assistantNoResponse: 'Failed to get AI response',
       assistantNotAvailable: 'Onion AI is not enabled or is otherwise unavailable.',
       assistantOutOfCredits: 'Insufficient credits. Please contact your administrator to purchase more credits.',
+      assistantPotentialOutage: 'There may be a network or upstream provider issue. Refer to the Security Onion status page for current state updates.',
       assistantSaveContextError: 'Failed to save context theshold setting',
       assistantSaveRecentError: 'Failed to save restore last active setting',
       assistantSaveReadApprovalError: 'Failed to save read request approval setting',

--- a/html/js/routes/aimetrics.js
+++ b/html/js/routes/aimetrics.js
@@ -324,7 +324,11 @@ routes.push({ path: '/aimetrics/:userId?/:sessionId?', name: 'aimetrics', compon
           }
         }
       } catch (error) {
-        this.$root.showError(this.i18n.assistantUnableToLoadCredits + ': ' + error.message);
+        if (error.response && error.response.status == 500) {
+          this.$root.showErrorExtraHtml(this.i18n.assistantUnableToLoadCredits + ': ' + error.message, this.i18n.assistantPotentialOutage, 'https://securityonionsolutions.com/status/');
+        } else {
+          this.$root.showError(this.i18n.assistantUnableToLoadCredits + ': ' + error.message);
+        }
         this.creditsLoaded = true;
       }
     },

--- a/html/js/routes/aimetrics.js
+++ b/html/js/routes/aimetrics.js
@@ -324,12 +324,8 @@ routes.push({ path: '/aimetrics/:userId?/:sessionId?', name: 'aimetrics', compon
           }
         }
       } catch (error) {
-        if (error.response && error.response.status == 500) {
-          this.$root.showErrorExtraHtml(this.i18n.assistantUnableToLoadCredits + ': ' + error.message, this.i18n.assistantPotentialOutage, 'https://securityonionsolutions.com/status/');
-        } else {
-          this.$root.showError(this.i18n.assistantUnableToLoadCredits + ': ' + error.message);
-        }
-        this.creditsLoaded = true;
+        this.creditsLoaded = false;
+        this.$root.showError(error);
       }
     },
     async lookupSocId(data) {

--- a/html/js/routes/aimetrics.test.js
+++ b/html/js/routes/aimetrics.test.js
@@ -578,6 +578,46 @@ test('loadCredits success', async () => {
   
   expect(mock).toHaveBeenCalledWith('/assistant/balance');
   expect(comp.creditsRemaining).toBe(150);
+  expect(comp.creditsLoaded).toBe(true);
+});
+
+test('loadCredits handles 500 error with extra HTML', async () => {
+  const error = new Error('Internal Server Error');
+  error.response = { status: 500 };
+  mockPapi("get", null, error);
+  comp.$root.showErrorExtraHtml = jest.fn();
+  
+  await comp.loadCredits();
+  
+  expect(comp.$root.showErrorExtraHtml).toHaveBeenCalledWith(
+    comp.i18n.assistantUnableToLoadCredits + ': ' + error.message,
+    comp.i18n.assistantPotentialOutage,
+    'https://securityonionsolutions.com/status/'
+  );
+  expect(comp.creditsLoaded).toBe(true);
+});
+
+test('loadCredits handles non-500 error', async () => {
+  const error = new Error('Bad Request');
+  error.response = { status: 400 };
+  mockPapi("get", null, error);
+  comp.$root.showError = jest.fn();
+  
+  await comp.loadCredits();
+  
+  expect(comp.$root.showError).toHaveBeenCalledWith(comp.i18n.assistantUnableToLoadCredits + ': ' + error.message);
+  expect(comp.creditsLoaded).toBe(true);
+});
+
+test('loadCredits handles error without response', async () => {
+  const error = new Error('Network error');
+  mockPapi("get", null, error);
+  comp.$root.showError = jest.fn();
+  
+  await comp.loadCredits();
+  
+  expect(comp.$root.showError).toHaveBeenCalledWith(comp.i18n.assistantUnableToLoadCredits + ': ' + error.message);
+  expect(comp.creditsLoaded).toBe(true);
 });
 
 test('loadCredits handles unhealthy status', async () => {
@@ -593,16 +633,7 @@ test('loadCredits handles unhealthy status', async () => {
   await comp.loadCredits();
   
   expect(comp.$root.showError).toHaveBeenCalledWith('Error loading credits from API: ' + comp.i18n.assistantBalanceCheckUnhealthy);
-});
-
-test('loadCredits handles API error', async () => {
-  const error = new Error('Network error');
-  mockPapi("get", null, error);
-  comp.$root.showError = jest.fn();
-  
-  await comp.loadCredits();
-  
-  expect(comp.$root.showError).toHaveBeenCalledWith(comp.i18n.assistantUnableToLoadCredits + ': ' + error.message);
+  expect(comp.creditsLoaded).toBe(true);
 });
 
 test('loadCredits handles missing data', async () => {

--- a/html/js/routes/aimetrics.test.js
+++ b/html/js/routes/aimetrics.test.js
@@ -581,32 +581,16 @@ test('loadCredits success', async () => {
   expect(comp.creditsLoaded).toBe(true);
 });
 
-test('loadCredits handles 500 error with extra HTML', async () => {
+test('loadCredits handles 500 error due to outage', async () => {
   const error = new Error('Internal Server Error');
-  error.response = { status: 500 };
-  mockPapi("get", null, error);
-  comp.$root.showErrorExtraHtml = jest.fn();
-  
-  await comp.loadCredits();
-  
-  expect(comp.$root.showErrorExtraHtml).toHaveBeenCalledWith(
-    comp.i18n.assistantUnableToLoadCredits + ': ' + error.message,
-    comp.i18n.assistantPotentialOutage,
-    'https://securityonionsolutions.com/status/'
-  );
-  expect(comp.creditsLoaded).toBe(true);
-});
-
-test('loadCredits handles non-500 error', async () => {
-  const error = new Error('Bad Request');
-  error.response = { status: 400 };
+  error.response = { status: 500, data: "ERROR_UPSTREAM_SERVICE_ERROR" };
   mockPapi("get", null, error);
   comp.$root.showError = jest.fn();
   
   await comp.loadCredits();
   
-  expect(comp.$root.showError).toHaveBeenCalledWith(comp.i18n.assistantUnableToLoadCredits + ': ' + error.message);
-  expect(comp.creditsLoaded).toBe(true);
+  expect(comp.$root.showError).toHaveBeenCalledWith(error);
+  expect(comp.creditsLoaded).toBe(false);
 });
 
 test('loadCredits handles error without response', async () => {
@@ -616,8 +600,8 @@ test('loadCredits handles error without response', async () => {
   
   await comp.loadCredits();
   
-  expect(comp.$root.showError).toHaveBeenCalledWith(comp.i18n.assistantUnableToLoadCredits + ': ' + error.message);
-  expect(comp.creditsLoaded).toBe(true);
+  expect(comp.$root.showError).toHaveBeenCalledWith(error);
+  expect(comp.creditsLoaded).toBe(false);
 });
 
 test('loadCredits handles unhealthy status', async () => {
@@ -632,8 +616,8 @@ test('loadCredits handles unhealthy status', async () => {
   
   await comp.loadCredits();
   
-  expect(comp.$root.showError).toHaveBeenCalledWith('Error loading credits from API: ' + comp.i18n.assistantBalanceCheckUnhealthy);
-  expect(comp.creditsLoaded).toBe(true);
+  expect(comp.$root.showError).toHaveBeenCalledWith(new Error(comp.i18n.assistantBalanceCheckUnhealthy));
+  expect(comp.creditsLoaded).toBe(false);
 });
 
 test('loadCredits handles missing data', async () => {

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -274,7 +274,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           }
         }
       } catch (error) {
-        this.$root.showError(this.i18n.assistantUnableToLoadCredits + ': ' + error.message);
+        if (error.response && error.response.status == 500) {
+          this.$root.showErrorExtraHtml(this.i18n.assistantUnableToLoadCredits + ': ' + error.message, this.i18n.assistantPotentialOutage, 'https://securityonionsolutions.com/status/');
+        } else {
+          this.$root.showError(this.i18n.assistantUnableToLoadCredits + ': ' + error.message);
+        }
         this.creditsLoaded = true;
       }
     },

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -160,8 +160,8 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         this.$root.showError(error);
       }
     },
-    async loadStoredChats() {
-      this.$root.startLoading();
+    async loadStoredChats(showLoading = true) {
+      if (showLoading) this.$root.startLoading();
       try {
         const response = await this.$root.papi.get('/assistant/sessions');
         if (response.data && Array.isArray(response.data)) {
@@ -182,7 +182,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         // Fallback to empty array if backend is unavailable
         this.chatHistory = [];
       } finally {
-        this.$root.stopLoading();
+        if (showLoading) this.$root.stopLoading();
       }
     },
     saveCurrentChatId() {
@@ -414,16 +414,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       // Show typing indicator
       this.isTyping = true;
       
-      try {
-        // Call the actual AI API - session ID is already set
-        await this.callAIAPI(messageText, tags);
+      // Call the actual AI API - session ID is already set
+      await this.callAIAPI(messageText, tags);
 
-        // Refresh chat history to show the latest session
-        await this.loadStoredChats();
-      } catch (error) {
-        this.$root.showError(this.i18n.assistantNoResponse + ': ' + error.message);
-        this.isTyping = false;
-      }
+      // Refresh chat history to show the latest session
+      await this.loadStoredChats(false);
     },
     
     // Helper method to parse JSON chunks and handle concatenated/partial JSON
@@ -804,7 +799,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           this.scrollIfPinned();
           
           // Show error to user
-          this.$root.showError(this.i18n.assistantNoResponse + ': ' + (error.response?.data?.error || error.message));
+          this.$root.showErrorExtraHtml(this.i18n.assistantNoResponse + ': ' + (error.response?.data?.error || error.message), this.i18n.assistantPotentialOutage, 'https://securityonionsolutions.com/status/');
         }
         
         // Clear the active streaming session if this was the active one

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -274,12 +274,8 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           }
         }
       } catch (error) {
-        if (error.response && error.response.status == 500) {
-          this.$root.showErrorExtraHtml(this.i18n.assistantUnableToLoadCredits + ': ' + error.message, this.i18n.assistantPotentialOutage, 'https://securityonionsolutions.com/status/');
-        } else {
-          this.$root.showError(this.i18n.assistantUnableToLoadCredits + ': ' + error.message);
-        }
-        this.creditsLoaded = true;
+        this.$root.showError(error);
+        this.creditsLoaded = false;
       }
     },
     async saveCurrentChat() {
@@ -797,9 +793,17 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           };
           this.messages.push(errorMessage);
           this.scrollIfPinned();
-          
+
+          // Read streamed error
+          if (error && error.response && error.response.data) {
+            const stream = error.response.data;
+            const reader = stream.pipeThrough(new TextDecoderStream()).getReader();
+            const { done, value } = await reader.read();
+            error = value;
+          }
+
           // Show error to user
-          this.$root.showErrorExtraHtml(this.i18n.assistantNoResponse + ': ' + (error.response?.data?.error || error.message), this.i18n.assistantPotentialOutage, 'https://securityonionsolutions.com/status/');
+          this.$root.showError(error);
         }
         
         // Clear the active streaming session if this was the active one

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -726,23 +726,6 @@ test('sendMessage creates session ID and updates URL', async () => {
   expect(comp.loadStoredChats).toHaveBeenCalled();
 });
 
-test('sendMessage handles API error', async () => {
-  const showErrorMock = mockShowError();
-  comp.newMessage = 'Test message';
-  comp.creditsRemaining = 100;
-  comp.currentChatId = fakeSessionId;
-  comp.callAIAPI = jest.fn().mockRejectedValue(new Error('API failed'));
-  comp.scrollToBottom = jest.fn();
-  comp.assistantEnabled = true;
-  comp.canChat = true;
-  comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
-  
-  await comp.sendMessage();
-  
-  expect(showErrorMock).toHaveBeenCalledWith('Failed to get AI response: API failed');
-  expect(comp.isTyping).toBe(false);
-});
-
 // Context length and model management tests
 test('calculateContextFromUsage calculates correct context length', () => {
   const usage1 = { input_tokens: 100, output_tokens: 50 };

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -521,22 +521,16 @@ test('loadCredits success', async () => {
   expect(comp.creditsLoaded).toBe(true);
 });
 
-test('loadCredits handles 500 error with extra HTML', async () => {
-  const error = new Error("Server error");
+test('loadCredits handles 500 error due to outage', async () => {
+  const error = new Error('ERROR_UPSTREAM_SERVICE_ERROR');
   error.response = { status: 500 };
   mockPapi("get", null, error);
-  
-  comp.$root.showErrorExtraHtml = jest.fn();
+  comp.$root.showError = jest.fn();
   
   await comp.loadCredits();
   
-  expect(comp.$root.showErrorExtraHtml).toHaveBeenCalledWith(
-    'Error loading credits from API: Server error',
-    comp.i18n.assistantPotentialOutage,
-    'https://securityonionsolutions.com/status/'
-  );
-  expect(comp.creditsRemaining).toBe(0);
-  expect(comp.creditsLoaded).toBe(true);
+  expect(comp.$root.showError).toHaveBeenCalledWith(error);
+  expect(comp.creditsLoaded).toBe(false);
 });
 
 test('loadCredits handles non-500 error', async () => {
@@ -547,20 +541,20 @@ test('loadCredits handles non-500 error', async () => {
   
   await comp.loadCredits();
   
-  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: API error');
+  expect(showErrorMock).toHaveBeenCalledWith(error);
   expect(comp.creditsRemaining).toBe(0);
-  expect(comp.creditsLoaded).toBe(true);
+  expect(comp.creditsLoaded).toBe(false);
 });
 
 test('loadCredits handles error without response', async () => {
   const showErrorMock = mockShowError();
-  mockPapi("get", null, new Error("Network error"));
+  const error = new Error("Network error")
+  mockPapi("get", null, error);
   
   await comp.loadCredits();
   
-  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: Network error');
-  expect(comp.creditsRemaining).toBe(0);
-  expect(comp.creditsLoaded).toBe(true);
+  expect(showErrorMock).toHaveBeenCalledWith(error);
+  expect(comp.creditsLoaded).toBe(false);
 });
 
 test('loadCredits handles unhealthy status', async () => {
@@ -573,9 +567,8 @@ test('loadCredits handles unhealthy status', async () => {
   
   await comp.loadCredits();
   
-  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: The AI model could not be reached. Support for local AI models is coming soon.');
-  expect(comp.creditsRemaining).toBe(0);
-  expect(comp.creditsLoaded).toBe(true);
+  expect(showErrorMock).toHaveBeenCalledWith(new Error(comp.i18n.assistantBalanceCheckUnhealthy));
+  expect(comp.creditsLoaded).toBe(false);
 });
 
 // Chat operations tests

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -518,15 +518,49 @@ test('loadCredits success', async () => {
   
   expect(mock).toHaveBeenCalledWith('/assistant/balance');
   expect(comp.creditsRemaining).toBe(100);
+  expect(comp.creditsLoaded).toBe(true);
 });
 
-test('loadCredits handles error', async () => {
-  const showErrorMock = mockShowError();
-  mockPapi("get", null, new Error("API error"));
+test('loadCredits handles 500 error with extra HTML', async () => {
+  const error = new Error("Server error");
+  error.response = { status: 500 };
+  mockPapi("get", null, error);
+  
+  comp.$root.showErrorExtraHtml = jest.fn();
   
   await comp.loadCredits();
   
+  expect(comp.$root.showErrorExtraHtml).toHaveBeenCalledWith(
+    'Error loading credits from API: Server error',
+    comp.i18n.assistantPotentialOutage,
+    'https://securityonionsolutions.com/status/'
+  );
   expect(comp.creditsRemaining).toBe(0);
+  expect(comp.creditsLoaded).toBe(true);
+});
+
+test('loadCredits handles non-500 error', async () => {
+  const showErrorMock = mockShowError();
+  const error = new Error("API error");
+  error.response = { status: 400 };
+  mockPapi("get", null, error);
+  
+  await comp.loadCredits();
+  
+  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: API error');
+  expect(comp.creditsRemaining).toBe(0);
+  expect(comp.creditsLoaded).toBe(true);
+});
+
+test('loadCredits handles error without response', async () => {
+  const showErrorMock = mockShowError();
+  mockPapi("get", null, new Error("Network error"));
+  
+  await comp.loadCredits();
+  
+  expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: Network error');
+  expect(comp.creditsRemaining).toBe(0);
+  expect(comp.creditsLoaded).toBe(true);
 });
 
 test('loadCredits handles unhealthy status', async () => {
@@ -540,7 +574,8 @@ test('loadCredits handles unhealthy status', async () => {
   await comp.loadCredits();
   
   expect(showErrorMock).toHaveBeenCalledWith('Error loading credits from API: The AI model could not be reached. Support for local AI models is coming soon.');
-  expect(comp.creditsRemaining).toBe(0); // Should remain 0 when unhealthy
+  expect(comp.creditsRemaining).toBe(0);
+  expect(comp.creditsLoaded).toBe(true);
 });
 
 // Chat operations tests

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -285,14 +285,14 @@
 						spellcheck="false"
 						class="chat-input flex-grow-1 mr-3"
 						@keydown.enter.exact.prevent="$refs.sendButton.$el.click()"
-						:disabled="!canChat"
+						:disabled="!canChat || !creditsLoaded"
 						data-aid="assistant_chat_input"
 					></v-textarea>
 					<v-btn
 						id="chat-send-button"
 						ref="sendButton"
 						color="primary"
-						:disabled="!newMessage.trim() || !canChat || checkForActivity()"
+						:disabled="!newMessage.trim() || !canChat || checkForActivity() || !creditsLoaded"
 						@click="sendMessage()"
 						data-aid="assistant_chat_send"
 						class="flex-shrink-0"

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -73,11 +73,7 @@
 			</v-expansion-panels>
 		</v-col>
 		<v-spacer></v-spacer>
-		<v-col cols="12" lg="2">
-			<h4 class="ml-5" data-aid="assistant_current_model">{{ i18n.currentModel }}: {{ modelsMap.get(currentModel).displayName }}</h4>
-			<h4 class="ml-5" data-aid="assistant_max_context">{{ i18n.contextLimit }}: {{ increaseContextLimit ? formatCount(contextLimitLarge) : formatCount(contextLimitSmall) }}</h4>
-		</v-col>
-		<v-col cols="12" lg="2" align="end">
+		<v-col cols="12" lg="4" align="end">
 			<h4 data-aid="assistant_credits_remaining">{{ i18n.creditsRemaining }}:
 				<span v-if="!creditsLoaded">
 					<v-progress-circular indeterminate color="primary" size="14" width="3"></v-progress-circular>
@@ -85,6 +81,7 @@
 				<span v-else :class="creditsRemaining <= lowBalanceColorAlert ? 'text-error' : 'text-primary'">{{ formatCount(creditsRemaining) }}</span>
 			</h4>
 			<span class="text-caption">{{ i18n.creditsSubjectToExpiration }}</span>
+			<h5 class="ml-5 mt-2" data-aid="assistant_current_model">{{ modelsMap.get(currentModel).displayName }}</h5>
 		</v-col>
 	</v-row>
 	<v-row align="start">
@@ -111,7 +108,7 @@
 						<v-icon>fa-minimize</v-icon>
 					</v-btn>
 					<div class="text-wrap mr-4" style="font-size: 14px;">{{ i18n.totalCredits }}: <span class="text-primary">{{ formatCount(creditsUsed) }}</span></div>
-					<div class="text-wrap" style="font-size: 14px;">{{ i18n.contextLength }}: <span :class="getContextColor(contextLength)">{{ formatCount(contextLength) }}</span></div>
+					<div class="text-wrap" style="font-size: 14px;">{{ i18n.contextLength }}: <span :class="getContextColor(contextLength)">{{ formatCount(contextLength) }}</span> / <span class="font-weight-thin">{{ increaseContextLimit ? formatCount(contextLimitLarge) : formatCount(contextLimitSmall) }}</span></div>
 				</v-card-title>
 				<v-divider></v-divider>
 				<v-card-text id="chat-messages" class="chat-messages pa-0" @scroll="onChatScroll">

--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -54,7 +54,7 @@ func RegisterAssistantRoutes(srv *Server, r chi.Router, prefix string) {
 }
 
 func (h *AssistantHandler) checkAssistantAvailable(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
-	if h.server.Config.AirgapEnabled {
+	if h.server != nil && h.server.Config != nil && h.server.Config.AirgapEnabled {
 		log.FromContext(ctx).Error("unable to use assistant on airgap installation")
 		web.Respond(w, r, http.StatusInternalServerError, "ERROR_SERVICE_NOT_AVAILABLE")
 		return false

--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -53,6 +53,15 @@ func RegisterAssistantRoutes(srv *Server, r chi.Router, prefix string) {
 	})
 }
 
+func (h *AssistantHandler) checkAssistantAvailable(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
+	if h.server.Config.AirgapEnabled {
+		log.FromContext(ctx).Error("unable to use assistant on airgap installation")
+		web.Respond(w, r, http.StatusInternalServerError, "ERROR_SERVICE_NOT_AVAILABLE")
+		return false
+	}
+	return true
+}
+
 // @Summary      Send Chat Message
 // @Description  Send a message to the AI assistant and receive a response. Supports both streaming (SSE) and non-streaming responses.
 // @Tags         Assistant
@@ -73,6 +82,10 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 	err := h.server.CheckAuthorized(ctx, "write_authored", "assistant")
 	if err != nil {
 		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
+	}
+
+	if !h.checkAssistantAvailable(ctx, w, r) {
 		return
 	}
 
@@ -146,7 +159,7 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 		response, err := h.server.AssistantManager.Chat(ctx, incMsg.Model, messages)
 		if err != nil {
 			logger.WithError(err).Error("unable to chat with assistant")
-			web.Respond(w, r, http.StatusInternalServerError, err)
+			web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
 
 			return
 		}
@@ -176,7 +189,7 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 	response, err := h.server.AssistantManager.ChatStream(noTimeOutCtx, incMsg.Model, messages)
 	if err != nil {
 		logger.WithError(err).Error("unable to chat (stream) with assistant")
-		web.Respond(w, r, http.StatusInternalServerError, err)
+		web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
 
 		return
 	}
@@ -227,6 +240,10 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 	err := h.server.CheckAuthorized(ctx, "write_authored", "assistant")
 	if err != nil {
 		web.Respond(w, r, http.StatusUnauthorized, err)
+		return
+	}
+
+	if !h.checkAssistantAvailable(ctx, w, r) {
 		return
 	}
 
@@ -295,7 +312,7 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 		response, err := h.server.AssistantManager.Chat(ctx, toolReq.Model, messages)
 		if err != nil {
 			logger.WithError(err).Error("unable to chat with assistant after tool execution")
-			web.Respond(w, r, http.StatusInternalServerError, err)
+			web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
 
 			return
 		}
@@ -316,7 +333,7 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 	response, err := h.server.AssistantManager.ChatStream(ctx, toolReq.Model, messages)
 	if err != nil {
 		logger.WithError(err).Error("unable to chat (stream) with assistant after tool execution")
-		web.Respond(w, r, http.StatusInternalServerError, err)
+		web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
 
 		return
 	}
@@ -365,7 +382,6 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 // @Failure      401           "Request was not properly authenticated"
 // @Failure      403           "Insufficient permissions for this request"
 // @Failure      500           "Internal SOC error; review SOC logs"
-// @Failure      503           "Service unavailable"
 // @Router       /api/assistant/balance [get]
 func (h *AssistantHandler) GetBalance(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -378,33 +394,27 @@ func (h *AssistantHandler) GetBalance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.server.Config.AirgapEnabled {
-		logger.Error("unable to retrieve balance on airgap installation")
-		web.Respond(w, r, http.StatusServiceUnavailable, nil)
-
+	if !h.checkAssistantAvailable(ctx, w, r) {
 		return
 	}
 
 	health, err := h.server.AssistantManager.Health(ctx)
 	if err != nil {
 		logger.WithError(err).Error("unable to get assistant health")
-		web.Respond(w, r, http.StatusInternalServerError, err)
-
+		web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
 		return
 	}
 
 	if health == nil || health.Status == "" {
 		logger.WithField("healthResponse", health).Warn("assistant health response is nil or missing status")
 		web.Respond(w, r, http.StatusInternalServerError, nil)
-
 		return
 	}
 
 	response, err := h.server.AssistantManager.Balance(ctx)
 	if err != nil {
 		logger.WithError(err).Error("unable to retrieve balance")
-		web.Respond(w, r, http.StatusInternalServerError, err)
-
+		web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
 		return
 	}
 

--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -365,6 +365,7 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 // @Failure      401           "Request was not properly authenticated"
 // @Failure      403           "Insufficient permissions for this request"
 // @Failure      500           "Internal SOC error; review SOC logs"
+// @Failure      503           "Service unavailable"
 // @Router       /api/assistant/balance [get]
 func (h *AssistantHandler) GetBalance(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -374,6 +375,13 @@ func (h *AssistantHandler) GetBalance(w http.ResponseWriter, r *http.Request) {
 	all := h.server.CheckAuthorized(ctx, "read_all", "assistant")
 	if self != nil && all != nil {
 		web.Respond(w, r, http.StatusUnauthorized, self)
+		return
+	}
+
+	if h.server.Config.AirgapEnabled {
+		logger.Error("unable to retrieve balance on airgap installation")
+		web.Respond(w, r, http.StatusServiceUnavailable, nil)
+
 		return
 	}
 

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/security-onion-solutions/securityonion-soc/config"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/rbac"
 	"github.com/security-onion-solutions/securityonion-soc/server/mock"
@@ -387,6 +388,9 @@ func TestGetBalance(t *testing.T) {
 	// Create mock server
 	srv := &Server{
 		Authorizer: &rbac.FakeAuthorizer{Authorized: true},
+		Config: &config.ServerConfig{
+			AirgapEnabled: false,
+		},
 	}
 	ctrl := gomock.NewController(t)
 	mockManager := mock.NewMockAssistantManager(ctrl)
@@ -430,6 +434,9 @@ func TestGetBalanceUnhealthy(t *testing.T) {
 	// Create mock server
 	srv := &Server{
 		Authorizer: &rbac.FakeAuthorizer{Authorized: true},
+		Config: &config.ServerConfig{
+			AirgapEnabled: false,
+		},
 	}
 	ctrl := gomock.NewController(t)
 	mockManager := mock.NewMockAssistantManager(ctrl)
@@ -457,6 +464,40 @@ func TestGetBalanceUnhealthy(t *testing.T) {
 
 	// Verify response
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+func TestGetBalanceAirgapEnabled(t *testing.T) {
+	// Create mock server with airgap enabled
+	srv := &Server{
+		Authorizer: &rbac.FakeAuthorizer{Authorized: true},
+		Config: &config.ServerConfig{
+			AirgapEnabled: true,
+		},
+	}
+	ctrl := gomock.NewController(t)
+	mockManager := mock.NewMockAssistantManager(ctrl)
+	defer ctrl.Finish()
+
+	srv.AssistantManager = mockManager
+
+	handler := NewAssistantHandler(srv)
+
+	req := httptest.NewRequest("GET", "/assistant/balance", nil)
+
+	// Add required context values
+	ctx := context.WithValue(req.Context(), web.ContextKeyRequestorId, "test-user-123")
+	ctx = context.WithValue(ctx, web.ContextKeyRequestStart, time.Now())
+	ctx = context.WithValue(ctx, web.ContextKeyRequestId, "test-request-123")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// No mock expectations needed - should return early due to airgap
+
+	// Execute the handler
+	handler.GetBalance(w, req)
+
+	// Verify response - should be 503 Service Unavailable
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 func TestGetUsage(t *testing.T) {

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -496,8 +496,8 @@ func TestGetBalanceAirgapEnabled(t *testing.T) {
 	// Execute the handler
 	handler.GetBalance(w, req)
 
-	// Verify response - should be 503 Service Unavailable
-	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, []byte("\"ERROR_SERVICE_NOT_AVAILABLE\""), w.Body.Bytes())
 }
 
 func TestGetUsage(t *testing.T) {
@@ -956,6 +956,7 @@ func TestCheckAssistantAvailable_AirgapEnabled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/assistant/test", nil)
 	ctx := context.WithValue(req.Context(), web.ContextKeyRequestorId, "test-user-123")
+	ctx = context.WithValue(ctx, web.ContextKeyRequestStart, time.Now())
 	req = req.WithContext(ctx)
 
 	w := httptest.NewRecorder()
@@ -966,8 +967,8 @@ func TestCheckAssistantAvailable_AirgapEnabled(t *testing.T) {
 	// Verify result is false
 	assert.False(t, result)
 
-	// Verify response is 503 Service Unavailable
-	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, []byte("\"ERROR_SERVICE_NOT_AVAILABLE\""), w.Body.Bytes())
 }
 
 func TestCheckAssistantAvailable_AirgapDisabled(t *testing.T) {
@@ -992,6 +993,6 @@ func TestCheckAssistantAvailable_AirgapDisabled(t *testing.T) {
 	// Verify result is true
 	assert.True(t, result)
 
-	// Verify no response was written (status should be 0)
-	assert.Equal(t, 0, w.Code)
+	// Verify no response was written
+	assert.Nil(t, w.Body.Bytes())
 }

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -943,3 +943,55 @@ func TestHistoryToContext(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckAssistantAvailable_AirgapEnabled(t *testing.T) {
+	// Create mock server with airgap enabled
+	srv := &Server{
+		Config: &config.ServerConfig{
+			AirgapEnabled: true,
+		},
+	}
+
+	handler := NewAssistantHandler(srv)
+
+	req := httptest.NewRequest("GET", "/assistant/test", nil)
+	ctx := context.WithValue(req.Context(), web.ContextKeyRequestorId, "test-user-123")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// Execute the check
+	result := handler.checkAssistantAvailable(ctx, w, req)
+
+	// Verify result is false
+	assert.False(t, result)
+
+	// Verify response is 503 Service Unavailable
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestCheckAssistantAvailable_AirgapDisabled(t *testing.T) {
+	// Create mock server with airgap disabled
+	srv := &Server{
+		Config: &config.ServerConfig{
+			AirgapEnabled: false,
+		},
+	}
+
+	handler := NewAssistantHandler(srv)
+
+	req := httptest.NewRequest("GET", "/assistant/test", nil)
+	ctx := context.WithValue(req.Context(), web.ContextKeyRequestorId, "test-user-123")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	// Execute the check
+	result := handler.checkAssistantAvailable(ctx, w, req)
+
+	// Verify result is true
+	assert.True(t, result)
+
+	// Verify no response was written (status should be 0)
+	assert.Equal(t, 0, w.Code)
+}


### PR DESCRIPTION
Added outage error message with a link to the status page. This message is separate from the error message airgap installations receive. [#357](https://github.com/Security-Onion-Solutions/sos/issues/357)

Assistant: outage error on initial balance inquiry (500):
<img width="1850" height="1044" alt="image" src="https://github.com/user-attachments/assets/b2467d96-37b0-44f0-92a7-5da1f56527a8" />

Assistant: airgap error on initial balance inquiry (503):
<img width="1850" height="1044" alt="image" src="https://github.com/user-attachments/assets/3c650265-03b4-4be8-8d9f-b53055328cae" />

AI Metrics: outage error on initial balance inquiry (500):
<img width="1850" height="1044" alt="image" src="https://github.com/user-attachments/assets/16373c81-bd34-4ffc-bf81-f6a69025c9e8" />

AI Metrics: airgap error on initial balance inquiry (503):
<img width="1850" height="1044" alt="image" src="https://github.com/user-attachments/assets/f8543de5-ee72-4b36-9c44-da7c22487ec2" />

Assistant: outage error mid-session (500):
<img width="1850" height="1044" alt="image" src="https://github.com/user-attachments/assets/5738a229-4c59-4470-abda-7a7df16b9566" />
