### PR TITLE
Assistant: Show Buttons in List Responses

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -1448,3 +1448,36 @@ ul ul ul {
 .tiny-link-icon {
   font-size: 12px !important;
 }
+
+.assistant-choice-btn {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+
+  padding: 9px 13px;
+  border-radius: 6px;
+
+  cursor: pointer;
+  user-select: none;
+
+  line-height: 1.3;
+
+  background-color: rgba(25, 118, 210, 0.08);
+  color: var(--v-theme-primary);
+
+  transition:
+    background-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.05s ease;
+}
+
+.assistant-choice-btn:hover {
+  background-color: rgba(25, 118, 210, 0.16);
+}
+
+.assistant-choice-btn:active {
+  transform: translateY(1px);
+  background-color: rgba(25, 118, 210, 0.22);
+}
+

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -10,6 +10,8 @@ const MSGTAG_CONTEXTCOMPRESSION = "context_compression";
 
 const SESTAG_SHARED = 'shared';
 
+const CHOICE_MARKER_REGEX = /\[\[CHOICE\]\]([\s\S]*?)\[\[\/CHOICE\]\]/g;
+
 routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
   template: '#page-assistant',
   data() { return {
@@ -1134,6 +1136,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       return this.$root.formatTimestamp(timestamp);
     },
     formatMarkdown(text) {
+      text = this.applyChoiceButtons(text);
       text = this.$root.performMermaidRegexes(text);
       md = this.$root.formatMarkdown(text, true);
       if (!this.isStreaming) {
@@ -1142,6 +1145,10 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         });
       }
       return md;
+    },
+    renderInlineMarkdown(text) {
+      if (!text) return '';
+      return this.$root.formatMarkdown(text, false);
     },
     formatChatDate(timestamp) {
       return this.$root.formatDateTime(timestamp);
@@ -1936,6 +1943,52 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         type: 'assistant_session',
         id: this.currentChatId,
       });
+    },
+    escapeHtml(str) {
+      return String(str).replace(/[&<>"']/g, (char) => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      }[char]));
+    },
+    applyChoiceButtons(text) {
+      if (!text || typeof text !== 'string') return text;
+
+      return text.replace(CHOICE_MARKER_REGEX, (_fullMatch, rawLabel) => {
+        const label = this.stripNewlines(rawLabel).trim();
+        if (!label) return '';
+
+        const cleanLabel = this.stripHtml(this.renderInlineMarkdown(label));
+        const safeChoiceAttr = this.escapeHtml(label);
+
+        return `<button type="button" class="assistant-choice-btn" data-choice="${safeChoiceAttr}">${cleanLabel}</button>`;
+      });
+    },
+    onChatClick(event) {
+      const btn = event.target?.closest?.('button[data-choice]');
+      if (!btn) return;
+
+      event.preventDefault();
+
+      if (!this.canChat || this.checkForActivity() || !this.creditsLoaded) return;
+
+      const choice = btn.getAttribute('data-choice') || '';
+      if (!choice.trim()) return;
+
+      this.newMessage = choice;
+      this.$nextTick(() => {
+        this.focusChatInput();
+        this.sendMessage();
+      });
+    },
+    stripHtml(str) {
+      return str.replace(/<[^>]*>/g, '');
+    },
+    stripNewlines(text) {
+      if (typeof text !== 'string') return text;
+      return text.replace(/^\s*\n+/, '').replace(/\n+\s*$/, '');
     }
   }
 }});

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -5149,3 +5149,274 @@ test('focusChatInput focuses the chat input textarea', () => {
   expect(mockInputField.$el.querySelector).toHaveBeenCalledWith('textarea');
   expect(mockTextarea.focus).toHaveBeenCalled();
 });
