### PR TITLE
Available Adapters

### DIFF
--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -48,6 +48,8 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     lowBalanceColorAlert: 0,
     availableModels: [],
     modelsMap: new Map(),
+    availableAdapters: [],
+    adaptersMap: new Map(),
     groupedModels: [],
     currentModel: '',
     activeStreamingSessionId: null, // Track which session is actively streaming
@@ -102,6 +104,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       this.thresholdColorRatioMed = params["thresholdColorRatioMed"];
       this.thresholdColorRatioMax = params["thresholdColorRatioMax"];
       this.availableModels = params["availableModels"];
+      this.availableAdapters = params["availableAdapters"];
       if (this.availableModels.length > 0) {
         this.availableModels.forEach(m => m.key = this.buildModelIdentifier(m));
         this.modelsMap = new Map(
@@ -112,6 +115,9 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         }
         if (!this.currentModel || !this.modelsMap.has(this.currentModel)) this.currentModel = this.availableModels[0].key;
         this.groupedModels = this.buildGroupedModels();
+      }
+      if (this.availableAdapters.length > 0) {
+        this.adaptersMap = new Map(this.availableAdapters.map(a => [a.name, a]));
       }
       this.updateModelParams();
 

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -89,7 +89,7 @@
 		</v-card>
 	</v-dialog>
 	<v-row align="stretch" class="ga-3" style="flex-wrap: nowrap;">
-		<v-col v-if="modelsMap.get(currentModel)?.adapter === 'SOAI'">
+		<v-col v-if="adaptersMap.get(modelsMap.get(currentModel)?.adapter)?.protocol === 'securityonion_ai_cloud'">
 			<div class="so-stat-pill" data-aid="assistant_credits_remaining">
 				<div class="so-stat-text">
 					<div class="so-stat-label">{{ i18n.creditsRemaining }}</div>

--- a/model/clientparameters.go
+++ b/model/clientparameters.go
@@ -180,13 +180,14 @@ type AlertingParameters struct {
 }
 
 type AssistantParameters struct {
-	Enabled                bool              `json:"enabled"`
-	InvestigationPrompt    string            `json:"investigationPrompt"`
-	CompressContextPrompt  string            `json:"compressContextPrompt"`
-	ThresholdColorRatioLow float64           `json:"thresholdColorRatioLow"`
-	ThresholdColorRatioMed float64           `json:"thresholdColorRatioMed"`
-	ThresholdColorRatioMax float64           `json:"thresholdColorRatioMax"`
-	AvailableModels        []ModelParameters `json:"availableModels"`
+	Enabled                bool                `json:"enabled"`
+	InvestigationPrompt    string              `json:"investigationPrompt"`
+	CompressContextPrompt  string              `json:"compressContextPrompt"`
+	ThresholdColorRatioLow float64             `json:"thresholdColorRatioLow"`
+	ThresholdColorRatioMed float64             `json:"thresholdColorRatioMed"`
+	ThresholdColorRatioMax float64             `json:"thresholdColorRatioMax"`
+	AvailableModels        []ModelParameters   `json:"availableModels"`
+	AvailableAdapters      []AdapterParameters `json:"availableAdapters"`
 }
 
 type ModelParameters struct {
@@ -198,6 +199,11 @@ type ModelParameters struct {
 	Origin               string `json:"origin"`
 	Adapter              string `json:"adapter"`
 	Enabled              bool   `json:"enabled"`
+}
+
+type AdapterParameters struct {
+	Name     string `json:"name"`
+	Protocol string `json:"protocol"`
 }
 
 // Custom unmarshal to handle numeric or scientific-notation string fields

--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -92,6 +92,7 @@ func (ac *AssistantCoordinator) Init(config module.ModuleConfig) (err error) {
 
 	adapterConfig, ok := config["adapters"].([]any)
 	if ok && adapterConfig != nil {
+		adapterArray := make([]model.AdapterParameters, 0, len(adapterConfig))
 		for i, adapterInter := range adapterConfig {
 			adapterEntry, ok := adapterInter.(map[string]any)
 			if !ok {
@@ -132,9 +133,17 @@ func (ac *AssistantCoordinator) Init(config module.ModuleConfig) (err error) {
 				"adapter":  name,
 				"protocol": protocol,
 			}).Info("loaded assistant adapter")
+
+			adapterArray = append(adapterArray, model.AdapterParameters{
+				Name:     module.GetStringDefault(adapterEntry, "name", ""),
+				Protocol: module.GetStringDefault(adapterEntry, "protocol", ""),
+			})
 		}
+
+		ac.srv.Config.ClientParams.AssistantParams.AvailableAdapters = adapterArray
 	} else {
 		logger.Warn("no adapter config, no adapters loaded")
+		ac.srv.Config.ClientParams.AssistantParams.AvailableAdapters = []model.AdapterParameters{}
 	}
 
 	ac.getPrompt()

--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -135,8 +135,8 @@ func (ac *AssistantCoordinator) Init(config module.ModuleConfig) (err error) {
 			}).Info("loaded assistant adapter")
 
 			adapterArray = append(adapterArray, model.AdapterParameters{
-				Name:     module.GetStringDefault(adapterEntry, "name", ""),
-				Protocol: module.GetStringDefault(adapterEntry, "protocol", ""),
+				Name:     name,
+				Protocol: protocol,
 			})
 		}
 

