### PR TITLE
ClientParameters no longer requires LowBalanceColorAlert

### DIFF
--- a/model/clientparameters.go
+++ b/model/clientparameters.go
@@ -240,8 +240,10 @@ func (m *ModelParameters) UnmarshalJSON(data []byte) error {
 	if m.ContextLimitLarge, err = parseToInt(aux.ContextLimitLarge); err != nil {
 		return fmt.Errorf("parsing contextLimitLarge: %w", err)
 	}
-	if m.LowBalanceColorAlert, err = parseToInt(aux.LowBalanceColorAlert); err != nil {
-		return fmt.Errorf("parsing LowBalanceColorAlert: %w", err)
+	if aux.LowBalanceColorAlert != nil {
+		if m.LowBalanceColorAlert, err = parseToInt(aux.LowBalanceColorAlert); err != nil {
+			return fmt.Errorf("parsing LowBalanceColorAlert: %w", err)
+		}
 	}
 
 	return nil

--- a/model/clientparameters_test.go
+++ b/model/clientparameters_test.go
@@ -210,6 +210,22 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 			}`,
 			wantErr: true,
 		},
+		{
+			name: "missing optional lowBalanceColorAlert should default to zero",
+			input: `{
+				"id": "abc",
+				"displayName": "Normal",
+				"contextLimitSmall": 512,
+				"contextLimitLarge": 2048
+			}`,
+			want: ModelParameters{
+				ID:                   "abc",
+				DisplayName:          "Normal",
+				ContextLimitSmall:    512,
+				ContextLimitLarge:    2048,
+				LowBalanceColorAlert: 0,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When parsing the file, the LowBalanceColorAlert logic wasn't allowing a non-existent value. Now it checks for nil before parsing and setting. Updated test.