### PR TITLE
Specify row_hover color, no background in so-status grid table

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -851,14 +851,6 @@ code {
   color: white;
 }
 
-tbody tr:hover {
-  background-color: transparent !important;
-}
-
-tbody tr:hover:nth-of-type(even) {
-  background-color: rgba(var(--v-theme-row_stripe), 0.25) !important;
-}
-
 .unset-vertical-align {
   vertical-align: unset !important;
 }

--- a/html/css/modern.css
+++ b/html/css/modern.css
@@ -255,7 +255,11 @@ html, body, * {
 }
 
 /* Softer row striping */
-.v-data-table tbody tr, .v-data-table th, .v-data-table-footer, .v-table tr, .v-data-table-rows-no-data {
+.v-data-table tbody tr,
+.v-data-table th,
+.v-data-table-footer,
+.v-table tr,
+.v-data-table-rows-no-data {
   background-color: rgb(var(--v-theme-table_background)) !important;
 }
 
@@ -297,6 +301,14 @@ html, body, * {
 .v-data-table-footer {
   border-top: 1px solid rgba(var(--v-theme-text), 0.06) !important;
   padding: 8px 16px !important;
+}
+
+.v-table.no-background,
+.v-table.no-background table,
+.v-table.no-background tr,
+.v-table.no-background td,
+.v-table.no-background th {
+  background-color: unset !important;
 }
 
 /* ============================================================

--- a/html/css/modern.css
+++ b/html/css/modern.css
@@ -259,11 +259,6 @@ html, body, * {
   background-color: rgb(var(--v-theme-table_background)) !important;
 }
 
-.v-theme--dark tr:hover,
-.v-theme--light tr:hover {
-  background-color: rgba(var(--v-theme-primary), 0.15) !important;
-}
-
 /* Spacious cells */
 .v-data-table td {
   padding: 12px 16px !important;
@@ -274,8 +269,8 @@ html, body, * {
   transition: background-color 0.15s ease;
 }
 
-.v-data-table tbody tr:hover {
-  background-color: rgba(var(--v-theme-text), 0.04) !important;
+.v-data-table tbody tr:not(.no-hover):hover {
+  background-color: rgb(var(--v-theme-row_hover)) !important;
 }
 
 /* Softer header row */

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -131,6 +131,7 @@ $(document).ready(function () {
               icon: '#7f7f7f',
               button_icon_color: '#ffffff',
               row_stripe: '#e6e6e6',
+              row_hover: '#e2e2e2',
             },
           },
           dark: {
@@ -149,6 +150,7 @@ $(document).ready(function () {
               icon: '#8B96A8',
               button_icon_color: '#ffffff',
               row_stripe: '#2d2d2d',
+              row_hover: '#154084'
             },
           },
         },

--- a/html/pages/grid.html
+++ b/html/pages/grid.html
@@ -408,7 +408,7 @@
 											<v-card>
 												<v-card-title v-text="i18n.containerStatus"></v-card-title>
 												<v-card-text>
-													<v-table v-if="item.statusCode <= 1">
+													<v-table v-if="item.statusCode <= 1" class="no-background">
 														<template #default>
 															<thead>
 																<tr>

--- a/html/pages/grid.html
+++ b/html/pages/grid.html
@@ -115,7 +115,7 @@
 						</tr>
 					</template>
 					<template #expanded-row="{ item }">
-						<tr data-aid="grid_node_details">
+						<tr data-aid="grid_node_details" class="no-hover">
 							<td :colspan="headers.length" class="px-0">
 								<v-container fluid grid-list-sm class="pa-4">
 									<v-row>


### PR DESCRIPTION
Hover color of rows of tables are now a color we can specify in the theme. No transparency is used, it's just a color replacement.

Because the grid page has a much larger region in it's expanded rows, I created the no-hover class to skip them so they don't change color on hover.