### PR TITLE
Quick Graceful Shutdown

### DIFF
--- a/cmd/sensoroni.go
+++ b/cmd/sensoroni.go
@@ -89,6 +89,15 @@ func main() {
 		signal.Notify(terminateChan, os.Interrupt, syscall.SIGTERM)
 		go func() {
 			<-terminateChan
+			shutdownStart := time.Now()
+
+			go func() {
+				time.Sleep(time.Duration(cfg.ShutdownGracePeriodMs) * time.Millisecond)
+				log.WithField("ShutdownGracePeriodMs", cfg.ShutdownGracePeriodMs).Warn("Shutdown did not exit within grace period; aborting")
+				logFile.Close()
+				os.Exit(1)
+			}()
+
 			log.Warn("Detected shutdown request, waiting for app to shutdown gracefully")
 			if agt != nil {
 				agt.Stop()
@@ -98,10 +107,9 @@ func main() {
 			}
 			licensing.Shutdown()
 
-			time.Sleep(time.Duration(cfg.ShutdownGracePeriodMs) * time.Millisecond)
-			log.WithField("ShutdownGracePeriodMs", cfg.ShutdownGracePeriodMs).Warn("Shutdown did not exit within grace period; aborting")
+			log.WithField("shutdownDurationSeconds", time.Since(shutdownStart).Seconds()).Info("Shutdown complete, exiting")
 			logFile.Close()
-			os.Exit(1)
+			os.Exit(0)
 		}()
 
 		if agt != nil {

--- a/licensing/license_manager.go
+++ b/licensing/license_manager.go
@@ -320,11 +320,13 @@ func startExpirationMonitor() {
 		}
 		manager.expirationTimer = time.NewTimer(duration)
 		<-manager.expirationTimer.C
-		log.WithFields(log.Fields{
-			"expiration": manager.licenseKey.Expiration,
-			"duration":   duration,
-		}).Warn("License has expired")
-		manager.status = LICENSE_STATUS_EXPIRED
+		if manager.licenseKey.Expiration.Before(time.Now()) {
+			log.WithFields(log.Fields{
+				"expiration": manager.licenseKey.Expiration,
+				"duration":   duration,
+			}).Warn("License has expired")
+			manager.status = LICENSE_STATUS_EXPIRED
+		}
 	}
 	manager.expirationTimer = nil
 }
@@ -426,10 +428,10 @@ func Usable() bool {
 func stopMonitor() {
 	if manager != nil {
 		if manager.expirationTimer != nil {
-			manager.expirationTimer.Stop()
+			manager.expirationTimer.Reset(time.Duration(0))
 		}
 		if manager.effectiveTimer != nil {
-			manager.effectiveTimer.Stop()
+			manager.effectiveTimer.Reset(time.Duration(0))
 		}
 		if manager.pillarTimer != nil {
 			pillarFilename = ""


### PR DESCRIPTION
Go changed some behavior in timers back in 1.23 where previously a stopped timer might buffer one more tick before it's truly stopped. Now if one goroutine is waiting on a timer and another goroutine stops that timer, the first goroutine will wait forever. To restore old behavior, I updated the license manager to reset it's timers to 0 so they immediately fire and overwrite themselves with nil. A condition was added so that we don't incorrectly print that the license is invalid while shutting down.

Reworked the graceful shutdown timing logic so it takes AT MOST the configured amount of time to shutdown. In most cases it will be able to shutdown in less than a second, this time is now logged.

If the graceful shutdown succeeded, the process exits with 0, else 1.