### PR TITLE
Cogburn/query name

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -903,6 +903,7 @@ const i18n = {
       queryCancelConfirmText: 'Canceling active queries should be avoided in most situations due to the risk of affecting the various components that interact with Elasticsearch. Would you like to continue anyway?',
       queryCanceled: 'The query cancelation has been submitted. Refresh the query list for updated results.',
       queryHelp: 'Specify a query in Onion Query Language (OQL)',
+      queryName: 'Query Name',
       quickActions: 'Actions',
       quickDrilldown: 'Quick Drilldown',
       rawToolResult: 'Raw Tool Result',

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -58,9 +58,9 @@
 				<v-col style="flex: 1 1 auto; min-width: 0;" class="pa-0">
 					<v-toolbar class="so-toolbar elevation-0" variant="flat">
 						<v-textarea :clearable="isAdvanced()" :auto-grow="isAdvanced()" :readonly="!isAdvanced()" :disabled="loading()" @input="queryAltered = true"
-							@change="queryModified" class="mx-2" v-model="$data[getDisplayedQueryVar()]" persistent-hint :hint="isAdvanced() ? (queryAltered ? i18n.queryHelp : $data['queryName']) : ''"
+							@change="queryModified" class="mx-2" v-model="$data[getDisplayedQueryVar()]" :hint="isAdvanced() && queryAltered ? i18n.queryHelp : ''"
 							rows="1" prepend-icon="fa-search" @keydown.enter.prevent="submitQuery" id="hunt-query-input" ref="huntQueryInput" :data-aid="'query_input_' + category"
-							no-resize :hide-details="isCategory('alerts') || isCategory('cases')">
+							no-resize hide-details>
 							<template #prepend-inner>
 								<v-menu density="compact" @update:model-value="saveMenuScrollPos($event, '#hunt-query-dropdown-list')">
 									<template #activator="{ props: menuProps }">
@@ -179,6 +179,15 @@
 							<div class="so-stat-value">{{ totalEvents.toLocaleString() }}</div>
 						</div>
 						<v-icon class="so-stat-icon">fa-circle-check</v-icon>
+					</div>
+				</v-col>
+				<v-col v-if="isCategory('hunt') || isCategory('dashboards')">
+					<div class="so-stat-pill" data-aid="stat_total_alerts">
+						<div class="so-stat-text">
+							<div class="so-stat-label">{{ i18n.queryName }}</div>
+							<div class="so-stat-value">{{ queryName }}</div>
+						</div>
+						<v-icon class="so-stat-icon">fa-clipboard-question</v-icon>
 					</div>
 				</v-col>
 				<v-col v-if="isCategory('alerts')">

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -58,9 +58,9 @@
 				<v-col style="flex: 1 1 auto; min-width: 0;" class="pa-0">
 					<v-toolbar class="so-toolbar elevation-0" variant="flat">
 						<v-textarea :clearable="isAdvanced()" :auto-grow="isAdvanced()" :readonly="!isAdvanced()" :disabled="loading()" @input="queryAltered = true"
-							@change="queryModified" class="mx-2" v-model="$data[getDisplayedQueryVar()]" :hint="isAdvanced() ? (queryAltered ? i18n.queryHelp : $data['queryName']) : ''"
+							@change="queryModified" class="mx-2" v-model="$data[getDisplayedQueryVar()]" persistent-hint :hint="isAdvanced() ? (queryAltered ? i18n.queryHelp : $data['queryName']) : ''"
 							rows="1" prepend-icon="fa-search" @keydown.enter.prevent="submitQuery" id="hunt-query-input" ref="huntQueryInput" :data-aid="'query_input_' + category"
-							no-resize hide-details>
+							no-resize :hide-details="isCategory('alerts') || isCategory('cases')">
 							<template #prepend-inner>
 								<v-menu density="compact" @update:model-value="saveMenuScrollPos($event, '#hunt-query-dropdown-list')">
 									<template #activator="{ props: menuProps }">


### PR DESCRIPTION
## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

In the update to 3.0, we lost the label for the named query that was last run on the Hunt and Dashboards pages. This adds them back as stat pills like the Total Found stat.

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->

I tried adding the title as a hint on the search box but it added a lot of whitespace to the screen. The pill seemed like a better use of space.