### PR TITLE
baseUrl => apiUrl

### DIFF
--- a/server/modules/assistant/openai_chat_adapter.go
+++ b/server/modules/assistant/openai_chat_adapter.go
@@ -37,13 +37,13 @@ type OpenAIChatAdapter struct {
 }
 
 func NewOpenAIChatAdapter(ctx context.Context, srv *server.Server, config map[string]any) (server.AssistantAdapter, error) {
-	baseUrl := module.GetStringDefault(config, "baseUrl", "")
-	if baseUrl == "" {
-		return nil, fmt.Errorf("openai_chat adapter requires baseUrl in config")
+	apiUrl := module.GetStringDefault(config, "apiUrl", "")
+	if apiUrl == "" {
+		return nil, fmt.Errorf("openai_chat adapter requires apiUrl in config")
 	}
 
 	opts := []option.RequestOption{
-		option.WithBaseURL(baseUrl),
+		option.WithBaseURL(apiUrl),
 	}
 
 	apiKey := module.GetStringDefault(config, "apiKey", "")

--- a/server/modules/assistant/openai_chat_adapter_test.go
+++ b/server/modules/assistant/openai_chat_adapter_test.go
@@ -147,7 +147,7 @@ func TestNewOpenAIChatAdapter(t *testing.T) {
 		{
 			name: "Success with all config values",
 			config: map[string]any{
-				"baseUrl":              "https://api.openai.com/v1",
+				"apiUrl":               "https://api.openai.com/v1",
 				"apiKey":               "test-key",
 				"healthTimeoutSeconds": float64(6),
 			},
@@ -156,24 +156,24 @@ func TestNewOpenAIChatAdapter(t *testing.T) {
 			validateHealthTimeout: true,
 		},
 		{
-			name: "Missing baseUrl returns error",
+			name: "Missing apiUrl returns error",
 			config: map[string]any{
 				"apiKey": "test-key",
 			},
 			expectError:   true,
-			errorContains: "baseUrl",
+			errorContains: "apiUrl",
 		},
 		{
 			name: "Without apiKey succeeds",
 			config: map[string]any{
-				"baseUrl": "https://api.openai.com/v1",
+				"apiUrl": "https://api.openai.com/v1",
 			},
 			expectError: false,
 		},
 		{
 			name: "Default health timeout",
 			config: map[string]any{
-				"baseUrl": "https://api.openai.com/v1",
+				"apiUrl": "https://api.openai.com/v1",
 			},
 			expectError:           false,
 			expectedHealthTimeout: DEFAULT_HEALTH_TIMEOUT_SECONDS,
@@ -811,11 +811,11 @@ func TestConvertToolConfigToChatCompletions(t *testing.T) {
 
 func TestOpenAIChatAdapter_SendMessage(t *testing.T) {
 	tests := []struct {
-		name             string
-		req              *model.ChatRequest
-		mockResponse     *openai.ChatCompletion
-		mockError        error
-		validate         func(*testing.T, *model.Message, error)
+		name         string
+		req          *model.ChatRequest
+		mockResponse *openai.ChatCompletion
+		mockError    error
+		validate     func(*testing.T, *model.Message, error)
 	}{
 		{
 			name: "success with text response",

--- a/server/modules/assistant/openai_responses_adapter.go
+++ b/server/modules/assistant/openai_responses_adapter.go
@@ -34,13 +34,13 @@ type OpenAIResponsesAdapter struct {
 }
 
 func NewOpenAIResponsesAdapter(ctx context.Context, srv *server.Server, config map[string]any) (server.AssistantAdapter, error) {
-	baseUrl := module.GetStringDefault(config, "baseUrl", "")
-	if baseUrl == "" {
-		return nil, fmt.Errorf("openai adapter requires baseUrl in config")
+	apiUrl := module.GetStringDefault(config, "apiUrl", "")
+	if apiUrl == "" {
+		return nil, fmt.Errorf("openai adapter requires apiUrl in config")
 	}
 
 	opts := []option.RequestOption{
-		option.WithBaseURL(baseUrl),
+		option.WithBaseURL(apiUrl),
 	}
 
 	apiKey := module.GetStringDefault(config, "apiKey", "")

--- a/server/modules/assistant/openai_responses_adapter_test.go
+++ b/server/modules/assistant/openai_responses_adapter_test.go
@@ -178,7 +178,7 @@ func TestNewOpenAIAdapter(t *testing.T) {
 		{
 			name: "Success with all config values",
 			config: map[string]any{
-				"baseUrl":              "https://api.openai.com/v1",
+				"apiUrl":               "https://api.openai.com/v1",
 				"apiKey":               "test-key",
 				"healthTimeoutSeconds": float64(6),
 			},
@@ -187,24 +187,24 @@ func TestNewOpenAIAdapter(t *testing.T) {
 			validateHealthTimeout: true,
 		},
 		{
-			name: "Missing baseUrl returns error",
+			name: "Missing apiUrl returns error",
 			config: map[string]any{
 				"apiKey": "test-key",
 			},
 			expectError:   true,
-			errorContains: "baseUrl",
+			errorContains: "apiUrl",
 		},
 		{
 			name: "Without apiKey succeeds",
 			config: map[string]any{
-				"baseUrl": "https://api.openai.com/v1",
+				"apiUrl": "https://api.openai.com/v1",
 			},
 			expectError: false,
 		},
 		{
 			name: "Default health timeout",
 			config: map[string]any{
-				"baseUrl": "https://api.openai.com/v1",
+				"apiUrl": "https://api.openai.com/v1",
 			},
 			expectError:           false,
 			expectedHealthTimeout: DEFAULT_HEALTH_TIMEOUT_SECONDS,
@@ -1128,8 +1128,8 @@ func TestGetHealth(t *testing.T) {
 
 	srv := server.NewFakeUnauthorizedServer()
 	adapter, err := NewOpenAIResponsesAdapter(context.Background(), srv, map[string]any{
-		"baseUrl": "https://api.openai.com/v1",
-		"apiKey":  "test-key",
+		"apiUrl": "https://api.openai.com/v1",
+		"apiKey": "test-key",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Config specifies `apiUrl` but code was looking for `baseUrl`. Opted to use the same name that SOAI uses, `apiUrl`. Updated tests