### PR TITLE
Reload credits on model change

### DIFF
--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -295,6 +295,10 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       }
       // If no valid last chat found, keep the default welcome message
     },
+    reloadCredits() {
+      this.creditsLoaded = false;
+      this.loadCredits();
+    },
     async loadCredits() {
       try {
         const response = await this.$root.papi.get('/assistant/balance/' + encodeURIComponent(this.currentModel));

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -65,7 +65,7 @@
 					<v-select
 						:disabled="$root.loading"
 						v-model="currentModel"
-						@update:model-value="updateModelParams()"
+						@update:model-value="updateModelParams(); reloadCredits()"
 						:items="groupedModels"
 						item-title="displayName"
 						item-value="key"


### PR DESCRIPTION
If you started with a non-SOAI model when you loaded the page, and you switched to an SOAI model, the Credits Remaining were not being reported correctly.

Changing the model now reloads credits to keep it up to date.