--- a/server/modules/assistant/assistant_test.go
+++ b/server/modules/assistant/assistant_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/security-onion-solutions/securityonion-soc/config"
 	"github.com/security-onion-solutions/securityonion-soc/licensing"
 	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/module"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	servermock "github.com/security-onion-solutions/securityonion-soc/server/mock"
 	detectionsmock "github.com/security-onion-solutions/securityonion-soc/server/modules/detections/mock"
 	"github.com/security-onion-solutions/securityonion-soc/web"
+
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -875,7 +877,234 @@ func TestAssistantCoordinator_GetPrompt(t *testing.T) {
 	}
 }
 
+func TestAssistantCoordinator_Init(t *testing.T) {
+	const fakeProtocol = "fake_protocol"
+	const failProtocol = "fail_protocol"
+
+	// Save and restore the protocols map and embeddedSystemPrompt.
+	origProtocols := protocols
+	origPrompt := embeddedSystemPrompt
+	t.Cleanup(func() {
+		protocols = origProtocols
+		embeddedSystemPrompt = origPrompt
+	})
+
+	// Disable embedded prompt so getPrompt() is a no-op.
+	embeddedSystemPrompt = []byte{}
+
+	protocols = map[string]ProtocolConstructor{
+		fakeProtocol: func(_ context.Context, _ *server.Server, cfg map[string]any) (server.AssistantAdapter, error) {
+			return &mockAdapter{protocol: fakeProtocol}, nil
+		},
+		failProtocol: func(_ context.Context, _ *server.Server, cfg map[string]any) (server.AssistantAdapter, error) {
+			return nil, errors.New("constructor failed")
+		},
+	}
+
+	validAdapter := func(name, proto string) map[string]any {
+		return map[string]any{"name": name, "protocol": proto}
+	}
+
+	testCases := []struct {
+		name                  string
+		config                module.ModuleConfig
+		expectedAdapterNames  []string
+		expectedAvailAdapters []model.AdapterParameters
+		expectedAddendum      string
+	}{
+		{
+			name:                  "no adapters key in config",
+			config:                module.ModuleConfig{},
+			expectedAdapterNames:  nil,
+			expectedAvailAdapters: []model.AdapterParameters{},
+			expectedAddendum:      "",
+		},
+		{
+			name:                  "adapters key is nil",
+			config:                module.ModuleConfig{"adapters": nil},
+			expectedAdapterNames:  nil,
+			expectedAvailAdapters: []model.AdapterParameters{},
+			expectedAddendum:      "",
+		},
+		{
+			name:                  "empty adapters array",
+			config:                module.ModuleConfig{"adapters": []any{}},
+			expectedAdapterNames:  nil,
+			expectedAvailAdapters: []model.AdapterParameters{},
+			expectedAddendum:      "",
+		},
+		{
+			name: "single valid adapter",
+			config: module.ModuleConfig{
+				"adapters": []any{
+					validAdapter("myAdapter", fakeProtocol),
+				},
+			},
+			expectedAdapterNames: []string{"myAdapter"},
+			expectedAvailAdapters: []model.AdapterParameters{
+				{Name: "myAdapter", Protocol: fakeProtocol},
+			},
+			expectedAddendum: "",
+		},
+		{
+			name: "multiple valid adapters",
+			config: module.ModuleConfig{
+				"adapters": []any{
+					validAdapter("first", fakeProtocol),
+					validAdapter("second", fakeProtocol),
+				},
+			},
+			expectedAdapterNames: []string{"first", "second"},
+			expectedAvailAdapters: []model.AdapterParameters{
+				{Name: "first", Protocol: fakeProtocol},
+				{Name: "second", Protocol: fakeProtocol},
+			},
+			expectedAddendum: "",
+		},
+		{
+			name: "adapter entry is not a map - skipped",
+			config: module.ModuleConfig{
+				"adapters": []any{
+					"not-a-map",
+					validAdapter("good", fakeProtocol),
+				},
+			},
+			expectedAdapterNames: []string{"good"},
+			expectedAvailAdapters: []model.AdapterParameters{
+				{Name: "good", Protocol: fakeProtocol},
+			},
+			expectedAddendum: "",
+		},
+		{
+			name: "missing name field - skipped",
+			config: module.ModuleConfig{
+				"adapters": []any{
+					map[string]any{"protocol": fakeProtocol},
+					validAdapter("good", fakeProtocol),
+				},
+			},
+			expectedAdapterNames: []string{"good"},
+			expectedAvailAdapters: []model.AdapterParameters{
+				{Name: "good", Protocol: fakeProtocol},
+			},
+			expectedAddendum: "",
+		},
+		{
+			name: "missing protocol field - skipped",
+			config: module.ModuleConfig{
+				"adapters": []any{
+					map[string]any{"name": "noProto"},
+					validAdapter("good", fakeProtocol),
+				},
+			},
+			expectedAdapterNames: []string{"good"},
+			expectedAvailAdapters: []model.AdapterParameters{
+				{Name: "good", Protocol: fakeProtocol},
+			},
+			expectedAddendum: "",
+		},
+		{
+			name: "unknown protocol - skipped",
+			config: module.ModuleConfig{
+				"adapters": []any{
+					validAdapter("unknown", "no_such_protocol"),
+					validAdapter("good", fakeProtocol),
+				},
+			},
+			expectedAdapterNames: []string{"good"},
+			expectedAvailAdapters: []model.AdapterParameters{
+				{Name: "good", Protocol: fakeProtocol},
+			},
+			expectedAddendum: "",
+		},
+		{
+			name: "constructor returns error - skipped",
+			config: module.ModuleConfig{
+				"adapters": []any{
+					validAdapter("broken", failProtocol),
+					validAdapter("good", fakeProtocol),
+				},
+			},
+			expectedAdapterNames: []string{"good"},
+			expectedAvailAdapters: []model.AdapterParameters{
+				{Name: "good", Protocol: fakeProtocol},
+			},
+			expectedAddendum: "",
+		},
+		{
+			name: "systemPromptAddendum within limit",
+			config: module.ModuleConfig{
+				"systemPromptAddendum": "custom addendum",
+			},
+			expectedAdapterNames:  nil,
+			expectedAvailAdapters: []model.AdapterParameters{},
+			expectedAddendum:      "custom addendum",
+		},
+		{
+			name: "systemPromptAddendum truncated to maxLength",
+			config: module.ModuleConfig{
+				"systemPromptAddendum":          "abcdefghij",
+				"systemPromptAddendumMaxLength": float64(5),
+			},
+			expectedAdapterNames:  nil,
+			expectedAvailAdapters: []model.AdapterParameters{},
+			expectedAddendum:      "abcde",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &server.Server{
+				Context: context.Background(),
+				Config: &config.ServerConfig{
+					ClientParams: model.ClientParameters{
+						AssistantParams: model.AssistantParameters{},
+					},
+				},
+			}
+
+			ac := NewAssistantCoordinator(srv)
+
+			err := ac.Init(tc.config)
+			assert.NoError(t, err)
+
+			// AssistantManager should be set to the coordinator.
+			assert.Equal(t, ac, srv.AssistantManager)
+
+			// Verify loaded adapters map.
+			if tc.expectedAdapterNames == nil {
+				assert.Empty(t, ac.adapters)
+			} else {
+				assert.Len(t, ac.adapters, len(tc.expectedAdapterNames))
+				for _, name := range tc.expectedAdapterNames {
+					assert.Contains(t, ac.adapters, name)
+				}
+			}
+
+			// Verify AvailableAdapters on server config.
+			assert.Equal(t, tc.expectedAvailAdapters, srv.Config.ClientParams.AssistantParams.AvailableAdapters)
+
+			// Verify systemPromptAddendum.
+			assert.Equal(t, tc.expectedAddendum, ac.systemPromptAddendum)
+		})
+	}
+}
+
 // Helper types and functions for testing
+
+type mockAdapter struct {
+	protocol string
+}
+
+func (m *mockAdapter) Protocol() string { return m.protocol }
+func (m *mockAdapter) SendMessage(context.Context, *model.ChatRequest) (*model.Message, error) {
+	return nil, nil
+}
+func (m *mockAdapter) SendMessageStream(context.Context, *model.ChatRequest) (*http.Response, *model.AuxMessageData, error) {
+	return nil, nil, nil
+}
+func (m *mockAdapter) GetBalance(context.Context) (*model.BalanceResponse, error) { return nil, nil }
+func (m *mockAdapter) GetHealth(context.Context) (*model.HealthResponse, error)   { return nil, nil }
 
 type mockTool struct {
 	name        string


### PR DESCRIPTION
To better support showing the remaining credits on the assistant screen only for SOAI, we're now passing back a list of configured adapters, name and protocol only (no API key leak).

The UI now uses this array to decide when to show the number of remaining credits: if the model uses an adapter that uses the `securityonion_ai_cloud` protocol, regardless what the name of the adapter is.

Added tests.