### PR TITLE
Fix postgres connection string for special characters

### DIFF
--- a/server/modules/postgres/postgres.go
+++ b/server/modules/postgres/postgres.go
@@ -46,8 +46,8 @@ func (pg *Postgres) Init(cfg module.ModuleConfig) error {
 	sslMode := module.GetStringDefault(cfg, "sslMode", "require")
 	assistantEnabled := module.GetBoolDefault(cfg, "assistantEnabled", true)
 
-	connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		username, password, host, port, dbname, sslMode)
+	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		host, port, username, password, dbname, sslMode)
 
 	poolConfig, err := pgxpool.ParseConfig(connStr)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Use key-value connection string format instead of URI format to handle special characters in generated passwords

## Test plan
- [ ] SOC connects to postgres with a password containing `@?#:/` characters