### PR TITLE
OpenAI Responses Tweaks

### DIFF
--- a/server/modules/assistant/openai_responses_adapter.go
+++ b/server/modules/assistant/openai_responses_adapter.go
@@ -232,6 +232,17 @@ func (a *OpenAIResponsesAdapter) SendMessageStream(ctx context.Context, req *mod
 				return
 			}
 		}
+		// Check if the stream ended due to an error
+		if err := stream.Err(); err != nil {
+			replacement, shouldReturn := handleStreamError(err, processor.firstSend, writer, logger, req.Model)
+			if shouldReturn {
+				if replacement != nil {
+					response = replacement
+				}
+				return
+			}
+		}
+
 		// Finalization - processor handles closing blocks and writing final events
 		processor.finalizeOpenAI(finishReason, stream.Current().Response.Usage)
 	}()
@@ -246,8 +257,7 @@ func convertHistoryToOpenAI(logger log.Interface, req *model.ChatRequest) respon
 
 	for _, msg := range req.Messages {
 		content := ""
-
-		h := responses.ResponseInputItemUnionParam{}
+		items := make([]responses.ResponseInputItemUnionParam, 0)
 
 		// Process each content block in the message
 		for _, block := range msg.ContentBlocks {
@@ -272,35 +282,42 @@ func convertHistoryToOpenAI(logger log.Interface, req *model.ChatRequest) respon
 					}
 				}
 
-				h.OfFunctionCall = &responses.ResponseFunctionToolCallParam{
-					ID:        openai.String(block.Id),
-					Name:      block.Name,
-					Arguments: string(block.Input),
-				}
+				items = append(items, responses.ResponseInputItemUnionParam{
+					OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+						CallID:    block.Id,
+						Name:      block.Name,
+						Arguments: string(block.Input),
+					},
+				})
 			case "tool_result":
 				// Handle tool results (responses from user with tool execution results)
 				if block.ToolResult != nil && len(block.ToolResult.Content) != 0 {
 					if block.ToolResult.IsError {
-						h.OfFunctionCallOutput = &responses.ResponseInputItemFunctionCallOutputParam{
-							CallID: block.ToolResult.ToolUseId,
-							Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
-								OfString: openai.String(fmt.Sprintf(`{"error": "%s"}`, block.ToolResult.Content[0].Text)),
+						errText, _ := json.Marshal(block.ToolResult.Content[0].Text)
+						items = append(items, responses.ResponseInputItemUnionParam{
+							OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+								CallID: block.ToolResult.ToolUseId,
+								Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+									OfString: openai.String(fmt.Sprintf(`{"error": %s}`, string(errText))),
+								},
+								Status: "completed",
 							},
-							Status: "completed",
-						}
+						})
 					} else {
 						jsonBytes, err := json.Marshal(block.ToolResult.Content[0].Json)
 						if err != nil {
 							jsonBytes = []byte(`{ "error": "failed to marshal tool result content" }`)
 						}
 
-						h.OfFunctionCallOutput = &responses.ResponseInputItemFunctionCallOutputParam{
-							CallID: block.ToolResult.ToolUseId,
-							Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
-								OfString: openai.String(string(jsonBytes)),
+						items = append(items, responses.ResponseInputItemUnionParam{
+							OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+								CallID: block.ToolResult.ToolUseId,
+								Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+									OfString: openai.String(string(jsonBytes)),
+								},
+								Status: "completed",
 							},
-							Status: "completed",
-						}
+						})
 					}
 				}
 			default:
