### PR TITLE
Reuse verifyRuleSyntax

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -214,8 +214,8 @@ $(document).ready(function () {
               { pattern: /sid:\s?(["']?)\d+\1;/, message: _i18n.invalidDetectionSuricataMissingSID, match: false },
             ],
             yara: [
-              { pattern: /rule\s+{/, message: _i18n.invalidDetectionStrelkaMissingRuleName, match: true },
-              { pattern: /rule\s+[a-zA-Z_][a-zA-Z0-9_]*/, message: _i18n.invalidDetectionStrelkaInvalidRuleName, match: false },
+              { pattern: /^rule\s+{/, message: _i18n.invalidDetectionStrelkaMissingRuleName, match: true },
+              { pattern: /^rule\s+[a-zA-Z_][a-zA-Z0-9_]*/, message: _i18n.invalidDetectionStrelkaInvalidRuleName, match: false },
               { pattern: /condition:/m, message: _i18n.invalidDetectionStrelkaMissingCondition, match: false },
             ],
           },

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -36,6 +36,7 @@ if (typeof global !== 'undefined') {
 
 $(document).ready(function () {
   Promise.all(templatePromises).then(() => {
+    const _i18n = i18n.getLocalizedTranslations(navigator.language);
     const vuetify = Vuetify.createVuetify({
       defaults: {
         VIcon: {
@@ -135,7 +136,7 @@ $(document).ready(function () {
         return {
           timestamp: Date.now(),
           theme: Vuetify.useTheme(),
-          i18n: i18n.getLocalizedTranslations(navigator.language),
+          i18n: _i18n,
           loading: false,
           loadingCancelCallback: null,
           error: false,
@@ -204,6 +205,20 @@ $(document).ready(function () {
           FEAT_RPT: 'rpt',
           FEAT_TTR: 'ttr',
           FEAT_OAI: 'oai',
+          ruleValidators: {
+            sigma: [
+              { pattern: /^id:\s*[^$]+?$/m, message: _i18n.invalidDetectionElastAlertMissingID, match: false },
+            ],
+            suricata: [
+              { pattern: /\n/, message: _i18n.invalidDetectionSuricataNewLine, match: true },
+              { pattern: /sid:\s?(["']?)\d+\1;/, message: _i18n.invalidDetectionSuricataMissingSID, match: false },
+            ],
+            yara: [
+              { pattern: /rule\s+{/, message: _i18n.invalidDetectionStrelkaMissingRuleName, match: true },
+              { pattern: /rule\s+[a-zA-Z_][a-zA-Z0-9_]*/, message: _i18n.invalidDetectionStrelkaInvalidRuleName, match: false },
+              { pattern: /condition:/m, message: _i18n.invalidDetectionStrelkaMissingCondition, match: false },
+            ],
+          },
         }
       },
       watch: {
@@ -1731,6 +1746,16 @@ $(document).ready(function () {
             this.showError(error);
           }
           this.stopLoading();
+        },
+        verifyRuleSyntax(det) {
+          const rules = this.ruleValidators[det.language.toLowerCase()];
+          for (let i = 0; i < rules.length; i++) {
+            if (rules[i].pattern.test(det.content) === rules[i].match) {
+              return rules[i].message;
+            }
+          }
+
+          return null;
         },
       },
       created() {

--- a/html/js/app.test.js
+++ b/html/js/app.test.js
@@ -1314,3 +1314,47 @@ graph TD
 
   expect(app.performMermaidRegexes(mermaidWithBothIssues)).toBe(expectedBothFixed);
 });
+
+test('verifyRuleSyntax - implementation', () => {
+  const _old = app.ruleValidators;
+	app.ruleValidators = {
+		engine: [
+			{ pattern: /1/m, message: 'should not have 1', match: true },
+			{ pattern: /2/m, message: 'should have 2', match: false },
+			{ pattern: /3/m, message: 'should not have 3', match: true },
+		],
+	};
+
+	let detect = {
+		content: '1',
+		language: 'engine',
+	};
+	let msg = app.verifyRuleSyntax(detect);
+	expect(msg).toBe('should not have 1');
+
+	detect.content = '2';
+	msg = app.verifyRuleSyntax(detect);
+	expect(msg).toBe(null);
+
+	detect.content = '3';
+	msg = app.verifyRuleSyntax(detect);
+	expect(msg).toBe('should have 2');
+
+	detect.content = '23';
+	msg = app.verifyRuleSyntax(detect);
+	expect(msg).toBe('should not have 3');
+
+	detect.content = '123';
+	msg = app.verifyRuleSyntax(detect);
+	expect(msg).toBe('should not have 1');
+
+	detect.content = '321';
+	msg = app.verifyRuleSyntax(detect);
+	expect(msg).toBe('should not have 1');
+
+	detect.content = '24';
+	msg = app.verifyRuleSyntax(detect);
+	expect(msg).toBe(null);
+
+  app.ruleValidators = _old;
+});

--- a/html/js/components/detection-panel.js
+++ b/html/js/components/detection-panel.js
@@ -389,19 +389,9 @@ components.push({
 					});
 				}
 			},
-			verifyRuleSyntax() {
-				const rules = this.ruleValidators[this.detection.language.toLowerCase()];
-				for (let i = 0; i < rules.length; i++) {
-					if (rules[i].pattern.test(this.detection.content) === rules[i].match) {
-						return rules[i].message;
-					}
-				}
-
-				return null;
-			},
 			validateStrelka() {
 				try {
-					let err = this.verifyRuleSyntax();
+					let err = this.$root.verifyRuleSyntax(this.detection);
 					if (err) {
 						return err;
 					}
@@ -413,7 +403,7 @@ components.push({
 			},
 			validateElastAlert() {
 				try {
-					let err = this.verifyRuleSyntax();
+					let err = this.$root.verifyRuleSyntax(this.detection);
 					if (err) {
 						return err;
 					}
@@ -430,7 +420,7 @@ components.push({
 			},
 			validateSuricata() {
 				try {
-					let err = this.verifyRuleSyntax();
+					let err = this.$root.verifyRuleSyntax(this.detection);
 					if (err) {
 						return err;
 					}

--- a/html/js/components/detection-panel.test.js
+++ b/html/js/components/detection-panel.test.js
@@ -267,7 +267,7 @@ test('validateStrelka success', () => {
 
 test('validateStrelka missing rule name', () => {
   comp.detection.language = 'yara';
-  comp.detection.content = 'condition: true';
+  comp.detection.content = 'rule { condition: true }';
   expect(comp.validateStrelka()).toBe(comp.i18n.invalidDetectionStrelkaMissingRuleName);
 });
 

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -705,6 +705,7 @@ const i18n = {
       invalidDetectionElastAlertMissingID: 'This Sigma rule is missing its ID. An "id" field is required.',
       invalidDetectionStrelkaMissingCondition: 'This YARA rule is missing its condition. A "condition" section is required.',
       invalidDetectionStrelkaMissingRuleName: 'This YARA rule is missing its identifier. An identifier is required.',
+      invalidDetectionStrelkaInvalidRuleName: 'This YARA rule has an invalid identifier. Identifiers must start with a letter or underscore, followed by letters, digits, or underscores.',
       invalidDetectionSuricataSIDMismatch: "The SID in this Suricata rule must match the detection's public Id.",
       invalidDetectionSuricataMissingSID: 'This Suricata rule is missing its SID. A SID is required.',
       invalidDetectionSuricataNewLine: 'Newline characters are not allowed in Suricata rules. The rule must fit on one line.',

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -172,19 +172,6 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 			},
 			changedKeys: {},
 			changedOverrideKeys: {},
-			ruleValidators: {
-				sigma: [
-					{ pattern: /^id:\s*[^$]+?$/m, message: this.$root.i18n.invalidDetectionElastAlertMissingID, match: false },
-				],
-				suricata: [
-					{ pattern: /\n/, message: this.$root.i18n.invalidDetectionSuricataNewLine, match: true },
-					{ pattern: /sid:\s?(["']?)\d+\1;/, message: this.$root.i18n.invalidDetectionSuricataMissingSID, match: false },
-				],
-				yara: [
-					{ pattern: /rule\s+[a-zA-Z0-9][a-zA-Z0-9_]*/, message: this.$root.i18n.invalidDetectionStrelkaMissingRuleName, match: false },
-					{ pattern: /condition:/m, message: this.$root.i18n.invalidDetectionStrelkaMissingCondition, match: false },
-				],
-			},
 			showUnreviewedAiSummaries: false,
 			MAX_OVERRIDE_NOTE_LENGTH: MAX_OVERRIDE_NOTE_LENGTH,
 			joinedPlaybookSource: '',
@@ -878,19 +865,9 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 				this.$root.stopLoading();
 			}
 		},
-		verifyRuleSyntax() {
-			const rules = this.ruleValidators[this.detect.language.toLowerCase()];
-			for (let i = 0; i < rules.length; i++) {
-				if (rules[i].pattern.test(this.detect.content) === rules[i].match) {
-					return rules[i].message;
-				}
-			}
-
-			return null;
-		},
 		validateStrelka() {
 			try {
-				let err = this.verifyRuleSyntax();
+				let err = this.$root.verifyRuleSyntax(this.detect);
 				if (err) {
 					return err;
 				}
@@ -902,7 +879,7 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 		},
 		validateElastAlert() {
 			try {
-				let err = this.verifyRuleSyntax();
+				let err = this.$root.verifyRuleSyntax(this.detect);
 				if (err) {
 					return err;
 				}
@@ -924,7 +901,7 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 		},
 		validateSuricata() {
 			try {
-				let err = this.verifyRuleSyntax();
+				let err = this.$root.verifyRuleSyntax(this.detect);
 				if (err) {
 					return err;
 				}

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -1056,96 +1056,65 @@ test('saveDetection - statusEffectedByFilter', async () => {
 	expect(comp.extractDetection).toHaveBeenCalledTimes(1);
 });
 
-test('verifyRuleSyntax - implementation', () => {
-	comp.ruleValidators = {
-		engine: [
-			{ pattern: /1/m, message: 'should not have 1', match: true },
-			{ pattern: /2/m, message: 'should have 2', match: false },
-			{ pattern: /3/m, message: 'should not have 3', match: true },
-		],
-	};
-
-	comp.detect = {
-		content: '1',
-		language: 'engine',
-	};
-	let msg = comp.verifyRuleSyntax();
-	expect(msg).toBe('should not have 1');
-
-	comp.detect.content = '2';
-	msg = comp.verifyRuleSyntax();
-	expect(msg).toBe(null);
-
-	comp.detect.content = '3';
-	msg = comp.verifyRuleSyntax();
-	expect(msg).toBe('should have 2');
-
-	comp.detect.content = '23';
-	msg = comp.verifyRuleSyntax();
-	expect(msg).toBe('should not have 3');
-
-	comp.detect.content = '123';
-	msg = comp.verifyRuleSyntax();
-	expect(msg).toBe('should not have 1');
-
-	comp.detect.content = '321';
-	msg = comp.verifyRuleSyntax();
-	expect(msg).toBe('should not have 1');
-
-	comp.detect.content = '24';
-	msg = comp.verifyRuleSyntax();
-	expect(msg).toBe(null);
-});
-
-test('verifyRuleSyntax - Sigma', () => {
+test('validateElastAlert', () => {
 	comp.detect = {
 		language: 'sigma',
 		content: ''
 	};
 
-	let msg = comp.verifyRuleSyntax();
+	let msg = comp.validateElastAlert();
 	expect(msg).toBe(comp.i18n.invalidDetectionElastAlertMissingID);
 
 	comp.detect.content = 'id: 123\n';
-	msg = comp.verifyRuleSyntax();
+	msg = comp.validateElastAlert();
+	expect(msg).toBe(comp.i18n.invalidDetectionElastAlertMissingDetectionLogic);
+
+	comp.detect.content += 'detection: {}'
+	msg = comp.validateElastAlert();
 	expect(msg).toBe(null);
 });
 
-test('verifyRuleSyntax - Suricata', () => {
+test('validateSuricata', () => {
 	comp.detect = {
 		language: 'suricata',
 		content: '\n',
+		publicId: '123',
 	};
 
-	let msg = comp.verifyRuleSyntax();
+	let msg = comp.validateSuricata();
 	expect(msg).toBe(comp.i18n.invalidDetectionSuricataNewLine);
 
 	comp.detect.content = '';
-	msg = comp.verifyRuleSyntax();
+	msg = comp.validateSuricata();
 	expect(msg).toBe(comp.i18n.invalidDetectionSuricataMissingSID);
 
 	comp.detect.content = 'sid: 123;';
-	msg = comp.verifyRuleSyntax();
+	msg = comp.validateSuricata();
 	expect(msg).toBe(null);
 });
 
-test('verifyRuleSyntax - YARA', () => {
+test('validateStrelka', () => {
 	comp.detect = {
 		language: 'yara',
-		content: '',
+		content: 'rule {}',
 	};
 
-	let msg = comp.verifyRuleSyntax();
+	let msg = comp.validateStrelka();
 	expect(msg).toBe(comp.i18n.invalidDetectionStrelkaMissingRuleName);
 
+	comp.detect.content = 'rule 5 {}';
+	msg = comp.validateStrelka();
+	expect(msg).toBe(comp.i18n.invalidDetectionStrelkaInvalidRuleName);
+
 	comp.detect.content = 'rule X {}';
-	msg = comp.verifyRuleSyntax();
+	msg = comp.validateStrelka();
 	expect(msg).toBe(comp.i18n.invalidDetectionStrelkaMissingCondition);
 
 	comp.detect.content = 'rule X { condition: }';
-	msg = comp.verifyRuleSyntax();
+	msg = comp.validateStrelka();
 	expect(msg).toBe(null);
 });
+
 
 test('validateElastAlert', () => {
 	comp.detect = {


### PR DESCRIPTION
Refactor the fetching of i18n for the root component so the strings are available when setting up the root's data.

Migrate/Consolidate the `verifyRuleSyntax` functions into the root component. Migrate tests.

Split hairs on invalid strelka id and missing strelka id.