### PR TITLE
Assistant: Per-Message Context (Hidden Feature)

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -1116,6 +1116,7 @@ const i18n = {
       title: 'Title',
       toggleLegend: 'Toggle Legend',
       toggleFullsizeHelp: 'Toggle between normal size and maximized size',
+      tokensLowercase: 'tokens',
       toolCyberchef: 'CyberChef',
       toolCyberchefHelp: 'Data decoding and transformation tools',
       toolElasticFleet: 'Elastic Fleet',

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -56,6 +56,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     paramsLoaded: false,
     caseMenuVisible: false,
     mruCases: [],
+    perMessageStatsEnabled: false,
   }},
   async created() {
     this.loadLocalSettings();
@@ -80,6 +81,12 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     'alwaysApproveReadRequests': 'saveLocalSettings',
     'showChatHistory': 'saveLocalSettings',
     'currentModel': 'saveLocalSettings'
+  },
+  computed: {
+    messageContextValues() {
+      const msgs = this.messages || [];
+      return msgs.map((_, i) => this.calculateContextOfMessage(msgs, i));
+    }
   },
   methods: {
 
@@ -1702,7 +1709,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
           // reset context, messages prior to this message are no longer
           // sent to the AI
           if (i >= 0 && i < backendMessages.length - 1) {
-            this.contextLength = this.calculateContextOfMessage(backendMessages, i);
+            this.contextLength = this.calculateContextOfMessage(backendMessages.map(m => m.message), i);
           } else {
             // this context compression is the latest message, can't determine
             // context size until assistant responds
@@ -1719,9 +1726,9 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     },
     calculateContextOfMessage(allMessages, msgIndex) {
       // non-user messages tell us their context in output_tokens
-      if (msgIndex >= 0 && msgIndex < allMessages.length && allMessages[msgIndex].message.role !== 'user') {
+      if (msgIndex >= 0 && msgIndex < allMessages.length && allMessages[msgIndex].role !== 'user') {
         // asking about an assistant message, return its output tokens
-        return allMessages[msgIndex].message.usage.output_tokens;
+        return allMessages[msgIndex].usage ? allMessages[msgIndex].usage.output_tokens : 0;
       }
 
       // this is a user message, use nearby message to calculate how many tokens
@@ -1731,12 +1738,12 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       if (msgIndex < allMessages.length - 1) next = allMessages[msgIndex + 1];
 
       let contextLength = 0;
-      if (prev && next) {
+      if (prev && prev.usage && next && next.usage) {
         // use the message before and after to calculate the tokens in this message
-        contextLength = next.message.usage.input_tokens - (prev.message.usage.input_tokens + prev.message.usage.output_tokens);
-      } else if (next) {
+        contextLength = next.usage.input_tokens - (prev.usage.input_tokens + prev.usage.output_tokens);
+      } else if (next && next.usage) {
         // use the next message's input_tokens as the length of this solitary message
-        contextLength = next.message.usage.input_tokens;
+        contextLength = next.usage.input_tokens;
       }
       return contextLength;
     },
@@ -1815,6 +1822,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       if (localStorage[prefix + '.alwaysApproveReadRequests']) this.alwaysApproveReadRequests = localStorage[prefix + '.alwaysApproveReadRequests'] == 'true';
       if (localStorage[prefix + '.showChatHistory']) this.showChatHistory = localStorage[prefix + '.showChatHistory'] == 'true';
       if (localStorage[prefix + '.currentModel']) this.currentModel = localStorage[prefix + '.currentModel'];
+      if (localStorage[prefix + '.perMessageStatsEnabled']) this.perMessageStatsEnabled = localStorage[prefix + '.perMessageStatsEnabled'] == 'true';
 
       if (localStorage['settings.case.mruCases']) this.mruCases = JSON.parse(localStorage['settings.case.mruCases']);
     },

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -5504,21 +5504,17 @@ test('createCase', async () => {
 test('calculateContextOfMessage - assistant message', () => {
   const allMessages = [
     {
-      message: {
-        role: 'user',
-        usage: {
-          input_tokens: 100,
-          output_tokens: 0
-        }
+      role: 'user',
+      usage: {
+        input_tokens: 100,
+        output_tokens: 0
       }
     },
     {
-      message: {
-        role: 'assistant',
-        usage: {
-          input_tokens: 200,
-          output_tokens: 150
-        }
+      role: 'assistant',
+      usage: {
+        input_tokens: 200,
+        output_tokens: 150
       }
     }
   ];
@@ -5533,30 +5529,24 @@ test('calculateContextOfMessage - assistant message', () => {
 test('calculateContextOfMessage - user message mid-session', () => {
   const allMessages = [
     {
-      message: {
-        role: 'assistant',
-        usage: {
-          input_tokens: 100,
-          output_tokens: 50
-        }
+      role: 'assistant',
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50
       }
     },
     {
-      message: {
-        role: 'user',
-        usage: {
-          input_tokens: 0,
-          output_tokens: 0
-        }
+      role: 'user',
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0
       }
     },
     {
-      message: {
-        role: 'assistant',
-        usage: {
-          input_tokens: 200,
-          output_tokens: 75
-        }
+      role: 'assistant',
+      usage: {
+        input_tokens: 200,
+        output_tokens: 75
       }
     }
   ];
@@ -5572,21 +5562,17 @@ test('calculateContextOfMessage - user message mid-session', () => {
 test('calculateContextOfMessage - first user message', () => {
   const allMessages = [
     {
-      message: {
-        role: 'user',
-        usage: {
-          input_tokens: 0,
-          output_tokens: 0
-        }
+      role: 'user',
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0
       }
     },
     {
-      message: {
-        role: 'assistant',
-        usage: {
-          input_tokens: 120,
-          output_tokens: 80
-        }
+      role: 'assistant',
+      usage: {
+        input_tokens: 120,
+        output_tokens: 80
       }
     }
   ];
@@ -5601,12 +5587,10 @@ test('calculateContextOfMessage - first user message', () => {
 test('calculateContextOfMessage - latest user message without assistant response', () => {
   const allMessages = [
     {
-      message: {
-        role: 'user',
-        usage: {
-          input_tokens: 0,
-          output_tokens: 0
-        }
+      role: 'user',
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0
       }
     }
   ];
@@ -5616,4 +5600,62 @@ test('calculateContextOfMessage - latest user message without assistant response
   // the length of this message isn't calculable given what we have. This should
   // only last for a short time until the model responds to the message.
   expect(result).toBe(0);
+});
+
+// messageContextValues computed property tests
+test('messageContextValues returns context values for all messages', () => {
+  comp.messages = [
+    {
+      role: 'user',
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0
+      }
+    },
+    {
+      role: 'assistant',
+      usage: {
+        input_tokens: 120,
+        output_tokens: 80
+      }
+    },
+    {
+      role: 'user',
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0
+      }
+    },
+    {
+      role: 'assistant',
+      usage: {
+        input_tokens: 200,
+        output_tokens: 150
+      }
+    }
+  ];
+
+  const result = comp.messageContextValues();
+
+  expect(result).toHaveLength(4);
+  expect(result[0]).toBe(120); // First user message: next.input_tokens = 120
+  expect(result[1]).toBe(80);  // First assistant message: output_tokens = 80
+  expect(result[2]).toBe(0);   // Second user message: next.input_tokens - (prev.input_tokens + prev.output_tokens) = 200 - (120 + 80) = 0
+  expect(result[3]).toBe(150); // Second assistant message: output_tokens = 150
+});
+
+test('messageContextValues handles empty messages array', () => {
+  comp.messages = [];
+
+  const result = comp.messageContextValues();
+
+  expect(result).toEqual([]);
+});
+
+test('messageContextValues handles null messages', () => {
+  comp.messages = null;
+
+  const result = comp.messageContextValues();
+
+  expect(result).toEqual([]);
 });

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -170,7 +170,10 @@
 									<div id="message-header" class="d-flex align-center mb-1">
 										<span class="font-weight-medium text-body-2 mr-2">{{ message.role === 'user' ? i18n.you : i18n.chat }}</span>
 										<span class="text-caption text-medium-emphasis mr-2">{{ formatTimestamp(message.timestamp) }}</span>
-										<span class="text-caption text-primary" v-if="message.usage && message.usage.credits">{{ message.usage.credits }} {{ i18n.creditsLowercase }}</span>
+										<template v-if="perMessageStatsEnabled">
+											<span class="text-caption text-primary mr-2" v-if="message.usage && message.usage.credits">{{ message.usage.credits }} {{ i18n.creditsLowercase }}</span>
+											<span class="text-caption text-green" v-if="messageContextValues[index] > 0">{{ messageContextValues[index] }} {{ i18n.tokensLowercase }}</span>
+										</template>
 									</div>
 									<div id="message-content" class="text-body-2" :key="message.content" v-html="formatMarkdown(message.content)"></div>
 									

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -171,8 +171,8 @@
 										<span class="font-weight-medium text-body-2 mr-2">{{ message.role === 'user' ? i18n.you : i18n.chat }}</span>
 										<span class="text-caption text-medium-emphasis mr-2">{{ formatTimestamp(message.timestamp) }}</span>
 										<template v-if="perMessageStatsEnabled">
-											<span class="text-caption text-primary mr-2" v-if="message.usage && message.usage.credits">{{ message.usage.credits }} {{ i18n.creditsLowercase }}</span>
-											<span class="text-caption text-green" v-if="messageContextValues[index] > 0">{{ messageContextValues[index] }} {{ i18n.tokensLowercase }}</span>
+											<span class="text-caption text-primary mr-2" v-if="message.usage && message.usage.credits">{{ formatCount(message.usage.credits) }} {{ i18n.creditsLowercase }}</span>
+											<span class="text-caption text-green" v-if="messageContextValues[index] > 0">{{ formatCount(messageContextValues[index]) }} {{ i18n.tokensLowercase }}</span>
 										</template>
 									</div>
 									<div id="message-content" class="text-body-2" :key="message.content" v-html="formatMarkdown(message.content)"></div>


### PR DESCRIPTION
- Added a per-message context stat to the Assistant page, which is displayed next to the credits used stat for each message in a session. [#363](https://github.com/Security-Onion-Solutions/sos/issues/363)
- Made this feature, as well as the per-message credits stat, disabled by default.
- These features are now hidden, and can be enabled by setting `settings.assistant.perMessageStatsEnabled` to true in local storage.
- Added and updated unit tests for the above changes.