@@ -315,19 +332,38 @@ func convertHistoryToOpenAI(logger log.Interface, req *model.ChatRequest) respon
 		// contain text, however openai will yell at you for including text (the
 		// filler &nbsp;) alongside a function call.
 		if content != "" && content != "&nbsp;" {
-			h.OfInputMessage = &responses.ResponseInputItemMessageParam{
-				Role: msg.Role,
-				Content: responses.ResponseInputMessageContentListParam{
-					{
-						OfInputText: &responses.ResponseInputTextParam{
-							Text: content,
+			var textItem responses.ResponseInputItemUnionParam
+			if msg.Role == "user" {
+				textItem = responses.ResponseInputItemUnionParam{
+					OfInputMessage: &responses.ResponseInputItemMessageParam{
+						Role: msg.Role,
+						Content: responses.ResponseInputMessageContentListParam{
+							{
+								OfInputText: &responses.ResponseInputTextParam{
+									Text: content,
+								},
+							},
 						},
 					},
-				},
+				}
+			} else {
+				textItem = responses.ResponseInputItemUnionParam{
+					OfOutputMessage: &responses.ResponseOutputMessageParam{
+						Content: []responses.ResponseOutputMessageContentUnionParam{
+							{
+								OfOutputText: &responses.ResponseOutputTextParam{
+									Text: content,
+								},
+							},
+						},
+					},
+				}
 			}
+			// Prepend text before tool items to preserve natural ordering
+			items = append([]responses.ResponseInputItemUnionParam{textItem}, items...)
 		}
 
-		history = append(history, h)
+		history = append(history, items...)
 	}
 
 	result := responses.ResponseNewParamsInputUnion{

--- a/server/modules/assistant/openai_responses_adapter_test.go
+++ b/server/modules/assistant/openai_responses_adapter_test.go
@@ -307,11 +307,10 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
 				require.Len(t, resp.OfInputItemList, 1)
 				item := resp.OfInputItemList[0]
-				require.NotNil(t, item.OfInputMessage)
-				assert.Equal(t, "assistant", item.OfInputMessage.Role)
-				require.Len(t, item.OfInputMessage.Content, 1)
-				require.NotNil(t, item.OfInputMessage.Content[0].OfInputText)
-				assert.Equal(t, "Hi there!", item.OfInputMessage.Content[0].OfInputText.Text)
+				require.NotNil(t, item.OfOutputMessage)
+				require.Len(t, item.OfOutputMessage.Content, 1)
+				require.NotNil(t, item.OfOutputMessage.Content[0].OfOutputText)
+				assert.Equal(t, "Hi there!", item.OfOutputMessage.Content[0].OfOutputText.Text)
 			},
 		},
 		{
@@ -340,9 +339,8 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 				assert.Equal(t, "user", resp.OfInputItemList[0].OfInputMessage.Role)
 				assert.Equal(t, "First message", resp.OfInputItemList[0].OfInputMessage.Content[0].OfInputText.Text)
 				// Second message
-				assert.NotNil(t, resp.OfInputItemList[1].OfInputMessage)
-				assert.Equal(t, "assistant", resp.OfInputItemList[1].OfInputMessage.Role)
-				assert.Equal(t, "Second message", resp.OfInputItemList[1].OfInputMessage.Content[0].OfInputText.Text)
+				assert.NotNil(t, resp.OfInputItemList[1].OfOutputMessage)
+				assert.Equal(t, "Second message", resp.OfInputItemList[1].OfOutputMessage.Content[0].OfOutputText.Text)
 			},
 		},
 		{
@@ -387,7 +385,7 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 				require.Len(t, resp.OfInputItemList, 1)
 				item := resp.OfInputItemList[0]
 				require.NotNil(t, item.OfFunctionCall)
-				assert.Equal(t, "call_123", item.OfFunctionCall.ID.Or(""))
+				assert.Equal(t, "call_123", item.OfFunctionCall.CallID)
 				assert.Equal(t, "get_weather", item.OfFunctionCall.Name)
 				assert.JSONEq(t, `{"location": "San Francisco"}`, item.OfFunctionCall.Arguments)
 			},
@@ -411,13 +409,7 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 			},
 			validate: func(t *testing.T, result interface{}) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
-				// Should have one item but it should be empty since the JSON was invalid and skipped
-				require.Len(t, resp.OfInputItemList, 1)
-				item := resp.OfInputItemList[0]
-				// All fields should be nil since the block was skipped
-				assert.Nil(t, item.OfInputMessage)
-				assert.Nil(t, item.OfFunctionCall)
-				assert.Nil(t, item.OfFunctionCallOutput)
+				require.Len(t, resp.OfInputItemList, 0)
 			},
 		},
 		{
@@ -505,12 +497,7 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 			},
 			validate: func(t *testing.T, result interface{}) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
