### PR TITLE
Assistant: Query Length Limiting

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -183,6 +183,7 @@ const i18n = {
       assistantLoadContextError: 'Failed to load context theshold setting',
       assistantLoadRecentError: 'Failed to load restore last active setting',
       assistantLoadReadApprovalError: 'Failed to load read request approval setting',
+      assistantMessageTooLong: 'Message is too long. Please shorten your message, compress the context, or start a new chat.',
       assistantNoHistoryFound: 'No chat history found for session',
       assistantNoRawToolResult: 'Could not capture raw tool result',
       assistantNoResponse: 'Failed to get AI response',

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -1262,6 +1262,7 @@ const i18n = {
 
       WARN_STATUS_EFFECTED_BY_FILTER: 'Saved successfully but the status of this detection is controlled by the current regex filter settings and was reverted. <a href="/#/config?s=soc.config.server.modules.suricataengine" data-aid="warning_update_configure_filters">Click here to configure those filters.</a>',
 
+      ERROR_ASSISTANT_REQUEST_TOO_LARGE: 'The request is too large for the current session and model. Please shorten your message, compress the context, or start a new chat.',
       ERROR_CASE_EVENT_ALREADY_ATTACHED: 'The event is already attached to the selected case.',
       ERROR_CASE_MODULE_NOT_ENABLED: 'A case module has not been configured for this installation. Unable to proceed with request.',
       ERROR_JINJA_NOT_SUPPORTED: 'For security reasons Jinja syntax cannot be specified in configuration values.',

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -42,6 +42,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     contextStartMessageIndex: -1,
     contextLimitSmall: 0,
     contextLimitLarge: 0,
+    charsPerTokenEstimate: 0,
     thresholdColorRatioLow: 0.5,
     thresholdColorRatioMed: 0.75,
     thresholdColorRatioMax: 1,
@@ -92,7 +93,14 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
     messageContextValues() {
       const msgs = this.messages || [];
       return msgs.map((_, i) => this.calculateContextOfMessage(msgs, i));
-    }
+    },
+    isMessageTooLong() {
+      if (!this.charsPerTokenEstimate || !this.newMessage) return false;
+      const contextLimit = this.increaseContextLimit ? this.contextLimitLarge : this.contextLimitSmall;
+      const maxChars = contextLimit * this.charsPerTokenEstimate * 1.1;
+      const usedChars = this.newMessage.length + (this.contextLength * this.charsPerTokenEstimate);
+      return usedChars >= maxChars;
+    },
   },
   methods: {
 
@@ -171,7 +179,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       }
       return false;
     },