+
+// Credits tracking tests
+test('updateCreditsUsed updates total credits used', () => {
+  comp.creditsUsed = 100;
+  const usage1 = { credits: 50 };
+  const usage2 = { credits: 25 };
+  
+  comp.updateCreditsUsed(usage1);
+  expect(comp.creditsUsed).toBe(150);
+  
+  comp.updateCreditsUsed(usage2);
+  expect(comp.creditsUsed).toBe(175);
+  
+  comp.updateCreditsUsed(null);
+  expect(comp.creditsUsed).toBe(175);
+});
+
+test('updateCreditsUsed handles missing credits field', () => {
+  comp.creditsUsed = 100;
+  const usage = { input_tokens: 10, output_tokens: 20 };
+  
+  comp.updateCreditsUsed(usage);
+  expect(comp.creditsUsed).toBe(100);
+});
+
+// Floating tool tests
+test('sendMessage marks floating tool as skipped when sending new message', async () => {
+  const floatingTool = {
+    id: 'tool_floating',
+    name: 'query_events',
+    status: 'pending_approval',
+    approved: null
+  };
+  
+  comp.messages = [fakeAssistantMessage, fakeMessage];
+  comp.currentChatId = 'test-session';
+  comp.mostRecentFloatingTool = new Map();
+  comp.mostRecentFloatingTool.set('test-session', floatingTool);
+  comp.newMessage = 'New message';
+  comp.canChat = true;
+  comp.assistantEnabled = true;
+  comp.creditsRemaining = 100;
+  comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
+  comp.callAIAPI = jest.fn().mockResolvedValue();
+  comp.loadStoredChats = jest.fn().mockResolvedValue();
+  comp.scrollToBottom = jest.fn();
+  
+  await comp.sendMessage();
+  
+  expect(floatingTool.status).toBe('skipped');
+  expect(comp.mostRecentFloatingTool.has('test-session')).toBe(false);
+});
+
+test('sendMessage does not mark floating tool as skipped when only welcome message', async () => {
+  const floatingTool = {
+    id: 'tool_floating',
+    name: 'query_events',
+    status: 'pending_approval',
+    approved: null
+  };
+  
+  comp.messages = [fakeAssistantMessage];
+  comp.currentChatId = 'test-session';
+  comp.mostRecentFloatingTool = new Map();
+  comp.mostRecentFloatingTool.set('test-session', floatingTool);
+  comp.newMessage = 'First message';
+  comp.canChat = true;
+  comp.assistantEnabled = true;
+  comp.creditsRemaining = 100;
+  comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
+  comp.callAIAPI = jest.fn().mockResolvedValue();
+  comp.loadStoredChats = jest.fn().mockResolvedValue();
+  comp.scrollToBottom = jest.fn();
+  
+  await comp.sendMessage();
+  
+  expect(floatingTool.status).toBe('pending_approval');
+});
+
+// Context compression tests
+test('compressCurrentSession sends compression message and reloads chat', async () => {
+  comp.currentChatId = 'test-session';
+  comp.newMessage = 'Original message';
+  comp.compressContextMsg = 'Compress the context';
+  comp.contextLength = 5000;
+  comp.sendMessage = jest.fn().mockResolvedValue();
+  comp.loadChatFromBackend = jest.fn().mockResolvedValue();
+  
+  await comp.compressCurrentSession();
+  
+  expect(comp.newMessage).toBe('Original message');
+  expect(comp.contextLength).toBe(0);
+  expect(comp.sendMessage).toHaveBeenCalledWith([MSGTAG_CONTEXTCOMPRESSION]);
+  expect(comp.loadChatFromBackend).toHaveBeenCalledWith('test-session');
+});
+
+// Choice buttons tests
+test('applyChoiceButtons converts choice markers to buttons', () => {
+  const text = 'Choose an option: [[CHOICE]]Option 1[[/CHOICE]] or [[CHOICE]]Option 2[[/CHOICE]]';
+  
+  const result = comp.applyChoiceButtons(text);
+  
+  expect(result).toContain('class="assistant-choice-btn"');
+  expect(result).toContain('data-choice="Option 1"');
+  expect(result).toContain('data-choice="Option 2"');
+});
+
+test('applyChoiceButtons handles empty choice markers', () => {
+  const text = 'Text with [[CHOICE]][[/CHOICE]] empty choice';
+  
+  const result = comp.applyChoiceButtons(text);
+  
+  expect(result).toBe('Text with  empty choice');
+});
+
+test('applyChoiceButtons handles text without choice markers', () => {
+  const text = 'Regular text without choices';
+  
+  const result = comp.applyChoiceButtons(text);
+  
+  expect(result).toBe('Regular text without choices');
+});
+
+test('applyChoiceButtons handles null text', () => {
+  const result = comp.applyChoiceButtons(null);
+  
+  expect(result).toBe(null);
+});
+
+test('applyChoiceButtons strips newlines from choice labels', () => {
+  const text = '[[CHOICE]]\n\nOption with newlines\n\n[[/CHOICE]]';
+  
+  const result = comp.applyChoiceButtons(text);
+  
+  expect(result).toContain('data-choice="Option with newlines"');
+});
+
+test('onChatClick handles choice button click', () => {
+  const mockButton = {
+    getAttribute: jest.fn().mockReturnValue('Selected choice')
+  };
+  const mockEvent = {
+    target: {
+      closest: jest.fn().mockReturnValue(mockButton)
+    },
+    preventDefault: jest.fn()
+  };
+  
+  comp.canChat = true;
+  comp.checkForActivity = jest.fn().mockReturnValue(false);
+  comp.creditsLoaded = true;
+  comp.focusChatInput = jest.fn();
+  comp.sendMessage = jest.fn();
+  
+  comp.onChatClick(mockEvent);
+  
+  expect(mockEvent.preventDefault).toHaveBeenCalled();
+  expect(comp.newMessage).toBe('Selected choice');
+  expect(comp.$nextTick).toHaveBeenCalled();
+});
+
+test('onChatClick ignores non-button clicks', () => {
+  const mockEvent = {
+    target: {
+      closest: jest.fn().mockReturnValue(null)
+    },
+    preventDefault: jest.fn()
+  };
+  
+  comp.sendMessage = jest.fn();
+  
+  comp.onChatClick(mockEvent);
+  
+  expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+  expect(comp.sendMessage).not.toHaveBeenCalled();
+});
+
+test('onChatClick does not send when activity in progress', () => {
+  const mockButton = {
+    getAttribute: jest.fn().mockReturnValue('Choice')
+  };
+  const mockEvent = {
+    target: {
+      closest: jest.fn().mockReturnValue(mockButton)
+    },
+    preventDefault: jest.fn()
+  };
+  
+  comp.canChat = true;
+  comp.checkForActivity = jest.fn().mockReturnValue(true);
+  comp.creditsLoaded = true;
+  comp.sendMessage = jest.fn();
+  
+  comp.onChatClick(mockEvent);
+  
+  expect(comp.sendMessage).not.toHaveBeenCalled();
+});
+
+test('onChatClick does not send when canChat is false', () => {
+  const mockButton = {
+    getAttribute: jest.fn().mockReturnValue('Choice')
+  };
+  const mockEvent = {
+    target: {
+      closest: jest.fn().mockReturnValue(mockButton)
+    },
+    preventDefault: jest.fn()
+  };
+  
+  comp.canChat = false;
+  comp.checkForActivity = jest.fn().mockReturnValue(false);
+  comp.creditsLoaded = true;
+  comp.sendMessage = jest.fn();
+  
+  comp.onChatClick(mockEvent);
+  
+  expect(comp.sendMessage).not.toHaveBeenCalled();
+});
+
+test('stripHtml removes HTML tags', () => {
+  expect(comp.stripHtml('<p>Hello <strong>World</strong></p>')).toBe('Hello World');
+  expect(comp.stripHtml('<div><span>Test</span></div>')).toBe('Test');
+  expect(comp.stripHtml('No tags')).toBe('No tags');
+});
+
+test('stripNewlines removes leading and trailing newlines', () => {
+  expect(comp.stripNewlines('\n\nHello World\n\n')).toBe('Hello World');
+  expect(comp.stripNewlines('  \n\nText\n\n  ')).toBe('Text');
+  expect(comp.stripNewlines('No newlines')).toBe('No newlines');
+});
+
+test('stripNewlines handles non-string input', () => {
+  expect(comp.stripNewlines(null)).toBe(null);
+  expect(comp.stripNewlines(undefined)).toBe(undefined);
+  expect(comp.stripNewlines(123)).toBe(123);
+});
+
+// Session tag update tests
+test('updateSessionTag sends correct API request for add action', async () => {
+  const sessionId = 'test-session';
+  const mockPut = mockPapi('put');
+  
+  await comp.updateSessionTag(sessionId, 'add', 'shared');
+  
+  expect(mockPut).toHaveBeenCalledWith(`/assistant/sessions/${sessionId}`, {
+    action: 'add',
+    tag: 'shared'
+  });
+});
+
+test('updateSessionTag sends correct API request for remove action', async () => {
+  const sessionId = 'test-session';
+  const mockPut = mockPapi('put');
+  
+  await comp.updateSessionTag(sessionId, 'remove', 'shared');
+  
+  expect(mockPut).toHaveBeenCalledWith(`/assistant/sessions/${sessionId}`, {
+    action: 'remove',
+    tag: 'shared'
+  });
+});
+
+test('updateSessionTag handles API error', async () => {
+  const sessionId = 'test-session';
+  const showErrorMock = mockShowError();
+  mockPapi('put', null, new Error('Update failed'));
+  
+  await comp.updateSessionTag(sessionId, 'add', 'shared');
+  
+  expect(showErrorMock).toHaveBeenCalledWith(expect.stringContaining('Update failed'));
+});

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -126,7 +126,7 @@
 					</v-icon>
 				</v-card-title>
 				<v-divider></v-divider>
-				<v-card-text id="chat-messages" class="chat-messages pa-0" @scroll="onChatScroll">
+				<v-card-text id="chat-messages" class="chat-messages pa-0" @scroll="onChatScroll" @click="onChatClick">
 					<div class="pa-4">
 						<div v-for="(message, index) in messages" :key="index" :id="'message-' + index" :class="['message-item', 'mb-3'].concat(messageClassesFromTags(message.tags || []))">
 							<div v-if="index === contextStartMessageIndex" class="context-divider py-4">


### PR DESCRIPTION
- When the AI Assistant responds with suggestions for how to proceed (usually in list format), these options will now each have their own button. When clicked, this button will send a new message with that option. [#389](https://github.com/Security-Onion-Solutions/sos/issues/389)
- The AI surrounds options with the start and end markers [[CHOICE]] and [[/CHOICE]]. Each option will has its own start and end markers.