-				// Should have one item but it should be empty since content was empty
-				require.Len(t, resp.OfInputItemList, 1)
-				item := resp.OfInputItemList[0]
-				assert.Nil(t, item.OfInputMessage)
-				assert.Nil(t, item.OfFunctionCall)
-				assert.Nil(t, item.OfFunctionCallOutput)
+				require.Len(t, resp.OfInputItemList, 0)
 			},
 		},
 		{
@@ -527,10 +514,7 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 			},
 			validate: func(t *testing.T, result interface{}) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
-				// Should have one item but no message content (nbsp is filtered out)
-				require.Len(t, resp.OfInputItemList, 1)
-				item := resp.OfInputItemList[0]
-				assert.Nil(t, item.OfInputMessage)
+				require.Len(t, resp.OfInputItemList, 0)
 			},
 		},
 		{
@@ -581,13 +565,15 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 			},
 			validate: func(t *testing.T, result interface{}) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
-				require.Len(t, resp.OfInputItemList, 1)
-				item := resp.OfInputItemList[0]
-				// Both text message and function call should be present on same item
-				require.NotNil(t, item.OfInputMessage)
-				assert.Equal(t, "Let me check that for you", item.OfInputMessage.Content[0].OfInputText.Text)
-				require.NotNil(t, item.OfFunctionCall)
-				assert.Equal(t, "search", item.OfFunctionCall.Name)
+				require.Len(t, resp.OfInputItemList, 2)
+				// First item: text as output message
+				require.NotNil(t, resp.OfInputItemList[0].OfOutputMessage)
+				assert.Equal(t, "Let me check that for you", resp.OfInputItemList[0].OfOutputMessage.Content[0].OfOutputText.Text)
+				assert.Nil(t, resp.OfInputItemList[0].OfFunctionCall)
+				// Second item: function call
+				require.NotNil(t, resp.OfInputItemList[1].OfFunctionCall)
+				assert.Equal(t, "search", resp.OfInputItemList[1].OfFunctionCall.Name)
+				assert.Nil(t, resp.OfInputItemList[1].OfOutputMessage)
 			},
 		},
 		{
@@ -604,10 +590,7 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 			},
 			validate: func(t *testing.T, result interface{}) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
-				// Empty string should be filtered out
-				require.Len(t, resp.OfInputItemList, 1)
-				item := resp.OfInputItemList[0]
-				assert.Nil(t, item.OfInputMessage)
+				require.Len(t, resp.OfInputItemList, 0)
 			},
 		},
 		{
@@ -622,11 +605,7 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 			},
 			validate: func(t *testing.T, result interface{}) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
-				// Should have one empty item
-				require.Len(t, resp.OfInputItemList, 1)
-				item := resp.OfInputItemList[0]
-				assert.Nil(t, item.OfInputMessage)
-				assert.Nil(t, item.OfFunctionCall)
+				require.Len(t, resp.OfInputItemList, 0)
 			},
 		},
 		{
@@ -654,13 +633,14 @@ func TestConvertHistoryToOpenAI(t *testing.T) {
 			},
 			validate: func(t *testing.T, result interface{}) {
 				resp := result.(responses.ResponseNewParamsInputUnion)
-				// Only one OfFunctionCall per history item - last one wins
-				require.Len(t, resp.OfInputItemList, 1)
-				item := resp.OfInputItemList[0]
-				require.NotNil(t, item.OfFunctionCall)
-				// Should be the last tool call since it overwrites previous ones
-				assert.Equal(t, "calculate", item.OfFunctionCall.Name)
-				assert.Equal(t, "call_2", item.OfFunctionCall.ID.Or(""))
+				// Each tool_use becomes its own item
+				require.Len(t, resp.OfInputItemList, 2)
+				require.NotNil(t, resp.OfInputItemList[0].OfFunctionCall)
+				assert.Equal(t, "search", resp.OfInputItemList[0].OfFunctionCall.Name)
+				assert.Equal(t, "call_1", resp.OfInputItemList[0].OfFunctionCall.CallID)
+				require.NotNil(t, resp.OfInputItemList[1].OfFunctionCall)
+				assert.Equal(t, "calculate", resp.OfInputItemList[1].OfFunctionCall.Name)
+				assert.Equal(t, "call_2", resp.OfInputItemList[1].OfFunctionCall.CallID)
 			},
 		},
 	}