-    
+
     async loadNewChatScreen() {
       try {
         // Initialize with a welcome message from the AI Assistant
@@ -406,8 +414,11 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
         return;
       }
 
+      const isCompressing = tags && tags.includes(MSGTAG_CONTEXTCOMPRESSION);
+      // Check if message + context exceeds estimated token limit
+      if (!isCompressing && this.isMessageTooLong) return;
       // Check if context length has reached the limit
-      if (this.checkContextLimitReached() && (!tags || !tags.includes(MSGTAG_CONTEXTCOMPRESSION))) return;
+      if (!isCompressing && this.checkContextLimitReached()) return;
       
       // Check if user has credits
       if (this.creditsRemaining <= 0) {
@@ -1905,6 +1916,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       if (!this.currentModel || this.modelsMap.size == 0) return;
       this.contextLimitSmall = this.modelsMap.get(this.currentModel).contextLimitSmall;
       this.contextLimitLarge = this.modelsMap.get(this.currentModel).contextLimitLarge;
+      this.charsPerTokenEstimate = this.modelsMap.get(this.currentModel).charsPerTokenEstimate;
       this.lowBalanceColorAlert = this.modelsMap.get(this.currentModel).lowBalanceColorAlert;
     },
 

--- a/html/js/routes/assistant.js
+++ b/html/js/routes/assistant.js
@@ -95,7 +95,7 @@ routes.push({ path: '/assistant/:sessionId?', name: 'assistant', component: {
       return msgs.map((_, i) => this.calculateContextOfMessage(msgs, i));
     },
     isMessageTooLong() {
-      if (!this.charsPerTokenEstimate || !this.newMessage) return false;
+      if (this.charsPerTokenEstimate <= 0 || !this.newMessage) return false;
       const contextLimit = this.increaseContextLimit ? this.contextLimitLarge : this.contextLimitSmall;
       const maxChars = contextLimit * this.charsPerTokenEstimate * 1.1;
       const usedChars = this.newMessage.length + (this.contextLength * this.charsPerTokenEstimate);

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -700,6 +700,7 @@ test('sendMessage with insufficient credits', async () => {
   comp.creditsRemaining = 0;
   comp.assistantEnabled = true;
   comp.canChat = true;
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   
   await comp.sendMessage();
@@ -729,10 +730,12 @@ test('sendMessage creates session ID and updates URL', async () => {
   comp.scrollToBottom = jest.fn();
   comp.assistantEnabled = true;
   comp.canChat = true;
+  comp.isMessageTooLong = false;
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
-  
+
   await comp.sendMessage();
-  
+
   expect(comp.generateChatId).toHaveBeenCalled();
   expect(comp.currentChatId).toBe(fakeSessionId);
   expect(comp.saveCurrentChatId).toHaveBeenCalled();
@@ -926,6 +929,7 @@ test('approveTool queues tool for execution', async () => {
   const toolUse = { ...fakeToolUse };
   comp.queueTool = jest.fn();
   comp.scrollToBottom = jest.fn();
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   comp.mostRecentFloatingTool = new Map();
   comp.mostRecentFloatingTool.set(comp.currentChatId, toolUse);
@@ -945,6 +949,7 @@ test('approveTool handles execution error', async () => {
     throw new Error('Execution failed');
   });
   comp.scrollToBottom = jest.fn();
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   comp.mostRecentFloatingTool = new Map();
   
@@ -958,6 +963,7 @@ test('rejectTool marks as rejected', async () => {
   const toolUse = { ...fakeToolUse };
   comp.scrollToBottom = jest.fn();
   comp.callAIAPI = jest.fn().mockResolvedValue();
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   
   await comp.rejectTool(toolUse);
@@ -4471,6 +4477,7 @@ test('sendMessage checks context limit before proceeding', async () => {
   comp.canChat = true;
   comp.assistantEnabled = true;
   comp.creditsRemaining = 100;
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(true);
   comp.callAIAPI = jest.fn();
   
@@ -4485,12 +4492,13 @@ test('sendMessage checks context limit before proceeding, but allows context_com
   comp.canChat = true;
   comp.assistantEnabled = true;
   comp.creditsRemaining = 100;
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(true);
   comp.callAIAPI = jest.fn();
   
   await comp.sendMessage([MSGTAG_CONTEXTCOMPRESSION]);
-  
-  expect(comp.checkContextLimitReached).toHaveBeenCalled();
+
+  expect(comp.checkContextLimitReached).not.toHaveBeenCalled();
   expect(comp.callAIAPI).toHaveBeenCalled();
   expect(comp.callAIAPI).toHaveBeenCalledWith('Summarize the conversation so far for context preservation', [MSGTAG_CONTEXTCOMPRESSION]);
 });
@@ -4510,6 +4518,7 @@ test('sendMessage clears welcome message when starting first real conversation',
   comp.callAIAPI = jest.fn().mockResolvedValue();
   comp.loadStoredChats = jest.fn().mockResolvedValue();
   comp.scrollToBottom = jest.fn();
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   
   await comp.sendMessage();
@@ -4670,6 +4679,7 @@ test('handleContentBlockStop processes tool completion with auto-approval', () =
   comp.getSessionToolMap = jest.fn().mockReturnValue(mockToolMap);
   comp.getIndexMap = jest.fn().mockReturnValue(mockIndexMap);
   comp.shouldAutoApproveTool = jest.fn().mockReturnValue(true);
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   comp.queueTool = jest.fn();
   
@@ -4755,6 +4765,7 @@ test('handleToolExecutionContentBlockStop processes chained tool with auto-appro
   comp.getSessionToolMap = jest.fn().mockReturnValue(mockToolMap);
   comp.getIndexMap = jest.fn().mockReturnValue(mockIndexMap);
   comp.shouldAutoApproveTool = jest.fn().mockReturnValue(true);
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   comp.queueTool = jest.fn();
   
@@ -5174,6 +5185,7 @@ test('sendMessage marks floating tool as skipped when sending new message', asyn
   comp.canChat = true;
   comp.assistantEnabled = true;
   comp.creditsRemaining = 100;
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   comp.callAIAPI = jest.fn().mockResolvedValue();
   comp.loadStoredChats = jest.fn().mockResolvedValue();
@@ -5201,6 +5213,7 @@ test('sendMessage does not mark floating tool as skipped when only welcome messa
   comp.canChat = true;
   comp.assistantEnabled = true;
   comp.creditsRemaining = 100;
+  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
   comp.callAIAPI = jest.fn().mockResolvedValue();
   comp.loadStoredChats = jest.fn().mockResolvedValue();
@@ -5641,6 +5654,78 @@ test('messageContextValues handles null messages', () => {
   const result = comp.messageContextValues();
 
   expect(result).toEqual([]);
+});
+
+// isMessageTooLong computed property tests
+test('isMessageTooLong returns false when charsPerTokenEstimate is 0', () => {
+  comp.charsPerTokenEstimate = 0;
+  comp.newMessage = 'Hello';
+  comp.contextLength = 0;
+  comp.contextLimitSmall = 1000;
+
+  expect(comp.isMessageTooLong()).toBe(false);
+});
+
+test('isMessageTooLong returns false when newMessage is empty', () => {
+  comp.charsPerTokenEstimate = 3.6;
+  comp.newMessage = '';
+  comp.contextLength = 0;
+  comp.contextLimitSmall = 1000;
+
+  expect(comp.isMessageTooLong()).toBe(false);
+});
+
+test('isMessageTooLong returns false when within limit', () => {
+  comp.charsPerTokenEstimate = 4;
+  comp.newMessage = 'Short message';
+  comp.contextLength = 0;
+  comp.increaseContextLimit = false;
+  comp.contextLimitSmall = 1000;
+
+  // maxChars = 1000 * 4 * 1.1 = 4400
+  // usedChars = 13 + 0 = 13
+  expect(comp.isMessageTooLong()).toBe(false);
+});
+
+test('isMessageTooLong returns true when message exceeds limit', () => {
+  comp.charsPerTokenEstimate = 4;
+  comp.newMessage = 'a'.repeat(4400);
+  comp.contextLength = 0;
+  comp.increaseContextLimit = false;
+  comp.contextLimitSmall = 1000;
+
+  // maxChars = 1000 * 4 * 1.1 = 4400
+  // usedChars = 4400 + 0 = 4400
+  expect(comp.isMessageTooLong()).toBe(true);
+});
+
+test('isMessageTooLong accounts for context length', () => {
+  comp.charsPerTokenEstimate = 4;
+  comp.newMessage = 'Hello';
+  comp.contextLength = 1000;
+  comp.increaseContextLimit = false;
+  comp.contextLimitSmall = 1000;
+
+  // maxChars = 1000 * 4 * 1.1 = 4400
+  // usedChars = 5 + (1000 * 4) = 4005
+  expect(comp.isMessageTooLong()).toBe(false);
+
+  comp.contextLength = 1100;
+  // usedChars = 5 + (1100 * 4) = 4405
+  expect(comp.isMessageTooLong()).toBe(true);
+});
+
+test('isMessageTooLong uses large context limit when toggled', () => {
+  comp.charsPerTokenEstimate = 4;
+  comp.newMessage = 'a'.repeat(4400);
+  comp.contextLength = 0;
+  comp.increaseContextLimit = true;
+  comp.contextLimitSmall = 1000;
+  comp.contextLimitLarge = 2000;
+
+  // maxChars = 2000 * 4 * 1.1 = 8800
+  // usedChars = 4400
+  expect(comp.isMessageTooLong()).toBe(false);
 });
 
 test('buildModelIdentifier', () => {

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -731,7 +731,6 @@ test('sendMessage creates session ID and updates URL', async () => {
   comp.assistantEnabled = true;
   comp.canChat = true;
   comp.isMessageTooLong = false;
-  comp.isMessageTooLong = false;
   comp.checkContextLimitReached = jest.fn().mockReturnValue(false);
 
   await comp.sendMessage();

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -362,7 +362,10 @@
 						:placeholder="i18n.chatPlaceholder"
 						variant="outlined"
 						density="compact"
-						hide-details
+						:hide-details="!isMessageTooLong"
+						:hint="isMessageTooLong ? i18n.assistantMessageTooLong : ''"
+						:persistent-hint="isMessageTooLong"
+						:error="isMessageTooLong"
 						auto-grow
 						rows="1"
 						max-rows="8"
@@ -376,7 +379,7 @@
 					<v-btn
 						id="chat-send-button"
 						ref="sendButton"
-						:disabled="!newMessage.trim() || !canChat || checkForActivity() || !creditsLoaded"
+						:disabled="!newMessage.trim() || !canChat || checkForActivity() || !creditsLoaded || isMessageTooLong"
 						@click="sendMessage()"
 						data-aid="assistant_chat_send"
 						class="flex-shrink-0"

--- a/model/clientparameters.go
+++ b/model/clientparameters.go
@@ -191,14 +191,15 @@ type AssistantParameters struct {
 }
 
 type ModelParameters struct {
-	ID                   string `json:"id"`
-	DisplayName          string `json:"displayName"`
-	ContextLimitSmall    int    `json:"contextLimitSmall"`
-	ContextLimitLarge    int    `json:"contextLimitLarge"`
-	LowBalanceColorAlert int    `json:"lowBalanceColorAlert"`
-	Origin               string `json:"origin"`
-	Adapter              string `json:"adapter"`
-	Enabled              bool   `json:"enabled"`
+	ID                    string  `json:"id"`
+	DisplayName           string  `json:"displayName"`
+	ContextLimitSmall     int     `json:"contextLimitSmall"`
+	ContextLimitLarge     int     `json:"contextLimitLarge"`
+	CharsPerTokenEstimate float64 `json:"charsPerTokenEstimate"`
+	LowBalanceColorAlert  int     `json:"lowBalanceColorAlert"`
+	Origin                string  `json:"origin"`
+	Adapter               string  `json:"adapter"`
+	Enabled               bool    `json:"enabled"`
 }
 
 type AdapterParameters struct {

--- a/model/clientparameters_test.go
+++ b/model/clientparameters_test.go
@@ -114,14 +114,16 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 				"displayName": "Normal",
 				"contextLimitSmall": 512,
 				"contextLimitLarge": 2048,
+				"charsPerTokenEstimate": 3.6,
 				"lowBalanceColorAlert": 7
 			}`,
 			want: ModelParameters{
-				ID:                   "abc",
-				DisplayName:          "Normal",
-				ContextLimitSmall:    512,
-				ContextLimitLarge:    2048,
-				LowBalanceColorAlert: 7,
+				ID:                    "abc",
+				DisplayName:           "Normal",
+				ContextLimitSmall:     512,
+				ContextLimitLarge:     2048,
+				CharsPerTokenEstimate: 3.6,
+				LowBalanceColorAlert:  7,
 			},
 		},
 		{
@@ -192,11 +194,12 @@ func TestModelParameters_UnmarshalJSON(t *testing.T) {
 				"displayName": "Missing Fields"
 			}`,
 			want: ModelParameters{
-				ID:                   "missing",
-				DisplayName:          "Missing Fields",
-				ContextLimitSmall:    0,
-				ContextLimitLarge:    0,
-				LowBalanceColorAlert: 0,
+				ID:                    "missing",
+				DisplayName:           "Missing Fields",
+				ContextLimitSmall:     0,
+				ContextLimitLarge:     0,
+				CharsPerTokenEstimate: 0,
+				LowBalanceColorAlert:  0,
 			},
 		},
 		{

--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -142,38 +142,9 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(history) == 0 {
-		// create new session
-		session := &model.AssistantSession{
-			SessionId: incMsg.SessionId,
-			Title:     incMsg.Msg,
-		}
-
-		// If entityType and entityId are provided, set them on the session
-		if entityType != "" && entityId != "" {
-			session.Type = entityType
-			session.EntityId = entityId
-		}
-
-		err = h.server.Assistantstore.CreateSession(ctx, session)
-		if err != nil {
-			logger.WithError(err).Error("unable to create session")
-			web.Respond(w, r, http.StatusInternalServerError, err)
-
-			return
-		}
-	}
+	isNewSession := len(history) == 0
 
 	messages := historyToContext(history)
-
-	err = h.server.Assistantstore.SaveChat(ctx, newMsg.PrepareForStorage(incMsg.SessionId, incMsg.Tags, incMsg.Model))
-	if err != nil {
-		logger.WithError(err).Error("unable to save chat message")
-		web.Respond(w, r, http.StatusInternalServerError, err)
-
-		return
-	}
-
 	messages = append(messages, newMsg)
 
 	_, ok := w.(http.Flusher)
@@ -185,7 +156,36 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 		response, err := h.server.AssistantManager.Chat(ctx, incMsg.Model, messages)
 		if err != nil {
 			logger.WithError(err).Error("unable to chat with assistant")
-			web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+			if err.Error() == "ERROR_ASSISTANT_REQUEST_TOO_LARGE" {
+				web.Respond(w, r, http.StatusBadRequest, err.Error())
+			} else {
+				web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+			}
+
+			return
+		}
+
+		if isNewSession {
+			session := &model.AssistantSession{
+				SessionId: incMsg.SessionId,
+				Title:     incMsg.Msg,
+			}
+			if entityType != "" && entityId != "" {
+				session.Type = entityType
+				session.EntityId = entityId
+			}
+			err = h.server.Assistantstore.CreateSession(ctx, session)
+			if err != nil {
+				logger.WithError(err).Error("unable to create session for non-streaming chat")
+				web.Respond(w, r, http.StatusInternalServerError, err)
+				return
+			}
+		}
+
+		err = h.server.Assistantstore.SaveChat(ctx, newMsg.PrepareForStorage(incMsg.SessionId, incMsg.Tags, incMsg.Model))
+		if err != nil {
+			logger.WithError(err).Error("unable to save user message for non-streaming chat")
+			web.Respond(w, r, http.StatusInternalServerError, err)
 
 			return
 		}
@@ -193,7 +193,7 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 		for _, msg := range response {
 			err = h.server.Assistantstore.SaveChat(ctx, msg.PrepareForStorage(incMsg.SessionId, nil, incMsg.Model))
 			if err != nil {
-				logger.WithError(err).Error("unable to save chat message")
+				logger.WithError(err).Error("unable to save assistant response (non-streaming)")
 				return
 			}
 		}
@@ -215,7 +215,36 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 	response, aux, err := h.server.AssistantManager.ChatStream(noTimeOutCtx, incMsg.Model, messages)
 	if err != nil {
 		logger.WithError(err).Error("unable to chat (stream) with assistant")
-		web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+		if err.Error() == "ERROR_ASSISTANT_REQUEST_TOO_LARGE" {
+			web.Respond(w, r, http.StatusBadRequest, err.Error())
+		} else {
+			web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+		}
+
+		return
+	}
+
+	if isNewSession {
+		session := &model.AssistantSession{
+			SessionId: incMsg.SessionId,
+			Title:     incMsg.Msg,
+		}
+		if entityType != "" && entityId != "" {
+			session.Type = entityType
+			session.EntityId = entityId
+		}
+		err = h.server.Assistantstore.CreateSession(noTimeOutCtx, session)
+		if err != nil {
+			logger.WithError(err).Error("unable to create session for streaming chat")
+			web.Respond(w, r, http.StatusInternalServerError, err)
+			return
+		}
+	}
+
+	err = h.server.Assistantstore.SaveChat(noTimeOutCtx, newMsg.PrepareForStorage(incMsg.SessionId, incMsg.Tags, incMsg.Model))
+	if err != nil {
+		logger.WithError(err).Error("unable to save user message before streaming response")
+		web.Respond(w, r, http.StatusInternalServerError, err)
 
 		return
 	}
@@ -332,14 +361,6 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	err = h.server.Assistantstore.SaveChat(ctx, toolMsg.PrepareForStorage(toolReq.SessionId, []string{"tool_result"}, toolReq.Model))
-	if err != nil {
-		logger.WithError(err).Error("unable to save tool result message")
-		web.Respond(w, r, http.StatusInternalServerError, err)
-
-		return
-	}
-
 	history, err := h.server.Assistantstore.GetChatHistory(ctx, toolReq.SessionId)
 	if err != nil {
 		logger.WithError(err).Error("unable to get chat history")
@@ -349,12 +370,25 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 	}
 
 	messages := historyToContext(history)
+	messages = append(messages, toolMsg)
 
 	if !streaming {
 		response, err := h.server.AssistantManager.Chat(ctx, toolReq.Model, messages)
 		if err != nil {
 			logger.WithError(err).Error("unable to chat with assistant after tool execution")
-			web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+			if err.Error() == "ERROR_ASSISTANT_REQUEST_TOO_LARGE" {
+				web.Respond(w, r, http.StatusBadRequest, err.Error())
+			} else {
+				web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+			}
+
+			return
+		}
+
+		err = h.server.Assistantstore.SaveChat(ctx, toolMsg.PrepareForStorage(toolReq.SessionId, []string{"tool_result"}, toolReq.Model))
+		if err != nil {
+			logger.WithError(err).Error("unable to save tool result message for non-streaming chat")
+			web.Respond(w, r, http.StatusInternalServerError, err)
 
 			return
 		}
@@ -364,7 +398,7 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 		for _, msg := range response {
 			err = h.server.Assistantstore.SaveChat(ctx, msg.PrepareForStorage(toolReq.SessionId, nil, toolReq.Model))
 			if err != nil {
-				logger.WithError(err).Error("unable to save tool result response message")
+				logger.WithError(err).Error("unable to save tool result response message (non-streaming)")
 				return
 			}
 		}
@@ -375,7 +409,19 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 	response, aux, err := h.server.AssistantManager.ChatStream(ctx, toolReq.Model, messages)
 	if err != nil {
 		logger.WithError(err).Error("unable to chat (stream) with assistant after tool execution")
-		web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+		if err.Error() == "ERROR_ASSISTANT_REQUEST_TOO_LARGE" {
+			web.Respond(w, r, http.StatusBadRequest, err.Error())
+		} else {
+			web.Respond(w, r, http.StatusInternalServerError, "ERROR_UPSTREAM_SERVICE_ERROR")
+		}
+
+		return
+	}
+
+	err = h.server.Assistantstore.SaveChat(ctx, toolMsg.PrepareForStorage(toolReq.SessionId, []string{"tool_result"}, toolReq.Model))
+	if err != nil {
+		logger.WithError(err).Error("unable to save tool result message before streaming response")
+		web.Respond(w, r, http.StatusInternalServerError, err)
 
 		return
 	}

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -320,21 +320,7 @@ func TestPostTool(t *testing.T) {
 	}
 	mockManager.EXPECT().ExecuteTool(gomock.Any(), "query_events", `{"query":"test query"}`, "").Return(mockToolResponse, nil)
 
-	// Mock saving the tool result message
-	mockAssistantStore.EXPECT().SaveChat(gomock.Any(), gomock.Any()).Do(
-		func(ctx context.Context, msg *model.StoredMessage) {
-			assert.Equal(t, sessionId, msg.SessionId)
-			assert.Equal(t, []string{"tool_result"}, msg.Tags)
-			assert.Equal(t, "user", msg.Message.Role)
-			assert.Len(t, msg.Message.ContentBlocks, 1)
-			assert.NotNil(t, msg.Message.ContentBlocks[0].ToolResult)
-			assert.Equal(t, "tooluse_test_123", msg.Message.ContentBlocks[0].ToolResult.ToolUseId)
-			assert.False(t, msg.Message.ContentBlocks[0].ToolResult.IsError)
-			assert.Equal(t, map[string]any{"result": mockToolResponse.Result}, msg.Message.ContentBlocks[0].ToolResult.Content[0].Json)
-		},
-	).Return(nil)
-
-	// Mock the history lookup to return previous messages including the new tool result
+	// Mock the history lookup to return previous messages (tool result not yet saved)
 	mockHistoryMessages := []*model.StoredMessage{
 		{
 			SessionId: sessionId,
@@ -344,26 +330,6 @@ func TestPostTool(t *testing.T) {
 					{
 						Type: "text",
 						Text: "Get me some events",
-					},
-				},
-			},
-		},
-		{
-			SessionId: sessionId,
-			Message: &model.Message{
-				Role: "user",
-				ContentBlocks: []model.ContentBlock{
-					{
-						Type: "tool_result",
-						ToolResult: &model.ToolResult{
-							ToolUseId: toolUseId,
-							Content: []model.ToolResultContent{
-								{
-									Json: map[string]any{"result": mockToolResponse.Result},
-								},
-							},
-							IsError: false,
-						},
 					},
 				},
 			},
@@ -387,6 +353,20 @@ func TestPostTool(t *testing.T) {
 			}}, nil
 		},
 	)
+
+	// Mock saving the tool result message (saved after successful chat)
+	mockAssistantStore.EXPECT().SaveChat(gomock.Any(), gomock.Any()).Do(
+		func(ctx context.Context, msg *model.StoredMessage) {
+			assert.Equal(t, sessionId, msg.SessionId)
+			assert.Equal(t, []string{"tool_result"}, msg.Tags)
+			assert.Equal(t, "user", msg.Message.Role)
+			assert.Len(t, msg.Message.ContentBlocks, 1)
+			assert.NotNil(t, msg.Message.ContentBlocks[0].ToolResult)
+			assert.Equal(t, "tooluse_test_123", msg.Message.ContentBlocks[0].ToolResult.ToolUseId)
+			assert.False(t, msg.Message.ContentBlocks[0].ToolResult.IsError)
+			assert.Equal(t, map[string]any{"result": mockToolResponse.Result}, msg.Message.ContentBlocks[0].ToolResult.Content[0].Json)
+		},
+	).Return(nil)
 
 	// Mock saving the assistant response
 	mockAssistantStore.EXPECT().SaveChat(gomock.Any(), gomock.Any()).Do(

--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -36,7 +36,8 @@ type ProtocolConstructor func(context.Context, *server.Server, map[string]any) (
 var protocols = map[string]ProtocolConstructor{}
 
 var (
-	ErrToolNotFound = errors.New("ERROR_ASSISTANT_TOOL_NOT_FOUND")
+	ErrToolNotFound    = errors.New("ERROR_ASSISTANT_TOOL_NOT_FOUND")
+	ErrRequestTooLarge = errors.New("ERROR_ASSISTANT_REQUEST_TOO_LARGE")
 )
 
 const (
@@ -259,6 +260,53 @@ func splitModelAdapter(aiModel string) (string, string) {
 	return parts[0], parts[1]
 }
 
+func estimateRequestChars(req *model.ChatRequest) int {
+	total := len(req.System) + len(req.SystemAppend) + len(req.ToolConfig)
+	for _, msg := range req.Messages {
+		total += len(msg.ContentStr)
+		for _, block := range msg.ContentBlocks {
+			total += len(block.Text) + len(block.Input)
+			if block.ToolResult != nil {
+				for _, c := range block.ToolResult.Content {
+					total += len(c.Text)
+				}
+			}
+		}
+	}
+	return total
+}
+
+func (ac *AssistantCoordinator) findModelParams(modelId string, adapterName string) *model.ModelParameters {
+	for _, m := range ac.srv.Config.ClientParams.AssistantParams.AvailableModels {
+		if m.ID == modelId && m.Adapter == adapterName {
+			return &m
+		}
+	}
+	return nil
+}
+
+func (ac *AssistantCoordinator) checkRequestSize(req *model.ChatRequest, modelId string, adapterName string) error {
+	params := ac.findModelParams(modelId, adapterName)
+	if params == nil || params.CharsPerTokenEstimate <= 0 {
+		return nil
+	}
+
+	contextLimit := params.ContextLimitLarge
+	if contextLimit <= 0 {
+		contextLimit = params.ContextLimitSmall
+	}
+	if contextLimit <= 0 {
+		return nil
+	}
+
+	maxChars := float64(contextLimit) * params.CharsPerTokenEstimate * 1.1
+	usedChars := float64(estimateRequestChars(req))
+	if usedChars >= maxChars {
+		return ErrRequestTooLarge
+	}
+	return nil
+}
+
 func (ac *AssistantCoordinator) Chat(ctx context.Context, aiModel string, messages []*model.Message, opts ...model.ChatOpt) ([]*model.Message, error) {
 	logger := log.FromContext(ctx)
 	userID := ctx.Value(web.ContextKeyRequestorId).(string)
@@ -275,6 +323,11 @@ func (ac *AssistantCoordinator) Chat(ctx context.Context, aiModel string, messag
 		Model:        modelId,
 		System:       ac.systemPrompt,
 		SystemAppend: ac.systemPromptAddendum,
+	}
+
+	if err := ac.checkRequestSize(req, modelId, adapterName); err != nil {
+		logger.WithFields(log.Fields{"modelId": modelId, "adapterName": adapterName, "estimatedChars": estimateRequestChars(req)}).Error("request exceeds estimated context limit")
+		return nil, err
 	}
 
 	adapter, ok := ac.adapters[adapterName]
@@ -374,6 +427,11 @@ func (ac *AssistantCoordinator) ChatStream(ctx context.Context, aiModel string, 
 		Model:        modelId,
 		System:       ac.systemPrompt,
 		SystemAppend: ac.systemPromptAddendum,
+	}
+
+	if err := ac.checkRequestSize(req, modelId, adapterName); err != nil {
+		logger.WithFields(log.Fields{"modelId": modelId, "adapterName": adapterName, "estimatedChars": estimateRequestChars(req)}).Error("request exceeds estimated context limit")
+		return nil, nil, err
 	}
 
 	adapter, ok := ac.adapters[adapterName]

--- a/server/modules/assistant/assistant_test.go
+++ b/server/modules/assistant/assistant_test.go
@@ -1134,3 +1134,182 @@ func (m *mockTool) Execute(ctx context.Context, srv *server.Server, params strin
 		Result:   "mock result",
 	}, nil
 }
+
+func TestEstimateRequestChars(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *model.ChatRequest
+		expected int
+	}{
+		{
+			name: "empty request",
+			req:  &model.ChatRequest{},
+			expected: 0,
+		},
+		{
+			name: "system prompt only",
+			req: &model.ChatRequest{
+				System:       "You are a helpful assistant.",
+				SystemAppend: "Additional context.",
+			},
+			expected: len("You are a helpful assistant.") + len("Additional context."),
+		},
+		{
+			name: "messages with text blocks",
+			req: &model.ChatRequest{
+				System: "System",
+				Messages: []*model.Message{
+					{
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Hello"},
+						},
+					},
+					{
+						ContentBlocks: []model.ContentBlock{
+							{Type: "text", Text: "Hi there!"},
+						},
+					},
+				},
+			},
+			expected: len("System") + len("Hello") + len("Hi there!"),
+		},
+		{
+			name: "message with content string",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{ContentStr: "Plain text message"},
+				},
+			},
+			expected: len("Plain text message"),
+		},
+		{
+			name: "message with tool result",
+			req: &model.ChatRequest{
+				Messages: []*model.Message{
+					{
+						ContentBlocks: []model.ContentBlock{
+							{
+								ToolResult: &model.ToolResult{
+									Content: []model.ToolResultContent{
+										{Text: "tool output data"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: len("tool output data"),
+		},
+		{
+			name: "tool config included",
+			req: &model.ChatRequest{
+				ToolConfig: json.RawMessage(`{"tools": [{"name": "query_events"}]}`),
+			},
+			expected: len(`{"tools": [{"name": "query_events"}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := estimateRequestChars(tc.req)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestCheckRequestSize(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *model.ChatRequest
+		models      []model.ModelParameters
+		modelId     string
+		adapterName string
+		expectError bool
+	}{
+		{
+			name:        "no model params found, skip check",
+			req:         &model.ChatRequest{System: strings.Repeat("a", 10000)},
+			models:      []model.ModelParameters{},
+			modelId:     "unknown",
+			adapterName: "SOAI",
+			expectError: false,
+		},
+		{
+			name: "charsPerTokenEstimate is zero, skip check",
+			req:  &model.ChatRequest{System: strings.Repeat("a", 10000)},
+			models: []model.ModelParameters{
+				{ID: "model1", Adapter: "SOAI", ContextLimitSmall: 1000, CharsPerTokenEstimate: 0},
+			},
+			modelId:     "model1",
+			adapterName: "SOAI",
+			expectError: false,
+		},
+		{
+			name: "within limit",
+			req:  &model.ChatRequest{System: strings.Repeat("a", 100)},
+			models: []model.ModelParameters{
+				{ID: "model1", Adapter: "SOAI", ContextLimitLarge: 1000, CharsPerTokenEstimate: 4.0},
+			},
+			modelId:     "model1",
+			adapterName: "SOAI",
+			// maxChars = 1000 * 4.0 * 1.1 = 4400, usedChars = 100
+			expectError: false,
+		},
+		{
+			name: "exceeds limit",
+			req:  &model.ChatRequest{System: strings.Repeat("a", 5000)},
+			models: []model.ModelParameters{
+				{ID: "model1", Adapter: "SOAI", ContextLimitLarge: 1000, CharsPerTokenEstimate: 4.0},
+			},
+			modelId:     "model1",
+			adapterName: "SOAI",
+			// maxChars = 1000 * 4.0 * 1.1 = 4400, usedChars = 5000
+			expectError: true,
+		},
+		{
+			name: "falls back to small context limit",
+			req:  &model.ChatRequest{System: strings.Repeat("a", 500)},
+			models: []model.ModelParameters{
+				{ID: "model1", Adapter: "SOAI", ContextLimitSmall: 100, CharsPerTokenEstimate: 4.0},
+			},
+			modelId:     "model1",
+			adapterName: "SOAI",
+			// maxChars = 100 * 4.0 * 1.1 = 440, usedChars = 500
+			expectError: true,
+		},
+		{
+			name: "context limits both zero, skip check",
+			req:  &model.ChatRequest{System: strings.Repeat("a", 10000)},
+			models: []model.ModelParameters{
+				{ID: "model1", Adapter: "SOAI", CharsPerTokenEstimate: 4.0},
+			},
+			modelId:     "model1",
+			adapterName: "SOAI",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ac := &AssistantCoordinator{
+				srv: &server.Server{
+					Config: &config.ServerConfig{
+						ClientParams: model.ClientParameters{
+							AssistantParams: model.AssistantParameters{
+								AvailableModels: tc.models,
+							},
+						},
+					},
+				},
+			}
+
+			err := ac.checkRequestSize(tc.req, tc.modelId, tc.adapterName)
+			if tc.expectError {
+				assert.ErrorIs(t, err, ErrRequestTooLarge)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

- We now prevent excessive OnionAI query length in both the frontend and backend, based on a configurable per-model characters-per-token estimate (`charsPerTokenEstimate`).
- The frontend check compares the maximum context against the current context + message length. The input field turns red and shows a hint when the user types in too much.

<img width="829" height="198" alt="image" src="https://github.com/user-attachments/assets/d9429780-f525-4632-bd1c-d7f018983ffb" />

- The backend check combines the system prompt, addendum prompt, tool responses, message history, and new message, and compares this result to the maximum context. When this check fails, the user sees an error banner.

<img width="557" height="151" alt="image" src="https://github.com/user-attachments/assets/3be2520b-3672-4bdf-adbb-ad2f3bef8a06" />

- Additionally, both checks first add a 10% buffer to the maximum context.

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments