### PR TITLE
Alerts: Long Unbreaking Message Content Causes Wide Table

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -259,6 +259,7 @@ th:hover, th.is-sorted, .solid {
   white-space: pre-wrap;
   word-break: break-all;
   overflow-x: hidden;
+  overflow-wrap: anywhere;
 }
 
 .semi-transparent {


### PR DESCRIPTION
- Fixed issue on Alerts page where expanding an alert with long unbreaking message content caused an extra wide table. [#15437](https://github.com/Security-Onion-Solutions/securityonion/issues/15437)