### PR TITLE
GetChatHistory return history for deleted sessions

### DIFF
--- a/server/modules/elastic/elasticassistantstore.go
+++ b/server/modules/elastic/elasticassistantstore.go
@@ -226,7 +226,7 @@ func (store *ElasticAssistantstore) SaveChat(ctx context.Context, chat *model.St
 func (store *ElasticAssistantstore) GetChatHistory(ctx context.Context, sessionId string) ([]*model.StoredMessage, error) {
 	logger := log.FromContext(ctx)
 
-	existing, err := store.GetSessions(ctx, model.GetSessionsWithSessionId(sessionId))
+	existing, err := store.GetSessions(ctx, model.GetSessionsWithSessionId(sessionId), model.GetSessionsWithIncludeDeleted(true))
 	if err != nil {
 		return nil, err
 	}

--- a/server/modules/elastic/elasticassistantstore_test.go
+++ b/server/modules/elastic/elasticassistantstore_test.go
@@ -1031,6 +1031,15 @@ func TestGetChatHistory(t *testing.T) {
 	assert.Equal(t, "msg2", messages[1].Id)
 	assert.Equal(t, "Hello", messages[0].Message.ContentStr)
 	assert.Equal(t, "Hi there!", messages[1].Message.ContentStr)
+
+	// ensure GetSession call does not filter out deleted sessions
+	reqs := transport.GetRequests()
+	assert.Len(t, reqs, 3) // One for GetSessions, one for session meta data, one for chat messages
+	body, err := reqs[0].GetBody()
+	assert.NoError(t, err)
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "deleteTime")
 }
 
 func TestGetSessions_WithFilters(t *testing.T) {


### PR DESCRIPTION
GetChatHistory needs to return history for deleted sessions for the sake of the AI Metrics page.

Added regression test.