### PR TITLE
OpenAI_Chat

### DIFF
--- a/server/modules/assistant/openai_chat_adapter.go
+++ b/server/modules/assistant/openai_chat_adapter.go
@@ -1,0 +1,419 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/module"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+
+	"github.com/apex/log"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+func init() {
+	protocols[(&OpenAIChatAdapter{}).Protocol()] = NewOpenAIChatAdapter
+}
+
+type OpenAIChatAdapter struct {
+	srv                  *server.Server
+	client               OpenAIClient
+	healthTimeoutSeconds int
+	detections.IOManager
+}
+
+func NewOpenAIChatAdapter(ctx context.Context, srv *server.Server, config map[string]any) (server.AssistantAdapter, error) {
+	baseUrl := module.GetStringDefault(config, "baseUrl", "")
+	if baseUrl == "" {
+		return nil, fmt.Errorf("openai_chat adapter requires baseUrl in config")
+	}
+
+	opts := []option.RequestOption{
+		option.WithBaseURL(baseUrl),
+	}
+
+	apiKey := module.GetStringDefault(config, "apiKey", "")
+	if apiKey != "" {
+		opts = append(opts, option.WithAPIKey(apiKey))
+	}
+
+	healthTimeoutSeconds := module.GetIntDefault(config, "healthTimeoutSeconds", DEFAULT_HEALTH_TIMEOUT_SECONDS)
+
+	return &OpenAIChatAdapter{
+		srv:                  srv,
+		healthTimeoutSeconds: healthTimeoutSeconds,
+		client:               NewOpenAIClientWrapper(openai.NewClient(opts...)),
+		IOManager: &detections.ResourceManager{
+			Config: srv.Config,
+		},
+	}, nil
+}
+
+func (a *OpenAIChatAdapter) Protocol() string {
+	return "openai_chat"
+}
+
+func (a *OpenAIChatAdapter) SendMessage(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
+	logger := log.FromContext(ctx)
+
+	// Convert history and tools
+	messages := convertHistoryToChatCompletions(logger, req)
+	tools := convertToolConfigToChatCompletions(req)
+
+	params := openai.ChatCompletionNewParams{
+		Model:    req.Model,
+		Messages: messages,
+	}
+
+	if tools != nil {
+		params.Tools = tools
+	}
+
+	// Call non-streaming API
+	resp, err := a.client.ChatCompletionsNew(ctx, params)
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"model": req.Model,
+		}).WithError(err).Error("error calling OpenAI ChatCompletions API")
+		return nil, err
+	}
+
+	// Build model.Message from first choice
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	choice := resp.Choices[0]
+	message := &model.Message{
+		Id:            resp.ID,
+		Role:          "assistant",
+		ContentBlocks: []model.ContentBlock{},
+	}
+
+	// Process text content
+	if choice.Message.Content != "" {
+		message.ContentBlocks = append(message.ContentBlocks, model.ContentBlock{
+			Type: "text",
+			Text: choice.Message.Content,
+		})
+	}
+
+	// Process tool calls
+	for _, toolCall := range choice.Message.ToolCalls {
+		// Tool calls have Type field indicating "function" or "custom"
+		if toolCall.Type == "function" {
+			message.ContentBlocks = append(message.ContentBlocks, model.ContentBlock{
+				Type:  "tool_use",
+				Id:    toolCall.ID,
+				Name:  toolCall.Function.Name,
+				Input: json.RawMessage(toolCall.Function.Arguments),
+			})
+		}
+	}
+
+	// Handle usage metadata
+	message.Usage = &model.Usage{
+		InputTokens:  int(resp.Usage.PromptTokens),
+		OutputTokens: int(resp.Usage.CompletionTokens),
+	}
+
+	// Handle finish reason
+	finishReason := string(choice.FinishReason)
+	if finishReason == "stop" {
+		finishReason = "end_turn"
+	}
+	message.StopReason = &finishReason
+
+	return message, nil
+}
+
+func (a *OpenAIChatAdapter) SendMessageStream(ctx context.Context, req *model.ChatRequest) (*http.Response, *model.AuxMessageData, error) {
+	logger := log.FromContext(ctx)
+
+	messages := convertHistoryToChatCompletions(logger, req)
+	tools := convertToolConfigToChatCompletions(req)
+
+	params := openai.ChatCompletionNewParams{
+		Model:    req.Model,
+		Messages: messages,
+	}
+
+	if tools != nil {
+		params.Tools = tools
+	}
+
+	// Use noTimeout context like Responses adapter
+	noTimeoutContext := context.WithValue(context.Background(), web.ContextKeyRequestId, ctx.Value(web.ContextKeyRequestId))
+	noTimeoutContext = context.WithValue(noTimeoutContext, web.ContextKeyRequestorId, ctx.Value(web.ContextKeyRequestorId))
+
+	stream := a.client.ChatCompletionsNewStreaming(noTimeoutContext, params)
+
+	response, bodyWriter := fabricateResponse(http.StatusOK)
+
+	wg := &sync.WaitGroup{}
+	writer := newSSEEventWriter(logger, bodyWriter)
+	processor := newStreamProcessor(writer, req.Model, wg)
+
+	err := stream.Err()
+	if err != nil {
+		bodyWriter.Close()
+		logger.WithError(err).Error("error before first response from OpenAI ChatCompletions streaming API")
+
+		replacement, _ := handleStreamError(err, processor.firstSend, writer, logger, req.Model)
+		if replacement != nil {
+			response = replacement
+		}
+
+		return response, nil, err
+	}
+
+	wg.Add(1)
+
+	go func() {
+		defer bodyWriter.Close()
+
+		var finishReason string
+		var usage openai.CompletionUsage
+
+		for stream.Next() {
+			err := stream.Err()
+			if err != nil {
+				replacement, shouldReturn := handleStreamError(err, processor.firstSend, writer, logger, req.Model)
+				if shouldReturn {
+					if replacement != nil {
+						response = replacement
+					}
+					return
+				}
+			}
+
+			chunk := stream.Current()
+
+			err = processor.processChatCompletionChunk(chunk)
+			if err != nil {
+				processor.writeError(err)
+				return
+			}
+
+			// Capture finish reason and usage from chunks
+			if len(chunk.Choices) > 0 {
+				if chunk.Choices[0].FinishReason != "" {
+					finishReason = chunk.Choices[0].FinishReason
+				}
+			}
+
+			// Update usage if present (it comes in the final chunk)
+			if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
+				usage = chunk.Usage
+			}
+		}
+
+		processor.finalizeChatCompletion(finishReason, &usage)
+	}()
+
+	wg.Wait()
+
+	return response, nil, nil
+}
+
+func (a *OpenAIChatAdapter) GetBalance(ctx context.Context) (*model.BalanceResponse, error) {
+	return &model.BalanceResponse{
+		Balance: UNUSED_BALANCE,
+	}, nil
+}
+
+func (a *OpenAIChatAdapter) GetHealth(ctx context.Context) (*model.HealthResponse, error) {
+	healthCtx, cancel := context.WithTimeout(a.srv.Context, time.Second*time.Duration(a.healthTimeoutSeconds))
+	defer cancel()
+
+	status := "unhealthy"
+
+	res, err := a.client.ModelsList(healthCtx)
+	if err == nil && len(res.Data) > 0 {
+		status = "healthy"
+	}
+
+	return &model.HealthResponse{
+		Status: status,
+	}, nil
+}
+
+func convertHistoryToChatCompletions(logger log.Interface, req *model.ChatRequest) []openai.ChatCompletionMessageParamUnion {
+	messages := make([]openai.ChatCompletionMessageParamUnion, 0, len(req.Messages)+1)
+
+	// 1. FIRST: Add system message if present
+	prompt := req.System
+	if req.SystemAppend != "" {
+		prompt += "\n" + req.SystemAppend
+	}
+	if prompt != "" {
+		messages = append(messages, openai.ChatCompletionMessageParamUnion{
+			OfSystem: &openai.ChatCompletionSystemMessageParam{
+				Content: openai.ChatCompletionSystemMessageParamContentUnion{
+					OfString: openai.String(prompt),
+				},
+			},
+		})
+	}
+
+	// 2. Convert message history
+	for _, msg := range req.Messages {
+		content := ""
+		var toolCalls []openai.ChatCompletionMessageToolCallUnionParam
+		var toolMessages []openai.ChatCompletionMessageParamUnion
+
+		for _, block := range msg.ContentBlocks {
+			if block.Type == "" && block.ToolResult != nil {
+				block.Type = "tool_result"
+			}
+
+			switch block.Type {
+			case "text":
+				content += block.Text
+
+			case "tool_use":
+				// Assistant made a function call
+				var args map[string]any
+				if len(block.Input) > 0 {
+					if err := json.Unmarshal(block.Input, &args); err != nil {
+						logger.WithError(err).Error("failed to unmarshal tool use input")
+						continue
+					}
+				}
+
+				toolCall := openai.ChatCompletionMessageToolCallUnionParam{
+					OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+						ID: block.Id,
+						Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+							Name:      block.Name,
+							Arguments: string(block.Input),
+						},
+					},
+				}
+				toolCalls = append(toolCalls, toolCall)
+
+			case "tool_result":
+				// User provided tool result
+				if block.ToolResult != nil && len(block.ToolResult.Content) != 0 {
+					var resultContent string
+					if block.ToolResult.IsError {
+						resultContent = fmt.Sprintf(`{"error": "%s"}`, block.ToolResult.Content[0].Text)
+					} else {
+						jsonBytes, err := json.Marshal(block.ToolResult.Content[0].Json)
+						if err != nil {
+							jsonBytes = []byte(`{"error": "failed to marshal tool result content"}`)
+						}
+						resultContent = string(jsonBytes)
+					}
+
+					toolMsg := openai.ChatCompletionMessageParamUnion{
+						OfTool: &openai.ChatCompletionToolMessageParam{
+							Content: openai.ChatCompletionToolMessageParamContentUnion{
+								OfString: openai.String(resultContent),
+							},
+							ToolCallID: block.ToolResult.ToolUseId,
+						},
+					}
+					toolMessages = append(toolMessages, toolMsg)
+				}
+			}
+		}
+
+		// Build message based on role and content type
+		if msg.Role == "user" {
+			if content != "" && content != "&nbsp;" {
+				messages = append(messages, openai.ChatCompletionMessageParamUnion{
+					OfUser: &openai.ChatCompletionUserMessageParam{
+						Content: openai.ChatCompletionUserMessageParamContentUnion{
+							OfString: openai.String(content),
+						},
+					},
+				})
+			}
+		} else if msg.Role == "assistant" {
+			assistantMsg := &openai.ChatCompletionAssistantMessageParam{}
+
+			if content != "" && content != "&nbsp;" {
+				assistantMsg.Content = openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfString: openai.String(content),
+				}
+			}
+
+			if len(toolCalls) > 0 {
+				assistantMsg.ToolCalls = toolCalls
+			}
+
+			messages = append(messages, openai.ChatCompletionMessageParamUnion{
+				OfAssistant: assistantMsg,
+			})
+		}
+
+		// Add tool messages after the assistant message
+		messages = append(messages, toolMessages...)
+	}
+
+	return messages
+}
+
+func convertToolConfigToChatCompletions(req *model.ChatRequest) []openai.ChatCompletionToolUnionParam {
+	if req.ToolConfig == nil {
+		return nil
+	}
+
+	var toolConfig model.ToolConfig
+	if err := json.Unmarshal(req.ToolConfig, &toolConfig); err != nil {
+		return nil
+	}
+
+	if len(toolConfig.Tools) == 0 {
+		return nil
+	}
+
+	tools := make([]openai.ChatCompletionToolUnionParam, 0, len(toolConfig.Tools))
+
+	for _, toolSpec := range toolConfig.Tools {
+		if toolSpec.Spec.InputSchema.Json == nil {
+			continue
+		}
+
+		parameters := convertJSONSchemaToOpenAI(toolSpec.Spec.InputSchema.Json)
+
+		var description param.Opt[string]
+		if toolSpec.Spec.Description != "" {
+			description = openai.String(toolSpec.Spec.Description)
+		}
+
+		toolParam := openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        toolSpec.Spec.Name,
+					Parameters:  openai.FunctionParameters(parameters),
+					Description: description,
+					Strict:      openai.Bool(true),
+				},
+			},
+		}
+
+		tools = append(tools, toolParam)
+	}
+
+	if len(tools) == 0 {
+		return nil
+	}
+
+	return tools
+}

