### PR TITLE
Respect UiElements.ForcedType for []{} Settings

### DIFF
--- a/server/modules/salt/saltstore.go
+++ b/server/modules/salt/saltstore.go
@@ -647,6 +647,11 @@ func (store *Saltstore) updateSetting(mapped map[string]interface{}, sections []
 				"forcedType":  setting.ForcedType,
 			}).Info("Forcing setting type")
 			mapped[name], err = store.forceType(value, setting.ForcedType)
+			if err == nil && setting.ForcedType == "[]{}" {
+				if mapList, ok := mapped[name].([]map[string]any); ok {
+					mapped[name], err = store.coerceMapListFieldTypes(mapList, setting.UiElements)
+				}
+			}
 		} else {
 			currentValue := mapped[name]
 			if currentValue == nil && setting.DefaultAvailable {
@@ -734,6 +739,7 @@ func (store *Saltstore) UpdateSetting(ctx context.Context, setting *model.Settin
 			setting.DefaultAvailable = settingDef.DefaultAvailable
 			setting.File = settingDef.File
 			setting.JinjaEscaped = settingDef.JinjaEscaped
+			setting.UiElements = settingDef.UiElements
 		}
 	}
 
@@ -907,6 +913,48 @@ func (store *Saltstore) alignMapList(newValue string) ([]map[string]interface{},
 		}
 	}
 	return newList, nil
+}
+
+func interfaceToString(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10)
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(val)
+	case []any:
+		parts := make([]string, len(val))
+		for i, item := range val {
+			parts[i] = interfaceToString(item)
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func (store *Saltstore) coerceMapListFieldTypes(list []map[string]any, uiElements []model.UiElement) ([]map[string]any, error) {
+	for _, m := range list {
+		for _, uiElement := range uiElements {
+			if uiElement.ForcedType == "" || uiElement.Field == "" {
+				continue
+			}
+			fieldVal, exists := m[uiElement.Field]
+			if !exists {
+				continue
+			}
+			coerced, err := store.forceType(interfaceToString(fieldVal), uiElement.ForcedType)
+			if err != nil {
+				return nil, fmt.Errorf("field %q: %w", uiElement.Field, err)
+			}
+			m[uiElement.Field] = coerced
+		}
+	}
+	return list, nil
 }
 
 func (store *Saltstore) alignBestGuess(newValue string) interface{} {

--- a/server/modules/salt/saltstore_test.go
+++ b/server/modules/salt/saltstore_test.go
@@ -25,7 +25,7 @@ import (
 const TMP_SALTSTACK_PATH = "/tmp/gotest-soc-saltstore"
 const TMP_QUEUE_DIR = "/tmp/gotest-soc-salt-relay-queue"
 const TMP_REQUEST_FILE = "req"
-const TEST_SETTINGS_COUNT = 27
+const TEST_SETTINGS_COUNT = 28
 
 func Cleanup() {
 	exec.Command("rm", "-fr", TMP_SALTSTACK_PATH).Run()
@@ -348,6 +348,13 @@ func TestGetSettings(tester *testing.T) {
 	assert.Equal(tester, "myapp.ui_json", settings[count].Id)
 	assert.Equal(tester, "{\"something\":\"here\",\"another\":\"else\"},{\"something\":\"here2\",\"another\":\"else2\"}", settings[count].Value)
 	assert.Equal(tester, "", settings[count].NodeId)
+	count++
+
+	assert.Equal(tester, "myapp.ui_map_typed", settings[count].Id)
+	assert.Equal(tester, "", settings[count].Value)
+	assert.Equal(tester, "", settings[count].NodeId)
+	assert.Equal(tester, "[]" + "{}", settings[count].ForcedType)
+	assert.Equal(tester, 3, len(settings[count].UiElements))
 	count++
 
 	assert.Equal(tester, "myapp.zdef", settings[count].Id)
@@ -1386,6 +1393,40 @@ func TestImportFile(t *testing.T) {
 
 	request := ReadRequest(t, "ctx_import-file")
 	assert.JSONEq(t, `{"command":"import-file","command_id":"ctx_import-file","node":"manager_standalone","file":"/nsm/soc/uploads/file.pcap","importer":"pcap"}`, request)
+}
+
+func TestUpdateSetting_ForceMapListFieldTypes_StringInput(tester *testing.T) {
+	defer Cleanup()
+	salt := NewTestSalt()
+
+	// UI sends int and bool fields as strings inside the JSON objects
+	setting := model.NewSetting("myapp.ui_map_typed")
+	setting.Value = "{\"enabled\":\"true\",\"name\":\"alpha\",\"port\":\"8080\"}\n{\"enabled\":\"false\",\"name\":\"beta\",\"port\":\"9090\"}"
+	err := salt.UpdateSetting(ctx(), setting, false)
+	assert.NoError(tester, err)
+
+	settings, get_err := salt.GetSettings(ctx(), true)
+	assert.NoError(tester, get_err)
+	updated := findSetting(settings, "myapp.ui_map_typed", "")
+	// After coercion, port must be a JSON number and enabled a JSON bool (not quoted strings)
+	assert.Equal(tester, "{\"enabled\":true,\"name\":\"alpha\",\"port\":8080}\n{\"enabled\":false,\"name\":\"beta\",\"port\":9090}\n", updated.Value)
+}
+
+func TestUpdateSetting_ForceMapListFieldTypes_NumericInput(tester *testing.T) {
+	defer Cleanup()
+	salt := NewTestSalt()
+
+	// UI sends properly-typed JSON (numbers as numbers, bools as bools)
+	setting := model.NewSetting("myapp.ui_map_typed")
+	setting.Value = "{\"enabled\":true,\"name\":\"alpha\",\"port\":8080}"
+	err := salt.UpdateSetting(ctx(), setting, false)
+	assert.NoError(tester, err)
+
+	settings, get_err := salt.GetSettings(ctx(), true)
+	assert.NoError(tester, get_err)
+	updated := findSetting(settings, "myapp.ui_map_typed", "")
+	// float64(8080) from JSON parse must be coerced to int64 so YAML stores it as an integer
+	assert.Equal(tester, "{\"enabled\":true,\"name\":\"alpha\",\"port\":8080}\n", updated.Value)
 }
 
 func TestReadSetting_UiElements(tester *testing.T) {

--- a/server/modules/salt/test_resources/saltstack/default/salt/myapp/soc_myapp.yaml
+++ b/server/modules/salt/test_resources/saltstack/default/salt/myapp/soc_myapp.yaml
@@ -7,6 +7,18 @@ myapp:
   ro:
     description: read only setting
     readonly: True
+  ui_map_typed:
+    description: Map list with typed UI elements
+    forcedType: "[]{}"
+    uiElements:
+    - field: port
+      label: Port
+      forcedType: int
+    - field: enabled
+      label: Enabled
+      forcedType: bool
+    - field: name
+      label: Name
   ui_json:
     description: UI elements for JSON packing
     uiElements:


### PR DESCRIPTION
When saving an array of objects setting, such as adding a new model to AvailableModels, the fields need their types coerced to match any ForcedType hints added to the annotations.