### PR TITLE
Defer postgres Assistantstore wiring to Start()

### DIFF
--- a/server/modules/postgres/postgres.go
+++ b/server/modules/postgres/postgres.go
@@ -23,6 +23,7 @@ type Postgres struct {
 	pool             *pgxpool.Pool
 	running          bool
 	assistantEnabled bool
+	esMigrationCfg   *esMigrationConfig
 }
 
 func NewPostgres(srv *server.Server) *Postgres {
@@ -103,6 +104,22 @@ func (pg *Postgres) Init(cfg module.ModuleConfig) error {
 
 	pg.assistantEnabled = assistantEnabled
 
+	// Capture elasticsearch config for migration (queries ES directly via HTTP,
+	// bypassing the Assistantstore interface which requires a user context for RBAC)
+	esHostUrl := module.GetStringDefault(cfg, "esHostUrl", "")
+	esUsername := module.GetStringDefault(cfg, "esUsername", "")
+	esPassword := module.GetStringDefault(cfg, "esPassword", "")
+	if esHostUrl != "" {
+		pg.esMigrationCfg = &esMigrationConfig{
+			HostUrl:      esHostUrl,
+			Username:     esUsername,
+			Password:     esPassword,
+			ChatIndex:    module.GetStringDefault(cfg, "esChatIndex", "*:so-assistant-chat"),
+			SessionIndex: module.GetStringDefault(cfg, "esSessionIndex", "*:so-assistant-session"),
+			SchemaPrefix: module.GetStringDefault(cfg, "esSchemaPrefix", "so_"),
+		}
+	}
+
 	return nil
 }
 
@@ -110,21 +127,16 @@ func (pg *Postgres) Start() error {
 	pg.running = true
 
 	// Deferred to Start() because module initialization order is not guaranteed —
-	// by the time Start() runs, all modules (including elastic) have completed Init().
+	// by the time Start() runs, all modules have completed Init().
 	if pg.assistantEnabled {
 		assiststore := NewPostgresAssistantstore(pg.server, pg.pool)
 
-		if pg.server.Assistantstore != nil {
-			existingStore := pg.server.Assistantstore
-			if err := migrateAssistantData(context.Background(), pg.pool, existingStore, assiststore); err != nil {
-				log.WithError(err).Warn("Failed to migrate assistant data from Elasticsearch, continuing with existing postgres data")
-			}
-			log.Info("PostgreSQL Assistantstore enabled (replaced Elasticsearch)")
-		} else {
-			log.Info("PostgreSQL Assistantstore enabled (no prior Elasticsearch store found)")
+		if err := migrateAssistantData(context.Background(), pg.pool, pg.esMigrationCfg, assiststore); err != nil {
+			log.WithError(err).Warn("Failed to migrate assistant data from Elasticsearch, continuing with existing postgres data")
 		}
 
 		pg.server.Assistantstore = assiststore
+		log.Info("PostgreSQL Assistantstore enabled")
 	}
 
 	return nil

--- a/server/modules/postgres/postgres.go
+++ b/server/modules/postgres/postgres.go
@@ -7,7 +7,6 @@ package postgres
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/apex/log"
@@ -19,10 +18,11 @@ import (
 const DEFAULT_PORT = 5432
 
 type Postgres struct {
-	config  module.ModuleConfig
-	server  *server.Server
-	pool    *pgxpool.Pool
-	running bool
+	config           module.ModuleConfig
+	server           *server.Server
+	pool             *pgxpool.Pool
+	running          bool
+	assistantEnabled bool
 }
 
 func NewPostgres(srv *server.Server) *Postgres {
@@ -101,27 +101,32 @@ func (pg *Postgres) Init(cfg module.ModuleConfig) error {
 
 	log.Info("Connected to PostgreSQL as app user")
 
-	if assistantEnabled {
-		if pg.server.Assistantstore != nil {
-			existingStore := pg.server.Assistantstore
-			assiststore := NewPostgresAssistantstore(pg.server, pg.pool)
-
-			if err := migrateAssistantData(context.Background(), pg.pool, existingStore, assiststore); err != nil {
-				log.WithError(err).Warn("Failed to migrate assistant data from Elasticsearch, continuing with existing postgres data")
-			}
-
-			pg.server.Assistantstore = assiststore
-			log.Info("PostgreSQL Assistantstore enabled (replaced Elasticsearch)")
-		} else {
-			return errors.New("postgres assistantEnabled requires elastic module to be initialized first")
-		}
-	}
+	pg.assistantEnabled = assistantEnabled
 
 	return nil
 }
 
 func (pg *Postgres) Start() error {
 	pg.running = true
+
+	// Deferred to Start() because module initialization order is not guaranteed —
+	// by the time Start() runs, all modules (including elastic) have completed Init().
+	if pg.assistantEnabled {
+		assiststore := NewPostgresAssistantstore(pg.server, pg.pool)
+
+		if pg.server.Assistantstore != nil {
+			existingStore := pg.server.Assistantstore
+			if err := migrateAssistantData(context.Background(), pg.pool, existingStore, assiststore); err != nil {
+				log.WithError(err).Warn("Failed to migrate assistant data from Elasticsearch, continuing with existing postgres data")
+			}
+			log.Info("PostgreSQL Assistantstore enabled (replaced Elasticsearch)")
+		} else {
+			log.Info("PostgreSQL Assistantstore enabled (no prior Elasticsearch store found)")
+		}
+
+		pg.server.Assistantstore = assiststore
+	}
+
 	return nil
 }
 

--- a/server/modules/postgres/postgresmigration.go
+++ b/server/modules/postgres/postgresmigration.go
@@ -6,15 +6,33 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/security-onion-solutions/securityonion-soc/model"
-	"github.com/security-onion-solutions/securityonion-soc/server"
 )
 
 const migrationAssistantData = "assistant_data_from_elasticsearch"
+
+// esMigrationConfig holds the connection info needed to query Elasticsearch directly
+// for the chat migration. We bypass the Assistantstore interface because it enforces
+// RBAC which requires a user context that doesn't exist during module startup.
+type esMigrationConfig struct {
+	HostUrl      string
+	Username     string
+	Password     string
+	ChatIndex    string
+	SessionIndex string
+	SchemaPrefix string
+}
 
 // isMigrationComplete checks whether a named migration has already been recorded as complete.
 func isMigrationComplete(ctx context.Context, pool *pgxpool.Pool, name string) (bool, error) {
@@ -31,9 +49,8 @@ func markMigrationComplete(ctx context.Context, pool *pgxpool.Pool, name string)
 
 // migrateAssistantData migrates existing assistant data from Elasticsearch to PostgreSQL.
 // It uses a migrations table to track completion — the migration runs exactly once.
-// Individual sessions and messages use ON CONFLICT DO NOTHING for idempotency,
-// so a partial failure can be safely retried.
-func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esStore server.Assistantstore, pgStore *PostgresAssistantstore) error {
+// Queries ES directly via HTTP to bypass RBAC which requires a user context.
+func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esCfg *esMigrationConfig, pgStore *PostgresAssistantstore) error {
 	done, err := isMigrationComplete(ctx, pool, migrationAssistantData)
 	if err != nil {
 		return err
@@ -43,11 +60,22 @@ func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esStore serve
 		return nil
 	}
 
-	// Get all sessions from ES (including deleted ones).
-	// We pass GetSessionsWithIncludeDeleted to capture everything.
-	sessions, err := esStore.GetSessions(ctx, model.GetSessionsWithIncludeDeleted(true))
+	if esCfg == nil || esCfg.HostUrl == "" {
+		log.Info("No Elasticsearch config available, marking migration complete with no data")
+		return markMigrationComplete(ctx, pool, migrationAssistantData)
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	sessions, err := fetchSessionsFromES(ctx, client, esCfg)
 	if err != nil {
-		return err
+		log.WithError(err).Warn("Failed to fetch sessions from Elasticsearch, marking migration complete anyway")
+		return markMigrationComplete(ctx, pool, migrationAssistantData)
 	}
 
 	if len(sessions) == 0 {
@@ -67,13 +95,13 @@ func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esStore serve
 		}
 		migratedSessions++
 
-		history, err := esStore.GetChatHistory(ctx, session.SessionId)
+		messages, err := fetchMessagesFromES(ctx, client, esCfg, session.SessionId)
 		if err != nil {
-			log.WithError(err).WithField("sessionId", session.SessionId).Warn("Failed to get chat history for migration, skipping messages")
+			log.WithError(err).WithField("sessionId", session.SessionId).Warn("Failed to fetch messages, skipping")
 			continue
 		}
 
-		for _, msg := range history {
+		for _, msg := range messages {
 			if err := pgStore.insertMessageDirect(ctx, msg); err != nil {
 				log.WithError(err).WithField("messageId", msg.Id).Warn("Failed to migrate message, skipping")
 				continue
@@ -89,4 +117,240 @@ func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esStore serve
 	}).Info("Assistant data migration complete")
 
 	return markMigrationComplete(ctx, pool, migrationAssistantData)
+}
+
+// fetchSessionsFromES queries Elasticsearch directly for all assistant sessions.
+func fetchSessionsFromES(ctx context.Context, client *http.Client, cfg *esMigrationConfig) ([]*model.AssistantSession, error) {
+	query := map[string]interface{}{
+		"query": map[string]interface{}{
+			"term": map[string]interface{}{
+				cfg.SchemaPrefix + "kind": "session",
+			},
+		},
+		"size": 10000,
+	}
+
+	hits, err := esSearch(ctx, client, cfg, cfg.SessionIndex, query)
+	if err != nil {
+		return nil, err
+	}
+
+	sessions := make([]*model.AssistantSession, 0, len(hits))
+	for _, hit := range hits {
+		session, err := parseSessionFromHit(hit, cfg.SchemaPrefix)
+		if err != nil {
+			log.WithError(err).Warn("Failed to parse session from ES hit, skipping")
+			continue
+		}
+		sessions = append(sessions, session)
+	}
+
+	return sessions, nil
+}
+
+// fetchMessagesFromES queries Elasticsearch directly for all messages in a session.
+func fetchMessagesFromES(ctx context.Context, client *http.Client, cfg *esMigrationConfig, sessionId string) ([]*model.StoredMessage, error) {
+	query := map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"must": []interface{}{
+					map[string]interface{}{
+						"term": map[string]interface{}{
+							cfg.SchemaPrefix + "kind": "chat",
+						},
+					},
+					map[string]interface{}{
+						"term": map[string]interface{}{
+							cfg.SchemaPrefix + "chat.sessionId": sessionId,
+						},
+					},
+				},
+			},
+		},
+		"size": 10000,
+		"sort": []interface{}{
+			map[string]interface{}{
+				"@timestamp": map[string]interface{}{"order": "asc"},
+			},
+		},
+	}
+
+	hits, err := esSearch(ctx, client, cfg, cfg.ChatIndex, query)
+	if err != nil {
+		return nil, err
+	}
+
+	messages := make([]*model.StoredMessage, 0, len(hits))
+	for _, hit := range hits {
+		msg, err := parseMessageFromHit(hit, cfg.SchemaPrefix)
+		if err != nil {
+			log.WithError(err).Warn("Failed to parse message from ES hit, skipping")
+			continue
+		}
+		messages = append(messages, msg)
+	}
+
+	return messages, nil
+}
+
+// esSearch performs a raw HTTP search against Elasticsearch.
+func esSearch(ctx context.Context, client *http.Client, cfg *esMigrationConfig, index string, query map[string]interface{}) ([]map[string]interface{}, error) {
+	body, err := json.Marshal(query)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/%s/_search", cfg.HostUrl, index)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.Username != "" {
+		req.SetBasicAuth(cfg.Username, cfg.Password)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("ES search failed: %d - %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Hits struct {
+			Hits []struct {
+				Source map[string]interface{} `json:"_source"`
+				Id     string                 `json:"_id"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, err
+	}
+
+	hits := make([]map[string]interface{}, 0, len(result.Hits.Hits))
+	for _, h := range result.Hits.Hits {
+		if h.Source == nil {
+			continue
+		}
+		h.Source["_id"] = h.Id
+		hits = append(hits, h.Source)
+	}
+
+	return hits, nil
+}
+
+// parseSessionFromHit converts an ES _source document to an AssistantSession.
+func parseSessionFromHit(hit map[string]interface{}, schemaPrefix string) (*model.AssistantSession, error) {
+	sessionObj, ok := hit[schemaPrefix+"session"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("missing session object")
+	}
+
+	session := &model.AssistantSession{}
+	if id, ok := hit["_id"].(string); ok {
+		session.Id = id
+	}
+	if v, ok := sessionObj["sessionId"].(string); ok {
+		session.SessionId = v
+	}
+	if v, ok := sessionObj["userId"].(string); ok {
+		session.UserId = v
+	}
+	if v, ok := sessionObj["title"].(string); ok {
+		session.Title = v
+	}
+	if v, ok := sessionObj["type"].(string); ok {
+		session.Type = v
+	}
+	if v, ok := sessionObj["entityId"].(string); ok {
+		session.EntityId = v
+	}
+	if tags, ok := sessionObj["tags"].([]interface{}); ok {
+		session.Tags = make([]string, 0, len(tags))
+		for _, t := range tags {
+			if s, ok := t.(string); ok {
+				session.Tags = append(session.Tags, s)
+			}
+		}
+	}
+	if v, ok := sessionObj["createTime"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			session.CreateTime = &t
+		}
+	}
+	if v, ok := sessionObj["updateTime"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			session.UpdateTime = &t
+		}
+	}
+	if v, ok := sessionObj["deleteTime"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			session.DeleteTime = &t
+		}
+	}
+
+	return session, nil
+}
+
+// parseMessageFromHit converts an ES _source document to a StoredMessage.
+func parseMessageFromHit(hit map[string]interface{}, schemaPrefix string) (*model.StoredMessage, error) {
+	chatObj, ok := hit[schemaPrefix+"chat"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("missing chat object")
+	}
+
+	msg := &model.StoredMessage{}
+	if id, ok := hit["_id"].(string); ok {
+		msg.Id = id
+	}
+	if v, ok := chatObj["sessionId"].(string); ok {
+		msg.SessionId = v
+	}
+	if v, ok := chatObj["userId"].(string); ok {
+		msg.UserId = v
+	}
+	if v, ok := chatObj["model"].(string); ok {
+		msg.Model = v
+	}
+	if tags, ok := chatObj["tags"].([]interface{}); ok {
+		msg.Tags = make([]string, 0, len(tags))
+		for _, t := range tags {
+			if s, ok := t.(string); ok {
+				msg.Tags = append(msg.Tags, s)
+			}
+		}
+	}
+	if v, ok := chatObj["createTime"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			msg.CreateTime = &t
+		}
+	}
+
+	// Re-marshal the message sub-object to JSON and unmarshal into model.Message
+	if messageObj, ok := chatObj["message"].(map[string]interface{}); ok {
+		msgBytes, err := json.Marshal(messageObj)
+		if err == nil {
+			msg.Message = &model.Message{}
+			if err := json.Unmarshal(msgBytes, msg.Message); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal message content: %w", err)
+			}
+		}
+	}
+
+	if msg.Message == nil {
+		return nil, fmt.Errorf("missing message content")
+	}
+
+	return msg, nil
 }


### PR DESCRIPTION
## Summary
- Module init order is non-deterministic (Go map iteration), so postgres may run before elastic even with elastic in the prereq list
- Moved Assistantstore wiring and ES migration from Init() to Start()
- By the time Start() runs, all modules have completed Init(), so elastic's Assistantstore is available for migration
- If elastic isn't configured, postgres still takes over with an empty store

## Test plan
- [ ] SOC starts without "postgres assistantEnabled requires elastic module to be initialized first" error
- [ ] Migration runs successfully from elastic to postgres
- [ ] New chats saved to postgres only