--- a/server/modules/assistant/openai_chat_adapter_test.go
+++ b/server/modules/assistant/openai_chat_adapter_test.go
@@ -1,0 +1,1405 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/server/modules/detections"
+
+	"github.com/apex/log"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/pagination"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper functions for creating mock ChatCompletion responses and chunks
+
+func createChatCompletionUsage(promptTokens, completionTokens int64) openai.CompletionUsage {
+	return openai.CompletionUsage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+	}
+}
+
+func createMockToolCall(id, name, args string) openai.ChatCompletionMessageToolCallUnion {
+	return openai.ChatCompletionMessageToolCallUnion{
+		ID:   id,
+		Type: "function",
+		Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+}
+
+func createMockChatCompletion(content string, toolCalls []openai.ChatCompletionMessageToolCallUnion, usage openai.CompletionUsage, finishReason string) *openai.ChatCompletion {
+	message := openai.ChatCompletionMessage{
+		Role:      "assistant",
+		Content:   content,
+		ToolCalls: toolCalls,
+	}
+
+	return &openai.ChatCompletion{
+		ID: "chatcmpl_test123",
+		Choices: []openai.ChatCompletionChoice{
+			{
+				Message:      message,
+				FinishReason: finishReason,
+			},
+		},
+		Usage: usage,
+	}
+}
+
+// Streaming chunk creators
+
+func newChatTextDelta(content string) openai.ChatCompletionChunk {
+	return openai.ChatCompletionChunk{
+		Choices: []openai.ChatCompletionChunkChoice{
+			{
+				Delta: openai.ChatCompletionChunkChoiceDelta{
+					Role:    "assistant",
+					Content: content,
+				},
+			},
+		},
+	}
+}
+
+func newChatToolCallStartDelta(index int, id, name string) openai.ChatCompletionChunk {
+	return openai.ChatCompletionChunk{
+		Choices: []openai.ChatCompletionChunkChoice{
+			{
+				Delta: openai.ChatCompletionChunkChoiceDelta{
+					Role: "assistant",
+					ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{
+						{
+							Index: int64(index),
+							ID:    id,
+							Type:  "function",
+							Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+								Name: name,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newChatToolCallArgumentsDelta(index int, args string) openai.ChatCompletionChunk {
+	return openai.ChatCompletionChunk{
+		Choices: []openai.ChatCompletionChunkChoice{
+			{
+				Delta: openai.ChatCompletionChunkChoiceDelta{
+					ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{
+						{
+							Index: int64(index),
+							Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+								Arguments: args,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newChatFinishReasonChunk(finishReason string) openai.ChatCompletionChunk {
+	return openai.ChatCompletionChunk{
+		Choices: []openai.ChatCompletionChunkChoice{
+			{
+				FinishReason: finishReason,
+			},
+		},
+	}
+}
+
+func newChatCompletionUsageChunk(usage openai.CompletionUsage) openai.ChatCompletionChunk {
+	return openai.ChatCompletionChunk{
+		Usage: usage,
+	}
+}
+
+// Test cases
+
+func TestNewOpenAIChatAdapter(t *testing.T) {
+	tests := []struct {
+		name                  string
+		config                map[string]any
+		expectError           bool
+		errorContains         string
+		expectedHealthTimeout int
+		validateHealthTimeout bool
+	}{
+		{
+			name: "Success with all config values",
+			config: map[string]any{
+				"baseUrl":              "https://api.openai.com/v1",
+				"apiKey":               "test-key",
+				"healthTimeoutSeconds": float64(6),
+			},
+			expectError:           false,
+			expectedHealthTimeout: 6,
+			validateHealthTimeout: true,
+		},
+		{
+			name: "Missing baseUrl returns error",
+			config: map[string]any{
+				"apiKey": "test-key",
+			},
+			expectError:   true,
+			errorContains: "baseUrl",
+		},
+		{
+			name: "Without apiKey succeeds",
+			config: map[string]any{
+				"baseUrl": "https://api.openai.com/v1",
+			},
+			expectError: false,
+		},
+		{
+			name: "Default health timeout",
+			config: map[string]any{
+				"baseUrl": "https://api.openai.com/v1",
+			},
+			expectError:           false,
+			expectedHealthTimeout: DEFAULT_HEALTH_TIMEOUT_SECONDS,
+			validateHealthTimeout: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := server.NewFakeUnauthorizedServer()
+			adapter, err := NewOpenAIChatAdapter(context.Background(), srv, tt.config)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, adapter)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, adapter)
+
+				if tt.validateHealthTimeout {
+					chatAdapter := adapter.(*OpenAIChatAdapter)
+					assert.Equal(t, tt.expectedHealthTimeout, chatAdapter.healthTimeoutSeconds)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenAIChatAdapter_Protocol(t *testing.T) {
+	adapter := &OpenAIChatAdapter{}
+	assert.Equal(t, "openai_chat", adapter.Protocol())
+}
+
+func TestOpenAIChatAdapter_GetBalance(t *testing.T) {
+	adapter := &OpenAIChatAdapter{}
+	ctx := context.Background()
+
+	balance, err := adapter.GetBalance(ctx)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, balance)
+	assert.Equal(t, int64(UNUSED_BALANCE), balance.Balance)
+}
+
+func TestOpenAIChatAdapter_GetHealth(t *testing.T) {
+	tests := []struct {
+		name           string
+		modelsListFunc func(ctx context.Context) (*pagination.Page[openai.Model], error)
+		expectedStatus string
+	}{
+		{
+			name: "Returns healthy when ModelsList succeeds",
+			modelsListFunc: func(ctx context.Context) (*pagination.Page[openai.Model], error) {
+				return &pagination.Page[openai.Model]{
+					Data: []openai.Model{{ID: "gpt-4"}},
+				}, nil
+			},
+			expectedStatus: "healthy",
+		},
+		{
+			name: "Returns unhealthy when ModelsList fails",
+			modelsListFunc: func(ctx context.Context) (*pagination.Page[openai.Model], error) {
+				return nil, errors.New("API error")
+			},
+			expectedStatus: "unhealthy",
+		},
+		{
+			name: "Returns unhealthy when ModelsList returns empty",
+			modelsListFunc: func(ctx context.Context) (*pagination.Page[openai.Model], error) {
+				return &pagination.Page[openai.Model]{
+					Data: []openai.Model{},
+				}, nil
+			},
+			expectedStatus: "unhealthy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockOpenAIClient{
+				modelsListFunc: tt.modelsListFunc,
+			}
+
+			srv := server.NewFakeUnauthorizedServer()
+			adapter := &OpenAIChatAdapter{
+				client: mockClient,
+				srv:    srv,
+				IOManager: &detections.ResourceManager{
+					Config: srv.Config,
+				},
+				healthTimeoutSeconds: DEFAULT_HEALTH_TIMEOUT_SECONDS,
+			}
+
+			ctx := context.Background()
+			health, err := adapter.GetHealth(ctx)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, health)
+			assert.Equal(t, tt.expectedStatus, health.Status)
+		})
+	}
+}
+
+func TestConvertHistoryToChatCompletions(t *testing.T) {
+	logger := log.Log
+
+	tests := []struct {
+		name     string
+		req      *model.ChatRequest
+		validate func(*testing.T, []openai.ChatCompletionMessageParamUnion)
+	}{
+		{
+			name: "empty messages",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "single text message from user",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Hello, world!"},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfUser)
+				assert.Equal(t, "Hello, world!", result[0].OfUser.Content.OfString.Value)
+			},
+		},
+		{
+			name: "single text message from assistant",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "assistant",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Hi there!"},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfAssistant)
+				assert.Equal(t, "Hi there!", result[0].OfAssistant.Content.OfString.Value)
+			},
+		},
+		{
+			name: "multiple text messages",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "First message"},
+						},
+					},
+					{
+						Role: "assistant",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Second message"},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 2)
+				require.NotNil(t, result[0].OfUser)
+				assert.Equal(t, "First message", result[0].OfUser.Content.OfString.Value)
+				require.NotNil(t, result[1].OfAssistant)
+				assert.Equal(t, "Second message", result[1].OfAssistant.Content.OfString.Value)
+			},
+		},
+		{
+			name: "system prompt with SystemAppend",
+			req: &model.ChatRequest{
+				System:       "You are a helpful assistant.",
+				SystemAppend: "Be concise.",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Hello"},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 2)
+				require.NotNil(t, result[0].OfSystem)
+				assert.Contains(t, result[0].OfSystem.Content.OfString.Value, "You are a helpful assistant.")
+				assert.Contains(t, result[0].OfSystem.Content.OfString.Value, "Be concise.")
+			},
+		},
+		{
+			name: "tool use with valid JSON",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "assistant",
+						ContentBlocks: []model.ContentBlock{
+							{
+								Type:  "tool_use",
+								Id:    "call_123",
+								Name:  "search",
+								Input: json.RawMessage(`{"query":"test"}`),
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfAssistant)
+				require.Len(t, result[0].OfAssistant.ToolCalls, 1)
+				assert.Equal(t, "call_123", result[0].OfAssistant.ToolCalls[0].OfFunction.ID)
+				assert.Equal(t, "search", result[0].OfAssistant.ToolCalls[0].OfFunction.Function.Name)
+				assert.Equal(t, `{"query":"test"}`, result[0].OfAssistant.ToolCalls[0].OfFunction.Function.Arguments)
+			},
+		},
+		{
+			name: "tool use with invalid JSON",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "assistant",
+						ContentBlocks: []model.ContentBlock{
+							{
+								Type:  "tool_use",
+								Id:    "call_123",
+								Name:  "search",
+								Input: json.RawMessage(`{invalid`),
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				// Invalid JSON should be skipped
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfAssistant)
+				assert.Empty(t, result[0].OfAssistant.ToolCalls)
+			},
+		},
+		{
+			name: "tool result with success",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{
+								Type: "tool_result",
+								ToolResult: &model.ToolResult{
+									ToolUseId: "call_123",
+									IsError:   false,
+									Content: []model.ToolResultContent{
+										{Json: map[string]any{"result": "success"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfTool)
+				assert.Equal(t, "call_123", result[0].OfTool.ToolCallID)
+				assert.Contains(t, result[0].OfTool.Content.OfString.Value, "result")
+			},
+		},
+		{
+			name: "tool result with error",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{
+								Type: "tool_result",
+								ToolResult: &model.ToolResult{
+									ToolUseId: "call_123",
+									IsError:   true,
+									Content: []model.ToolResultContent{
+										{Text: "Tool execution failed"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfTool)
+				assert.Equal(t, "call_123", result[0].OfTool.ToolCallID)
+				assert.Contains(t, result[0].OfTool.Content.OfString.Value, "error")
+			},
+		},
+		{
+			name: "tool result with empty content array",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{
+								Type: "tool_result",
+								ToolResult: &model.ToolResult{
+									ToolUseId: "call_123",
+									IsError:   false,
+									Content:   []model.ToolResultContent{},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				// Empty content should result in no tool message
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "message with nbsp only (filtered out)",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "&nbsp;"},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				// &nbsp; only messages are filtered out
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "message with nbsp and tool use (nbsp filtered, tool preserved)",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "assistant",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "&nbsp;"},
+							{
+								Type:  "tool_use",
+								Id:    "call_123",
+								Name:  "search",
+								Input: json.RawMessage(`{"query":"test"}`),
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfAssistant)
+				// Content should be empty (nbsp filtered)
+				assert.Empty(t, result[0].OfAssistant.Content.OfString.Value)
+				// Tool call should be present
+				require.Len(t, result[0].OfAssistant.ToolCalls, 1)
+				assert.Equal(t, "call_123", result[0].OfAssistant.ToolCalls[0].OfFunction.ID)
+			},
+		},
+		{
+			name: "mixed content with text and tool use",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "assistant",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Let me search for that."},
+							{
+								Type:  "tool_use",
+								Id:    "call_123",
+								Name:  "search",
+								Input: json.RawMessage(`{"query":"test"}`),
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfAssistant)
+				assert.Equal(t, "Let me search for that.", result[0].OfAssistant.Content.OfString.Value)
+				require.Len(t, result[0].OfAssistant.ToolCalls, 1)
+				assert.Equal(t, "call_123", result[0].OfAssistant.ToolCalls[0].OfFunction.ID)
+			},
+		},
+		{
+			name: "empty string content (filtered out)",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: ""},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "multiple tool uses in single message",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						Role: "assistant",
+						ContentBlocks: []model.ContentBlock{
+							{
+								Type:  "tool_use",
+								Id:    "call_1",
+								Name:  "search",
+								Input: json.RawMessage(`{"query":"first"}`),
+							},
+							{
+								Type:  "tool_use",
+								Id:    "call_2",
+								Name:  "calculate",
+								Input: json.RawMessage(`{"expression":"1+1"}`),
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result []openai.ChatCompletionMessageParamUnion) {
+				require.Len(t, result, 1)
+				require.NotNil(t, result[0].OfAssistant)
+				require.Len(t, result[0].OfAssistant.ToolCalls, 2)
+				assert.Equal(t, "call_1", result[0].OfAssistant.ToolCalls[0].OfFunction.ID)
+				assert.Equal(t, "search", result[0].OfAssistant.ToolCalls[0].OfFunction.Function.Name)
+				assert.Equal(t, "call_2", result[0].OfAssistant.ToolCalls[1].OfFunction.ID)
+				assert.Equal(t, "calculate", result[0].OfAssistant.ToolCalls[1].OfFunction.Function.Name)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertHistoryToChatCompletions(logger, tt.req)
+			tt.validate(t, result)
+		})
+	}
+}
+
+func TestConvertToolConfigToChatCompletions(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *model.ChatRequest
+		wantNil   bool
+		wantCount int
+	}{
+		{
+			name: "nil tool config returns nil",
+			req: &model.ChatRequest{
+				ToolConfig: nil,
+			},
+			wantNil: true,
+		},
+		{
+			name: "invalid JSON in tool config returns nil",
+			req: &model.ChatRequest{
+				ToolConfig: json.RawMessage(`{invalid`),
+			},
+			wantNil: true,
+		},
+		{
+			name: "empty tools list returns nil",
+			req: &model.ChatRequest{
+				ToolConfig: mustMarshal(model.ToolConfig{
+					Tools: []*model.ToolSpec{},
+				}),
+			},
+			wantNil: true,
+		},
+		{
+			name: "single tool with schema",
+			req: &model.ChatRequest{
+				ToolConfig: mustMarshal(model.ToolConfig{
+					Tools: []*model.ToolSpec{
+						{
+							Spec: model.ToolDefinition{
+								Name: "search",
+								InputSchema: model.JSONSchema{
+									Json: &model.ToolSchema{Type: "object"},
+								},
+							},
+						},
+					},
+				}),
+			},
+			wantNil:   false,
+			wantCount: 1,
+		},
+		{
+			name: "multiple tools",
+			req: &model.ChatRequest{
+				ToolConfig: mustMarshal(model.ToolConfig{
+					Tools: []*model.ToolSpec{
+						{
+							Spec: model.ToolDefinition{
+								Name: "search",
+								InputSchema: model.JSONSchema{
+									Json: &model.ToolSchema{Type: "object"},
+								},
+							},
+						},
+						{
+							Spec: model.ToolDefinition{
+								Name: "calculate",
+								InputSchema: model.JSONSchema{
+									Json: &model.ToolSchema{Type: "object"},
+								},
+							},
+						},
+					},
+				}),
+			},
+			wantNil:   false,
+			wantCount: 2,
+		},
+		{
+			name: "tool with empty InputSchema (skipped)",
+			req: &model.ChatRequest{
+				ToolConfig: mustMarshal(model.ToolConfig{
+					Tools: []*model.ToolSpec{
+						{
+							Spec: model.ToolDefinition{
+								Name:        "invalid_tool",
+								InputSchema: model.JSONSchema{},
+							},
+						},
+					},
+				}),
+			},
+			wantNil: true,
+		},
+		{
+			name: "tool with description",
+			req: &model.ChatRequest{
+				ToolConfig: mustMarshal(model.ToolConfig{
+					Tools: []*model.ToolSpec{
+						{
+							Spec: model.ToolDefinition{
+								Name:        "search",
+								Description: "Search for information",
+								InputSchema: model.JSONSchema{
+									Json: &model.ToolSchema{Type: "object"},
+								},
+							},
+						},
+					},
+				}),
+			},
+			wantNil:   false,
+			wantCount: 1,
+		},
+		{
+			name: "tool without description",
+			req: &model.ChatRequest{
+				ToolConfig: mustMarshal(model.ToolConfig{
+					Tools: []*model.ToolSpec{
+						{
+							Spec: model.ToolDefinition{
+								Name: "search",
+								InputSchema: model.JSONSchema{
+									Json: &model.ToolSchema{Type: "object"},
+								},
+							},
+						},
+					},
+				}),
+			},
+			wantNil:   false,
+			wantCount: 1,
+		},
+		{
+			name: "mix of valid and invalid tools - only valid returned",
+			req: &model.ChatRequest{
+				ToolConfig: mustMarshal(model.ToolConfig{
+					Tools: []*model.ToolSpec{
+						{
+							Spec: model.ToolDefinition{
+								Name:        "valid_tool",
+								InputSchema: model.JSONSchema{Json: &model.ToolSchema{Type: "object"}},
+							},
+						},
+						{
+							Spec: model.ToolDefinition{
+								Name:        "invalid_tool",
+								InputSchema: model.JSONSchema{}, // Empty schema
+							},
+						},
+					},
+				}),
+			},
+			wantNil:   false,
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertToolConfigToChatCompletions(tt.req)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Len(t, result, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestOpenAIChatAdapter_SendMessage(t *testing.T) {
+	tests := []struct {
+		name             string
+		req              *model.ChatRequest
+		mockResponse     *openai.ChatCompletion
+		mockError        error
+		validate         func(*testing.T, *model.Message, error)
+	}{
+		{
+			name: "success with text response",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Hello"},
+						},
+					},
+				},
+				System: "You are a helpful assistant",
+			},
+			mockResponse: createMockChatCompletion(
+				"Hello! How can I help you today?",
+				nil,
+				createChatCompletionUsage(10, 15),
+				"stop",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				assert.Equal(t, "assistant", message.Role)
+				require.Len(t, message.ContentBlocks, 1)
+				assert.Equal(t, "text", message.ContentBlocks[0].Type)
+				assert.Equal(t, "Hello! How can I help you today?", message.ContentBlocks[0].Text)
+				assert.Equal(t, 10, message.Usage.InputTokens)
+				assert.Equal(t, 15, message.Usage.OutputTokens)
+				assert.Equal(t, "end_turn", *message.StopReason)
+			},
+		},
+		{
+			name: "success with function call response",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Search for cats"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"",
+				[]openai.ChatCompletionMessageToolCallUnion{
+					createMockToolCall("call_123", "search", `{"query":"cats"}`),
+				},
+				createChatCompletionUsage(12, 8),
+				"tool_calls",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				require.Len(t, message.ContentBlocks, 1)
+				assert.Equal(t, "tool_use", message.ContentBlocks[0].Type)
+				assert.Equal(t, "call_123", message.ContentBlocks[0].Id)
+				assert.Equal(t, "search", message.ContentBlocks[0].Name)
+				assert.JSONEq(t, `{"query":"cats"}`, string(message.ContentBlocks[0].Input))
+				assert.Equal(t, "tool_calls", *message.StopReason)
+			},
+		},
+		{
+			name: "mixed content with text and function call",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Search for something"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"Let me search for that.",
+				[]openai.ChatCompletionMessageToolCallUnion{
+					createMockToolCall("call_456", "search", `{"query":"something"}`),
+				},
+				createChatCompletionUsage(15, 20),
+				"tool_calls",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				require.Len(t, message.ContentBlocks, 2)
+				assert.Equal(t, "text", message.ContentBlocks[0].Type)
+				assert.Equal(t, "Let me search for that.", message.ContentBlocks[0].Text)
+				assert.Equal(t, "tool_use", message.ContentBlocks[1].Type)
+				assert.Equal(t, "call_456", message.ContentBlocks[1].Id)
+			},
+		},
+		{
+			name: "multiple function calls",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Do multiple things"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"",
+				[]openai.ChatCompletionMessageToolCallUnion{
+					createMockToolCall("call_1", "search", `{"query":"first"}`),
+					createMockToolCall("call_2", "calculate", `{"expression":"1+1"}`),
+				},
+				createChatCompletionUsage(20, 10),
+				"tool_calls",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				require.Len(t, message.ContentBlocks, 2)
+				assert.Equal(t, "tool_use", message.ContentBlocks[0].Type)
+				assert.Equal(t, "call_1", message.ContentBlocks[0].Id)
+				assert.Equal(t, "tool_use", message.ContentBlocks[1].Type)
+				assert.Equal(t, "call_2", message.ContentBlocks[1].Id)
+			},
+		},
+		{
+			name: "response with system prompt append",
+			req: &model.ChatRequest{
+				Model:        "gpt-4",
+				System:       "You are helpful.",
+				SystemAppend: "Be concise.",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"Response",
+				nil,
+				createChatCompletionUsage(20, 5),
+				"stop",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+			},
+		},
+		{
+			name: "empty system prompt",
+			req: &model.ChatRequest{
+				Model:  "gpt-4",
+				System: "",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"Response",
+				nil,
+				createChatCompletionUsage(10, 5),
+				"stop",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+			},
+		},
+		{
+			name: "empty response with no content",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"",
+				nil,
+				createChatCompletionUsage(10, 0),
+				"stop",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				assert.Empty(t, message.ContentBlocks)
+			},
+		},
+		{
+			name: "response with very large usage numbers",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"Response",
+				nil,
+				createChatCompletionUsage(1000000, 2000000),
+				"stop",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				assert.Equal(t, 1000000, message.Usage.InputTokens)
+				assert.Equal(t, 2000000, message.Usage.OutputTokens)
+			},
+		},
+		{
+			name: "finish reason length preserved",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"Response",
+				nil,
+				createChatCompletionUsage(10, 5),
+				"length",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				assert.Equal(t, "length", *message.StopReason)
+			},
+		},
+		{
+			name: "API error",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockError: errors.New("API error"),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, message)
+				assert.Contains(t, err.Error(), "API error")
+			},
+		},
+		{
+			name: "empty choices array returns error",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockResponse: &openai.ChatCompletion{
+				ID:      "test123",
+				Choices: []openai.ChatCompletionChoice{},
+				Usage:   createChatCompletionUsage(10, 5),
+			},
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, message)
+				assert.Contains(t, err.Error(), "no choices")
+			},
+		},
+		{
+			name: "message ID is preserved",
+			req: &model.ChatRequest{
+				Model: "gpt-4",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			},
+			mockResponse: createMockChatCompletion(
+				"Response",
+				nil,
+				createChatCompletionUsage(10, 5),
+				"stop",
+			),
+			validate: func(t *testing.T, message *model.Message, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, message)
+				assert.Equal(t, "chatcmpl_test123", message.Id)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockOpenAIClient{
+				chatCompletionsNewFunc: func(ctx context.Context, params openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
+					if tt.mockError != nil {
+						return nil, tt.mockError
+					}
+					return tt.mockResponse, nil
+				},
+			}
+
+			srv := server.NewFakeUnauthorizedServer()
+			adapter := &OpenAIChatAdapter{
+				client: mockClient,
+				srv:    srv,
+				IOManager: &detections.ResourceManager{
+					Config: srv.Config,
+				},
+			}
+
+			ctx := context.Background()
+			message, err := adapter.SendMessage(ctx, tt.req)
+
+			tt.validate(t, message, err)
+		})
+	}
+}
+
+func TestOpenAIChatAdapter_SendMessageStream(t *testing.T) {
+	tests := []struct {
+		name             string
+		chunks           []openai.ChatCompletionChunk
+		finalUsage       openai.CompletionUsage
+		initialStreamErr error
+		expectedStatus   int
+		expectError      bool
+		expectedEvents   []expectedSSEEvent
+	}{
+		{
+			name: "simple text response",
+			chunks: []openai.ChatCompletionChunk{
+				newChatTextDelta("Hello, world!"),
+			},
+			finalUsage:     createChatCompletionUsage(10, 5),
+			expectedStatus: 200,
+			expectedEvents: []expectedSSEEvent{
+				{
+					eventType: "message_start",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						msg := e["message"].(map[string]interface{})
+						assert.Equal(t, "gpt-4o", msg["model"])
+					},
+				},
+				{
+					eventType: "content_block_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						delta := e["delta"].(map[string]interface{})
+						assert.Equal(t, "text_delta", delta["type"])
+						assert.Equal(t, "Hello, world!", delta["text"])
+					},
+				},
+				{eventType: "content_block_stop"},
+				{eventType: "message_delta"}, // stop_reason
+				{eventType: "message_delta"}, // usage
+				{eventType: "message_stop"},
+				{eventType: "[DONE]"},
+			},
+		},
+		{
+			name: "multiple text deltas",
+			chunks: []openai.ChatCompletionChunk{
+				newChatTextDelta("Hello"),
+				newChatTextDelta(", "),
+				newChatTextDelta("world!"),
+			},
+			finalUsage:     createChatCompletionUsage(10, 5),
+			expectedStatus: 200,
+			expectedEvents: []expectedSSEEvent{
+				{eventType: "message_start"},
+				{
+					eventType: "content_block_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						delta := e["delta"].(map[string]interface{})
+						assert.Equal(t, "Hello", delta["text"])
+					},
+				},
+				{
+					eventType: "content_block_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						delta := e["delta"].(map[string]interface{})
+						assert.Equal(t, ", ", delta["text"])
+					},
+				},
+				{
+					eventType: "content_block_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						delta := e["delta"].(map[string]interface{})
+						assert.Equal(t, "world!", delta["text"])
+					},
+				},
+				{eventType: "content_block_stop"},
+				{eventType: "message_delta"},
+				{eventType: "message_delta"},
+				{eventType: "message_stop"},
+				{eventType: "[DONE]"},
+			},
+		},
+		{
+			name: "function call streaming",
+			chunks: []openai.ChatCompletionChunk{
+				newChatToolCallStartDelta(0, "call_123", "search"),
+				newChatToolCallArgumentsDelta(0, `{"query":`),
+				newChatToolCallArgumentsDelta(0, `"cats"}`),
+			},
+			finalUsage:     createChatCompletionUsage(12, 8),
+			expectedStatus: 200,
+			expectedEvents: []expectedSSEEvent{
+				{eventType: "message_start"},
+				{
+					eventType: "content_block_start",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						block := e["content_block"].(map[string]interface{})
+						assert.Equal(t, "tool_use", block["type"])
+						assert.Equal(t, "call_123", block["id"])
+						assert.Equal(t, "search", block["name"])
+					},
+				},
+				{
+					eventType: "content_block_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						delta := e["delta"].(map[string]interface{})
+						assert.Equal(t, "input_json_delta", delta["type"])
+					},
+				},
+				{
+					eventType: "content_block_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						delta := e["delta"].(map[string]interface{})
+						assert.Equal(t, "input_json_delta", delta["type"])
+					},
+				},
+				{eventType: "content_block_stop"},
+				{eventType: "message_delta"},
+				{eventType: "message_delta"},
+				{eventType: "message_stop"},
+				{eventType: "[DONE]"},
+			},
+		},
+		{
+			name:             "initial stream error",
+			initialStreamErr: errors.New("stream connection failed"),
+			expectedStatus:   500,
+			expectError:      true,
+		},
+		{
+			name: "finish reason stop mapped to end_turn",
+			chunks: []openai.ChatCompletionChunk{
+				newChatTextDelta("Response"),
+				newChatFinishReasonChunk("stop"),
+			},
+			finalUsage:     createChatCompletionUsage(10, 5),
+			expectedStatus: 200,
+			expectedEvents: []expectedSSEEvent{
+				{eventType: "message_start"},
+				{eventType: "content_block_delta"},
+				{eventType: "content_block_stop"},
+				{
+					eventType: "message_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						delta := e["delta"].(map[string]interface{})
+						assert.Equal(t, "end_turn", delta["stop_reason"])
+					},
+				},
+				{eventType: "message_delta"}, // usage
+				{eventType: "message_stop"},
+				{eventType: "[DONE]"},
+			},
+		},
+		{
+			name: "usage in final chunk",
+			chunks: []openai.ChatCompletionChunk{
+				newChatTextDelta("Text"),
+			},
+			finalUsage:     createChatCompletionUsage(100, 200),
+			expectedStatus: 200,
+			expectedEvents: []expectedSSEEvent{
+				{eventType: "message_start"},
+				{eventType: "content_block_delta"},
+				{eventType: "content_block_stop"},
+				{eventType: "message_delta"}, // stop_reason
+				{
+					eventType: "message_delta",
+					validate: func(t *testing.T, e map[string]interface{}) {
+						usage := e["usage"].(map[string]interface{})
+						assert.Equal(t, float64(100), usage["input_tokens"])
+						assert.Equal(t, float64(200), usage["output_tokens"])
+					},
+				},
+				{eventType: "message_stop"},
+				{eventType: "[DONE]"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockOpenAIClient{
+				chatCompletionsNewStreamingFunc: func(ctx context.Context, params openai.ChatCompletionNewParams) ChatCompletionStream {
+					return newMockChatCompletionStream(tt.chunks, tt.finalUsage, tt.initialStreamErr)
+				},
+			}
+
+			srv := server.NewFakeUnauthorizedServer()
+			adapter := &OpenAIChatAdapter{
+				client: mockClient,
+				srv:    srv,
+				IOManager: &detections.ResourceManager{
+					Config: srv.Config,
+				},
+			}
+
+			req := &model.ChatRequest{
+				Model: "gpt-4o",
+				Messages: []*model.Message{
+					{
+						Role: "user",
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Test"},
+						},
+					},
+				},
+			}
+
+			ctx := context.Background()
+			resp, _, err := adapter.SendMessageStream(ctx, req)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			if len(tt.expectedEvents) > 0 {
+				body := readResponseBody(t, resp)
+				events := parseSSEEvents(body)
+
+				require.Len(t, events, len(tt.expectedEvents), "number of SSE events should match")
+
+				for i, expected := range tt.expectedEvents {
+					event := validateSSEEventType(t, events[i], expected.eventType)
+					if expected.validate != nil && event != nil {
+						expected.validate(t, event)
+					}
+				}
+			}
+		})
+	}
+}