--- a/server/modules/assistant/sse.go
+++ b/server/modules/assistant/sse.go
@@ -89,6 +89,7 @@ type streamProcessor struct {
 	hasOpenBlock         bool
 	firstSend            bool
 	writingOpenAIToolUse bool
+	receivedFnArgs       bool
 }
 
 func newStreamProcessor(writer *sseEventWriter, model string, wg *sync.WaitGroup) *streamProcessor {
@@ -192,11 +193,26 @@ func (p *streamProcessor) processOpenAIChunk(resp responses.ResponseStreamEventU
 			callId := resp.Item.CallID
 			name := resp.Item.Name
 
+			p.receivedFnArgs = false
 			p.writeOpenAIFunctionHeader(callId, name)
 		}
 	case "response.function_call_arguments.delta":
-		if p.hasOpenBlock {
+		if content == "" && resp.Arguments != "" {
+			content = resp.Arguments
+		}
+		if p.hasOpenBlock && content != "" {
+			p.receivedFnArgs = true
 			p.writeOpenAIFunctionInput(content)
+		}
+	case "response.function_call_arguments.done":
+		// Only use .done arguments if no deltas were received (some models skip deltas)
+		if !p.receivedFnArgs {
+			if content == "" && resp.Arguments != "" {
+				content = resp.Arguments
+			}
+			if p.hasOpenBlock && content != "" {
+				p.writeOpenAIFunctionInput(content)
+			}
 		}
 	case "response.output_item.done":
 		if p.writingOpenAIToolUse {
@@ -333,6 +349,7 @@ func (p *streamProcessor) writeOpenAIFunctionStop() {
 	p.contentBlockIndex++
 	p.hasOpenBlock = false
 	p.writingOpenAIToolUse = false
+	p.receivedFnArgs = false
 }
 
 // closeOpenBlock closes the currently open text/thought block

--- a/server/modules/assistant/sse_test.go
+++ b/server/modules/assistant/sse_test.go
@@ -852,6 +852,13 @@ func newFunctionArgumentsDelta(jsonContent string) responses.ResponseStreamEvent
 	}
 }
 
+func newFunctionArgumentsDone(jsonContent string) responses.ResponseStreamEventUnion {
+	return responses.ResponseStreamEventUnion{
+		Type:      "response.function_call_arguments.done",
+		Arguments: jsonContent,
+	}
+}
+
 func newFunctionCallDone() responses.ResponseStreamEventUnion {
 	return responses.ResponseStreamEventUnion{
 		Type: "response.output_item.done",
@@ -1125,6 +1132,71 @@ func TestProcessOpenAIChunk_FunctionCalls(t *testing.T) {
 				"hasOpenBlock": true,
 			},
 		},
+		{
+			name: "done after deltas is ignored",
+			events: []responses.ResponseStreamEventUnion{
+				newFunctionCallStart("call_dup", "search"),
+				newFunctionArgumentsDelta(`{"qu`),
+				newFunctionArgumentsDelta(`ery": "test"}`),
+				newFunctionArgumentsDone(`{"query": "test"}`),
+				newFunctionCallDone(),
+			},
+			expectedInOutput: []string{
+				`"name":"search"`,
+				`"partial_json":"{\"qu"`,
+				`"partial_json":"ery\": \"test\"}"`,
+				`"type":"content_block_stop"`,
+			},
+			expectedState: map[string]interface{}{
+				"hasOpenBlock":         false,
+				"writingOpenAIToolUse": false,
+				"contentBlockIndex":    1,
+				"receivedFnArgs":       false, // Reset after stop
+			},
+		},
+		{
+			name: "done without deltas sends args",
+			events: []responses.ResponseStreamEventUnion{
+				newFunctionCallStart("call_nodelta", "lookup"),
+				newFunctionArgumentsDone(`{"id": 42}`),
+				newFunctionCallDone(),
+			},
+			expectedInOutput: []string{
+				`"name":"lookup"`,
+				`"partial_json":"{\"id\": 42}"`,
+				`"type":"content_block_stop"`,
+			},
+			expectedState: map[string]interface{}{
+				"hasOpenBlock":         false,
+				"writingOpenAIToolUse": false,
+				"contentBlockIndex":    1,
+			},
+		},
+		{
+			name: "receivedFnArgs resets between function calls",
+			events: []responses.ResponseStreamEventUnion{
+				// First call: uses deltas, done should be ignored
+				newFunctionCallStart("call_a", "func_a"),
+				newFunctionArgumentsDelta(`{"x": 1}`),
+				newFunctionArgumentsDone(`{"x": 1}`),
+				newFunctionCallDone(),
+				// Second call: no deltas, done should be used
+				newFunctionCallStart("call_b", "func_b"),
+				newFunctionArgumentsDone(`{"y": 2}`),
+				newFunctionCallDone(),
+			},
+			expectedInOutput: []string{
+				`"name":"func_a"`,
+				`"name":"func_b"`,
+				`"partial_json":"{\"x\": 1}"`,
+				`"partial_json":"{\"y\": 2}"`,
+			},
+			expectedState: map[string]interface{}{
+				"hasOpenBlock":         false,
+				"writingOpenAIToolUse": false,
+				"contentBlockIndex":    2,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1155,8 +1227,38 @@ func TestProcessOpenAIChunk_FunctionCalls(t *testing.T) {
 			if expectedIndex, ok := tt.expectedState["contentBlockIndex"].(int); ok {
 				assert.Equal(t, expectedIndex, processor.contentBlockIndex)
 			}
+			if expectedReceivedFnArgs, ok := tt.expectedState["receivedFnArgs"].(bool); ok {
+				assert.Equal(t, expectedReceivedFnArgs, processor.receivedFnArgs)
+			}
 		})
 	}
+}
+
+func TestProcessOpenAIChunk_FunctionArgsDedupCount(t *testing.T) {
+	// Verify that when deltas are sent, the done event does NOT add another input_json_delta
+	var buf strings.Builder
+	writer := newSSEEventWriter(log.Log, &buf)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	processor := newStreamProcessor(writer, "gpt-4", wg)
+
+	events := []responses.ResponseStreamEventUnion{
+		newFunctionCallStart("call_count", "search"),
+		newFunctionArgumentsDelta(`{"query"`),
+		newFunctionArgumentsDelta(`: "test"}`),
+		newFunctionArgumentsDone(`{"query": "test"}`),
+		newFunctionCallDone(),
+	}
+
+	for _, event := range events {
+		_, err := processor.processOpenAIChunk(event)
+		assert.NoError(t, err)
+	}
+
+	output := buf.String()
+	// Should have exactly 2 input_json_delta events (from the two deltas), not 3
+	count := strings.Count(output, `"type":"input_json_delta"`)
+	assert.Equal(t, 2, count, "done event should not add a third input_json_delta when deltas were received")
 }
 
 func TestFinalizeOpenAI(t *testing.T) {


### PR DESCRIPTION
After the library version bump, there were errors in how we converted history and how we handled tool use messages.

Fixed history conversion to properly handle assistant messages, tool use calls, and error messages.

Fixed an issue in our SSE parser to watch for an odd behavior when using the OpenAI Responses adapter. A tool can 1) send tool arguments a token at a time in delta messages, 2) send the entire arguments string in one "done" message, or 3) BOTH send tokens AND send a complete arguments string when done. Tested against multiple local models.

Updated tests.