--- a/server/modules/assistant/openai_client.go
+++ b/server/modules/assistant/openai_client.go
@@ -28,6 +28,19 @@ type ResponseStream interface {
 	Err() error
 }
 
+// ChatCompletionStream is an interface that wraps the ChatCompletion streaming functionality.
+// This allows us to mock ChatCompletion streaming responses for testing.
+type ChatCompletionStream interface {
+	// Next advances to the next event. Returns false when done or on error.
+	Next() bool
+
+	// Current returns the current event after a successful Next() call.
+	Current() openai.ChatCompletionChunk
+
+	// Err returns any error that occurred during streaming.
+	Err() error
+}
+
 // OpenAIClient is an interface that wraps the openai.Client functionality we use.
 // This allows us to mock the OpenAI client for testing.
 type OpenAIClient interface {
@@ -39,6 +52,12 @@ type OpenAIClient interface {
 
 	// ResponsesNewStreaming wraps the Responses.NewStreaming method for streaming calls
 	ResponsesNewStreaming(ctx context.Context, params responses.ResponseNewParams) ResponseStream
+
+	// ChatCompletionsNew wraps the Chat.Completions.New method for non-streaming calls
+	ChatCompletionsNew(ctx context.Context, params openai.ChatCompletionNewParams) (*openai.ChatCompletion, error)
+
+	// ChatCompletionsNewStreaming wraps the Chat.Completions.NewStreaming method for streaming calls
+	ChatCompletionsNewStreaming(ctx context.Context, params openai.ChatCompletionNewParams) ChatCompletionStream
 }
 
 //go:generate mockgen -source=openai_client.go -destination=mock/mock_openai_client.go -package=mock
@@ -84,4 +103,32 @@ func (r *realOpenAIClient) ResponsesNew(ctx context.Context, params responses.Re
 func (r *realOpenAIClient) ResponsesNewStreaming(ctx context.Context, params responses.ResponseNewParams) ResponseStream {
 	stream := r.client.Responses.NewStreaming(ctx, params)
 	return &realResponseStream{stream: stream}
+}
+
+// ChatCompletionsNew wraps the client.Chat.Completions.New call.
+func (r *realOpenAIClient) ChatCompletionsNew(ctx context.Context, params openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
+	return r.client.Chat.Completions.New(ctx, params)
+}
+
+// ChatCompletionsNewStreaming wraps the client.Chat.Completions.NewStreaming call.
+func (r *realOpenAIClient) ChatCompletionsNewStreaming(ctx context.Context, params openai.ChatCompletionNewParams) ChatCompletionStream {
+	stream := r.client.Chat.Completions.NewStreaming(ctx, params)
+	return &realChatCompletionStream{stream: stream}
+}
+
+// realChatCompletionStream wraps a concrete ssestream.Stream to implement ChatCompletionStream interface
+type realChatCompletionStream struct {
+	stream *ssestream.Stream[openai.ChatCompletionChunk]
+}
+
+func (r *realChatCompletionStream) Next() bool {
+	return r.stream.Next()
+}
+
+func (r *realChatCompletionStream) Current() openai.ChatCompletionChunk {
+	return r.stream.Current()
+}
+
+func (r *realChatCompletionStream) Err() error {
+	return r.stream.Err()
 }

--- a/server/modules/assistant/openai_responses_adapter.go
+++ b/server/modules/assistant/openai_responses_adapter.go
@@ -23,17 +23,17 @@ import (
 )
 
 func init() {
-	protocols[(&OpenAIAdapter{}).Protocol()] = NewOpenAIAdapter
+	protocols[(&OpenAIResponsesAdapter{}).Protocol()] = NewOpenAIResponsesAdapter
 }
 
-type OpenAIAdapter struct {
+type OpenAIResponsesAdapter struct {
 	srv                  *server.Server
 	client               OpenAIClient
 	healthTimeoutSeconds int
 	detections.IOManager
 }
 
-func NewOpenAIAdapter(ctx context.Context, srv *server.Server, config map[string]any) (server.AssistantAdapter, error) {
+func NewOpenAIResponsesAdapter(ctx context.Context, srv *server.Server, config map[string]any) (server.AssistantAdapter, error) {
 	baseUrl := module.GetStringDefault(config, "baseUrl", "")
 	if baseUrl == "" {
 		return nil, fmt.Errorf("openai adapter requires baseUrl in config")
@@ -50,7 +50,7 @@ func NewOpenAIAdapter(ctx context.Context, srv *server.Server, config map[string
 
 	healthTimeoutSeconds := module.GetIntDefault(config, "healthTimeoutSeconds", DEFAULT_HEALTH_TIMEOUT_SECONDS)
 
-	return &OpenAIAdapter{
+	return &OpenAIResponsesAdapter{
 		srv:                  srv,
 		healthTimeoutSeconds: healthTimeoutSeconds,
 		client:               NewOpenAIClientWrapper(openai.NewClient(opts...)),
@@ -60,11 +60,11 @@ func NewOpenAIAdapter(ctx context.Context, srv *server.Server, config map[string
 	}, nil
 }
 
-func (a *OpenAIAdapter) Protocol() string {
-	return "openai"
+func (a *OpenAIResponsesAdapter) Protocol() string {
+	return "openai_responses"
 }
 
-func (a *OpenAIAdapter) SendMessage(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
+func (a *OpenAIResponsesAdapter) SendMessage(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
 	logger := log.FromContext(ctx)
 
 	// Convert history and tools (reuse existing functions)
@@ -153,7 +153,7 @@ func (a *OpenAIAdapter) SendMessage(ctx context.Context, req *model.ChatRequest)
 	return message, nil
 }
 
-func (a *OpenAIAdapter) SendMessageStream(ctx context.Context, req *model.ChatRequest) (response *http.Response, _ *model.AuxMessageData, err error) {
+func (a *OpenAIResponsesAdapter) SendMessageStream(ctx context.Context, req *model.ChatRequest) (response *http.Response, _ *model.AuxMessageData, err error) {
 	logger := log.FromContext(ctx)
 
 	history := convertHistoryToOpenAI(logger, req)
@@ -341,13 +341,13 @@ func convertHistoryToOpenAI(logger log.Interface, req *model.ChatRequest) respon
 	return result
 }
 
-func (a *OpenAIAdapter) GetBalance(ctx context.Context) (*model.BalanceResponse, error) {
+func (a *OpenAIResponsesAdapter) GetBalance(ctx context.Context) (*model.BalanceResponse, error) {
 	return &model.BalanceResponse{
 		Balance: UNUSED_BALANCE,
 	}, nil
 }
 
-func (a *OpenAIAdapter) GetHealth(ctx context.Context) (*model.HealthResponse, error) {
+func (a *OpenAIResponsesAdapter) GetHealth(ctx context.Context) (*model.HealthResponse, error) {
 	healthCtx, cancel := context.WithTimeout(a.srv.Context, time.Second*time.Duration(a.healthTimeoutSeconds))
 	defer cancel()
 

--- a/server/modules/assistant/openai_responses_adapter_test.go
+++ b/server/modules/assistant/openai_responses_adapter_test.go
@@ -29,9 +29,11 @@ import (
 // Test doubles to avoid import cycles
 
 type mockOpenAIClient struct {
-	modelsListFunc            func(ctx context.Context) (*pagination.Page[openai.Model], error)
-	responsesNewFunc          func(ctx context.Context, params responses.ResponseNewParams) (*responses.Response, error)
-	responsesNewStreamingFunc func(ctx context.Context, params responses.ResponseNewParams) ResponseStream
+	modelsListFunc                  func(ctx context.Context) (*pagination.Page[openai.Model], error)
+	responsesNewFunc                func(ctx context.Context, params responses.ResponseNewParams) (*responses.Response, error)
+	responsesNewStreamingFunc       func(ctx context.Context, params responses.ResponseNewParams) ResponseStream
+	chatCompletionsNewFunc          func(ctx context.Context, params openai.ChatCompletionNewParams) (*openai.ChatCompletion, error)
+	chatCompletionsNewStreamingFunc func(ctx context.Context, params openai.ChatCompletionNewParams) ChatCompletionStream
 }
 
 func (m *mockOpenAIClient) ModelsList(ctx context.Context) (*pagination.Page[openai.Model], error) {
@@ -51,6 +53,20 @@ func (m *mockOpenAIClient) ResponsesNew(ctx context.Context, params responses.Re
 func (m *mockOpenAIClient) ResponsesNewStreaming(ctx context.Context, params responses.ResponseNewParams) ResponseStream {
 	if m.responsesNewStreamingFunc != nil {
 		return m.responsesNewStreamingFunc(ctx, params)
+	}
+	return nil
+}
+
+func (m *mockOpenAIClient) ChatCompletionsNew(ctx context.Context, params openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
+	if m.chatCompletionsNewFunc != nil {
+		return m.chatCompletionsNewFunc(ctx, params)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockOpenAIClient) ChatCompletionsNewStreaming(ctx context.Context, params openai.ChatCompletionNewParams) ChatCompletionStream {
+	if m.chatCompletionsNewStreamingFunc != nil {
+		return m.chatCompletionsNewStreamingFunc(ctx, params)
 	}
 	return nil
 }
@@ -84,6 +100,35 @@ func (m *mockResponseStream) Err() error {
 	return m.err
 }
 
+// mockChatCompletionStream is a simple implementation of ChatCompletionStream for testing
+type mockChatCompletionStream struct {
+	chunks       []openai.ChatCompletionChunk
+	currentIndex int
+	err          error
+}
+
+func (m *mockChatCompletionStream) Next() bool {
+	if m.err != nil {
+		return false
+	}
+	if m.currentIndex >= len(m.chunks) {
+		return false
+	}
+	m.currentIndex++
+	return true
+}
+
+func (m *mockChatCompletionStream) Current() openai.ChatCompletionChunk {
+	if m.currentIndex == 0 || m.currentIndex > len(m.chunks) {
+		return openai.ChatCompletionChunk{}
+	}
+	return m.chunks[m.currentIndex-1]
+}
+
+func (m *mockChatCompletionStream) Err() error {
+	return m.err
+}
+
 // newMockStream creates a mock stream for testing
 func newMockStream(events []responses.ResponseStreamEventUnion, finalUsage responses.ResponseUsage, initialErr error) ResponseStream {
 	// Add a final event with Response.Usage for finalization
@@ -100,6 +145,23 @@ func newMockStream(events []responses.ResponseStreamEventUnion, finalUsage respo
 
 	return &mockResponseStream{
 		events: events,
+		err:    initialErr,
+	}
+}
+
+// newMockChatCompletionStream creates a mock ChatCompletion stream for testing
+func newMockChatCompletionStream(chunks []openai.ChatCompletionChunk, finalUsage openai.CompletionUsage, initialErr error) ChatCompletionStream {
+	// Add a final chunk with usage for finalization
+	// This mimics how the real stream provides usage data at the end
+	if initialErr == nil {
+		finalChunk := openai.ChatCompletionChunk{
+			Usage: finalUsage,
+		}
+		chunks = append(chunks, finalChunk)
+	}
+
+	return &mockChatCompletionStream{
+		chunks: chunks,
 		err:    initialErr,
 	}
 }
@@ -153,7 +215,7 @@ func TestNewOpenAIAdapter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := server.NewFakeUnauthorizedServer()
-			adapter, err := NewOpenAIAdapter(context.Background(), srv, tt.config)
+			adapter, err := NewOpenAIResponsesAdapter(context.Background(), srv, tt.config)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -166,7 +228,7 @@ func TestNewOpenAIAdapter(t *testing.T) {
 				assert.NotNil(t, adapter)
 
 				if tt.validateHealthTimeout {
-					openaiAdapter := adapter.(*OpenAIAdapter)
+					openaiAdapter := adapter.(*OpenAIResponsesAdapter)
 					assert.Equal(t, tt.expectedHealthTimeout, openaiAdapter.healthTimeoutSeconds)
 				}
 			}
@@ -175,12 +237,12 @@ func TestNewOpenAIAdapter(t *testing.T) {
 }
 
 func TestProtocol(t *testing.T) {
-	adapter := &OpenAIAdapter{}
-	assert.Equal(t, "openai", adapter.Protocol())
+	adapter := &OpenAIResponsesAdapter{}
+	assert.Equal(t, "openai_responses", adapter.Protocol())
 }
 
 func TestGetBalance(t *testing.T) {
-	adapter := &OpenAIAdapter{}
+	adapter := &OpenAIResponsesAdapter{}
 	ctx := context.Background()
 
 	balance, err := adapter.GetBalance(ctx)
@@ -1065,7 +1127,7 @@ func TestGetHealth(t *testing.T) {
 	// in external packages that don't have import cycle constraints.
 
 	srv := server.NewFakeUnauthorizedServer()
-	adapter, err := NewOpenAIAdapter(context.Background(), srv, map[string]any{
+	adapter, err := NewOpenAIResponsesAdapter(context.Background(), srv, map[string]any{
 		"baseUrl": "https://api.openai.com/v1",
 		"apiKey":  "test-key",
 	})
@@ -1498,7 +1560,7 @@ func TestOpenAIAdapter_SendMessage(t *testing.T) {
 			}
 
 			srv := server.NewFakeUnauthorizedServer()
-			adapter := &OpenAIAdapter{
+			adapter := &OpenAIResponsesAdapter{
 				srv:    srv,
 				client: mockClient,
 				IOManager: &detections.ResourceManager{
@@ -1755,7 +1817,7 @@ func TestOpenAIAdapter_SendMessage_EdgeCases(t *testing.T) {
 			}
 
 			srv := server.NewFakeUnauthorizedServer()
-			adapter := &OpenAIAdapter{
+			adapter := &OpenAIResponsesAdapter{
 				srv:    srv,
 				client: mockClient,
 				IOManager: &detections.ResourceManager{
@@ -1909,7 +1971,7 @@ func TestOpenAIAdapter_SendMessageStream(t *testing.T) {
 			}
 
 			srv := server.NewFakeUnauthorizedServer()
-			adapter := &OpenAIAdapter{
+			adapter := &OpenAIResponsesAdapter{
 				client: client,
 				srv:    srv,
 				IOManager: &detections.ResourceManager{

--- a/server/modules/assistant/sse.go
+++ b/server/modules/assistant/sse.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/apex/log"
+	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/responses"
 	"google.golang.org/genai"
 )
@@ -29,7 +30,7 @@ func (w *sseEventWriter) writeMessageStart(model string) error {
 }
 
 func (w *sseEventWriter) writeContentBlockDelta(index int, deltaType string, text string) error {
-	_, err := fmt.Fprintf(w.writer, `data: {"type":"content_block_delta","index":%d,"delta":{"type":%s,"text":%s}}`+"\n\n", index, strconv.Quote(deltaType), text)
+	_, err := fmt.Fprintf(w.writer, `data: {"type":"content_block_delta","index":%d,"delta":{"type":%s,"text":%s}}`+"\n\n", index, strconv.Quote(deltaType), strconv.Quote(text))
 	return err
 }
 
@@ -259,15 +260,13 @@ func (p *streamProcessor) ensureFirstSend() {
 
 // writeThought writes a thought delta
 func (p *streamProcessor) writeThought(thought string) {
-	escapedText := strconv.Quote(thought)
-	p.writer.writeContentBlockDelta(p.contentBlockIndex, "thought_delta", escapedText)
+	p.writer.writeContentBlockDelta(p.contentBlockIndex, "thought_delta", thought)
 	p.hasOpenBlock = true
 }
 
 // writeText writes a text delta
 func (p *streamProcessor) writeText(text string) {
-	escapedText := strconv.Quote(text)
-	p.writer.writeContentBlockDelta(p.contentBlockIndex, "text_delta", escapedText)
+	p.writer.writeContentBlockDelta(p.contentBlockIndex, "text_delta", text)
 	p.hasOpenBlock = true
 }
 
@@ -343,4 +342,103 @@ func (p *streamProcessor) closeOpenBlock() {
 		p.contentBlockIndex++
 		p.hasOpenBlock = false
 	}
+}
+
+// processChatCompletionChunk processes a ChatCompletionChunk and writes appropriate events
+func (p *streamProcessor) processChatCompletionChunk(chunk openai.ChatCompletionChunk) error {
+	if len(chunk.Choices) == 0 {
+		return nil
+	}
+
+	delta := chunk.Choices[0].Delta
+	reasoning := delta.JSON.ExtraFields["reasoning"].Raw()
+
+	if reasoning != "" {
+		p.ensureFirstSend()
+		p.writeThought(reasoning)
+	}
+
+	// Handle text content delta
+	if delta.Content != "" {
+		p.ensureFirstSend()
+		p.writeText(delta.Content)
+	}
+
+	// Handle tool calls
+	if len(delta.ToolCalls) > 0 {
+		for _, toolCall := range delta.ToolCalls {
+			// Check if this is a new tool call (has ID and Name)
+			if toolCall.ID != "" && toolCall.Function.Name != "" {
+				// Close any open text block
+				if p.hasOpenBlock {
+					p.closeOpenBlock()
+				}
+
+				p.writeChatCompletionFunctionHeader(toolCall.ID, toolCall.Function.Name)
+			}
+			if toolCall.Function.Arguments != "" {
+				// This is a delta for function arguments
+				p.writeChatCompletionFunctionInput(toolCall.Function.Arguments)
+			}
+		}
+	}
+
+	return nil
+}
+
+// writeChatCompletionFunctionHeader writes the start of a function call for ChatCompletion streaming
+func (p *streamProcessor) writeChatCompletionFunctionHeader(id string, name string) {
+	p.ensureFirstSend()
+
+	if id == "" {
+		id = fmt.Sprintf("toolu_%d", p.contentBlockIndex)
+	}
+
+	toolUseBlock := map[string]any{
+		"type":  "tool_use",
+		"id":    id,
+		"name":  name,
+		"input": map[string]any{},
+	}
+
+	p.writer.writeContentBlockStart(p.contentBlockIndex, toolUseBlock)
+	p.hasOpenBlock = true
+	p.writingOpenAIToolUse = true
+}
+
+// writeChatCompletionFunctionInput writes function arguments delta for ChatCompletion streaming
+func (p *streamProcessor) writeChatCompletionFunctionInput(arguments string) {
+	p.writer.writeInputJsonDelta(p.contentBlockIndex, arguments)
+}
+
+// writeChatCompletionFunctionStop closes a function call block for ChatCompletion streaming
+func (p *streamProcessor) writeChatCompletionFunctionStop() {
+	p.writer.writeContentBlockStop(p.contentBlockIndex)
+	p.contentBlockIndex++
+	p.hasOpenBlock = false
+	p.writingOpenAIToolUse = false
+}
+
+// finalizeChatCompletion closes any open blocks and writes final events for ChatCompletion streaming
+func (p *streamProcessor) finalizeChatCompletion(finishReason string, usage *openai.CompletionUsage) {
+	if p.hasOpenBlock {
+		if p.writingOpenAIToolUse {
+			p.writeChatCompletionFunctionStop()
+		} else {
+			p.closeOpenBlock()
+		}
+	}
+
+	if finishReason == "" || finishReason == "stop" {
+		finishReason = "end_turn"
+	}
+
+	p.writer.writeStopReason(finishReason)
+
+	if usage != nil && (usage.PromptTokens > 0 || usage.CompletionTokens > 0) {
+		p.writer.writeUsage(usage.PromptTokens, usage.CompletionTokens)
+	}
+
+	p.writer.writeMessageStop()
+	p.writer.writeDone()
 }

--- a/server/modules/assistant/sse_test.go
+++ b/server/modules/assistant/sse_test.go
@@ -37,21 +37,21 @@ func TestSSEEventWriter(t *testing.T) {
 		{
 			name: "writeContentBlockDelta text",
 			writeOp: func(w *sseEventWriter) error {
-				return w.writeContentBlockDelta(0, "text_delta", `"Hello World"`)
+				return w.writeContentBlockDelta(0, "text_delta", "Hello World")
 			},
 			expected: `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello World"}}` + "\n\n",
 		},
 		{
 			name: "writeContentBlockDelta thought",
 			writeOp: func(w *sseEventWriter) error {
-				return w.writeContentBlockDelta(0, "thought_delta", `"Thinking about it"`)
+				return w.writeContentBlockDelta(0, "thought_delta", "Thinking about it")
 			},
 			expected: `data: {"type":"content_block_delta","index":0,"delta":{"type":"thought_delta","text":"Thinking about it"}}` + "\n\n",
 		},
 		{
 			name: "writeContentBlockDelta with newlines",
 			writeOp: func(w *sseEventWriter) error {
-				return w.writeContentBlockDelta(1, "text_delta", `"Line 1\nLine 2\tTabbed"`)
+				return w.writeContentBlockDelta(1, "text_delta", "Line 1\nLine 2\tTabbed")
 			},
 			expected: `data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Line 1\nLine 2\tTabbed"}}` + "\n\n",
 		},
@@ -131,119 +131,146 @@ func TestSSEEventWriter(t *testing.T) {
 		})
 	}
 
-	t.Run("writeContentBlockStart with complex object", func(t *testing.T) {
-		var buf strings.Builder
-		writer := newSSEEventWriter(log.Log, &buf)
+	// Sequence tests - these test multiple operations in sequence with flexible validation
+	sequenceTests := []struct {
+		name          string
+		writeOps      []func(*sseEventWriter) error
+		contains      []string
+		orderedChecks []string
+	}{
+		{
+			name: "writeContentBlockStart with complex object",
+			writeOps: []func(*sseEventWriter) error{
+				func(w *sseEventWriter) error {
+					block := map[string]any{
+						"type":  "tool_use",
+						"id":    "toolu_123",
+						"name":  "search",
+						"input": map[string]any{},
+					}
+					return w.writeContentBlockStart(1, block)
+				},
+			},
+			contains: []string{
+				`"type":"content_block_start"`,
+				`"index":1`,
+				`"type":"tool_use"`,
+				`"id":"toolu_123"`,
+				`"name":"search"`,
+			},
+		},
+		{
+			name: "full message sequence with thought and text",
+			writeOps: []func(*sseEventWriter) error{
+				func(w *sseEventWriter) error { return w.writeMessageStart("gemini-2.0-flash-exp") },
+				func(w *sseEventWriter) error {
+					return w.writeContentBlockDelta(0, "thought_delta", "Let me think about this...")
+				},
+				func(w *sseEventWriter) error {
+					return w.writeContentBlockDelta(0, "thought_delta", " analyzing the request")
+				},
+				func(w *sseEventWriter) error {
+					return w.writeContentBlockDelta(0, "text_delta", "Here is the answer: ")
+				},
+				func(w *sseEventWriter) error { return w.writeContentBlockDelta(0, "text_delta", "42") },
+				func(w *sseEventWriter) error { return w.writeContentBlockStop(0) },
+				func(w *sseEventWriter) error { return w.writeStopReason("end_turn") },
+				func(w *sseEventWriter) error { return w.writeUsage(50, 15) },
+				func(w *sseEventWriter) error { return w.writeMessageStop() },
+				func(w *sseEventWriter) error { return w.writeDone() },
+			},
+			contains: []string{
+				`"type":"message_start"`,
+				`"model":"gemini-2.0-flash-exp"`,
+				`"type":"thought_delta","text":"Let me think about this..."`,
+				`"type":"thought_delta","text":" analyzing the request"`,
+				`"type":"text_delta","text":"Here is the answer: "`,
+				`"type":"text_delta","text":"42"`,
+				`"type":"content_block_stop","index":0`,
+				`"stop_reason":"end_turn"`,
+				`"input_tokens":50,"output_tokens":15`,
+				`"type":"message_stop"`,
+				`data: [DONE]`,
+			},
+			orderedChecks: []string{
+				"thought_delta",
+				"text_delta",
+				"content_block_stop",
+				"[DONE]",
+			},
+		},
+		{
+			name: "full message sequence with function call",
+			writeOps: []func(*sseEventWriter) error{
+				func(w *sseEventWriter) error { return w.writeMessageStart("gemini-2.0-flash-exp") },
+				func(w *sseEventWriter) error {
+					return w.writeContentBlockDelta(0, "text_delta", "I'll search for that.")
+				},
+				func(w *sseEventWriter) error { return w.writeContentBlockStop(0) },
+				func(w *sseEventWriter) error {
+					toolBlock := map[string]any{
+						"type":  "tool_use",
+						"id":    "toolu_abc123",
+						"name":  "web_search",
+						"input": map[string]any{},
+					}
+					return w.writeContentBlockStart(1, toolBlock)
+				},
+				func(w *sseEventWriter) error {
+					return w.writeInputJsonDelta(1, `{"query":"test search"}`)
+				},
+				func(w *sseEventWriter) error { return w.writeContentBlockStop(1) },
+				func(w *sseEventWriter) error { return w.writeStopReason("tool_use") },
+				func(w *sseEventWriter) error { return w.writeUsage(30, 25) },
+				func(w *sseEventWriter) error { return w.writeMessageStop() },
+				func(w *sseEventWriter) error { return w.writeDone() },
+			},
+			contains: []string{
+				`"type":"message_start"`,
+				`"type":"text_delta","text":"I'll search for that."`,
+				`"type":"content_block_stop","index":0`,
+				`"type":"content_block_start"`,
+				`"type":"tool_use"`,
+				`"id":"toolu_abc123"`,
+				`"name":"web_search"`,
+				`"input_json_delta"`,
+				`"type":"content_block_stop","index":1`,
+				`"stop_reason":"tool_use"`,
+				`data: [DONE]`,
+			},
+		},
+	}
 
-		block := map[string]any{
-			"type":  "tool_use",
-			"id":    "toolu_123",
-			"name":  "search",
-			"input": map[string]any{},
-		}
+	for _, tt := range sequenceTests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			writer := newSSEEventWriter(log.Log, &buf)
 
-		err := writer.writeContentBlockStart(1, block)
-		assert.NoError(t, err)
+			// Execute sequence of operations
+			for _, op := range tt.writeOps {
+				err := op(writer)
+				assert.NoError(t, err)
+			}
 
-		result := buf.String()
-		assert.Contains(t, result, `"type":"content_block_start"`)
-		assert.Contains(t, result, `"index":1`)
-		assert.Contains(t, result, `"type":"tool_use"`)
-		assert.Contains(t, result, `"id":"toolu_123"`)
-		assert.Contains(t, result, `"name":"search"`)
-	})
+			result := buf.String()
 
-	t.Run("full message sequence with thought and text", func(t *testing.T) {
-		var buf strings.Builder
-		writer := newSSEEventWriter(log.Log, &buf)
+			// Validate contains
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
 
-		// Write a complete message stream
-		writer.writeMessageStart("gemini-2.0-flash-exp")
-		writer.writeContentBlockDelta(0, "thought_delta", `"Let me think about this..."`)
-		writer.writeContentBlockDelta(0, "thought_delta", `" analyzing the request"`)
-		writer.writeContentBlockDelta(0, "text_delta", `"Here is the answer: "`)
-		writer.writeContentBlockDelta(0, "text_delta", `"42"`)
-		writer.writeContentBlockStop(0)
-		writer.writeStopReason("end_turn")
-		writer.writeUsage(50, 15)
-		writer.writeMessageStop()
-		writer.writeDone()
-
-		result := buf.String()
-
-		// Verify each event is present in order
-		assert.Contains(t, result, `"type":"message_start"`)
-		assert.Contains(t, result, `"model":"gemini-2.0-flash-exp"`)
-
-		// Verify thought deltas
-		assert.Contains(t, result, `"type":"thought_delta","text":"Let me think about this..."`)
-		assert.Contains(t, result, `"type":"thought_delta","text":" analyzing the request"`)
-
-		// Verify text deltas
-		assert.Contains(t, result, `"type":"text_delta","text":"Here is the answer: "`)
-		assert.Contains(t, result, `"type":"text_delta","text":"42"`)
-
-		// Verify closure
-		assert.Contains(t, result, `"type":"content_block_stop","index":0`)
-		assert.Contains(t, result, `"stop_reason":"end_turn"`)
-		assert.Contains(t, result, `"input_tokens":50,"output_tokens":15`)
-		assert.Contains(t, result, `"type":"message_stop"`)
-		assert.Contains(t, result, `data: [DONE]`)
-
-		// Verify sequence order
-		thoughtIndex := strings.Index(result, "thought_delta")
-		textIndex := strings.Index(result, "text_delta")
-		stopIndex := strings.Index(result, "content_block_stop")
-		doneIndex := strings.Index(result, "[DONE]")
-
-		assert.Less(t, thoughtIndex, textIndex, "thought should come before text")
-		assert.Less(t, textIndex, stopIndex, "text should come before stop")
-		assert.Less(t, stopIndex, doneIndex, "stop should come before done")
-	})
-
-	t.Run("full message sequence with function call", func(t *testing.T) {
-		var buf strings.Builder
-		writer := newSSEEventWriter(log.Log, &buf)
-
-		// Write a message with text followed by a function call
-		writer.writeMessageStart("gemini-2.0-flash-exp")
-		writer.writeContentBlockDelta(0, "text_delta", `"I'll search for that."`)
-		writer.writeContentBlockStop(0)
-
-		toolBlock := map[string]any{
-			"type":  "tool_use",
-			"id":    "toolu_abc123",
-			"name":  "web_search",
-			"input": map[string]any{},
-		}
-		writer.writeContentBlockStart(1, toolBlock)
-		writer.writeInputJsonDelta(1, `{"query":"test search"}`)
-		writer.writeContentBlockStop(1)
-
-		writer.writeStopReason("tool_use")
-		writer.writeUsage(30, 25)
-		writer.writeMessageStop()
-		writer.writeDone()
-
-		result := buf.String()
-
-		// Verify message structure
-		assert.Contains(t, result, `"type":"message_start"`)
-		assert.Contains(t, result, `"type":"text_delta","text":"I'll search for that."`)
-		assert.Contains(t, result, `"type":"content_block_stop","index":0`)
-
-		// Verify function call block
-		assert.Contains(t, result, `"type":"content_block_start"`)
-		assert.Contains(t, result, `"type":"tool_use"`)
-		assert.Contains(t, result, `"id":"toolu_abc123"`)
-		assert.Contains(t, result, `"name":"web_search"`)
-		assert.Contains(t, result, `"input_json_delta"`)
-		assert.Contains(t, result, `"type":"content_block_stop","index":1`)
-
-		// Verify closure with tool_use stop reason
-		assert.Contains(t, result, `"stop_reason":"tool_use"`)
-		assert.Contains(t, result, `data: [DONE]`)
-	})
+			// Validate ordering if specified
+			if len(tt.orderedChecks) > 0 {
+				lastIndex := -1
+				for _, expected := range tt.orderedChecks {
+					currentIndex := strings.Index(result, expected)
+					assert.Less(t, lastIndex, currentIndex,
+						fmt.Sprintf("%s should come after previous element", expected))
+					lastIndex = currentIndex
+				}
+			}
+		})
+	}
 }
 
 func TestStreamProcessorFirstSend(t *testing.T) {


### PR DESCRIPTION
The existing openai module has had it's protocol renamed `openai_responses` and the new one uses `openai_chat`.

A new OpenAI module that supports the ChatCompletions endpoint. Supports messaging, tool use, thoughts, and using the embedded prompt. Users should strive to use the Responses endpoint where supported and only fall back to this module when responses is not supported.

Fixed a double quoting issue happening in the SSE writer.