### PR TITLE
exempt reverse dns lookups from requiring csrf token

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -25,6 +25,10 @@ import (
 
 const ALL_GRIDS = "_all"
 
+var csrfExemptPaths = []string{
+	"/api/util/reverse-lookup",
+}
+
 func Middleware(host *Host, isWS bool, subgrids []*model.Subgrid) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -88,6 +92,12 @@ func validateRequest(ctx context.Context, host *Host, request *http.Request) err
 		exempt := ctx.Value(ContextKeyRequestCSRFExempt).(bool)
 		if exempt {
 			return nil
+		}
+
+		for _, path := range csrfExemptPaths {
+			if request.URL.Path == path {
+				return nil
+			}
 		}
 
 		token := request.Header.Get("x-srv-token")

--- a/web/middleware_test.go
+++ b/web/middleware_test.go
@@ -93,6 +93,12 @@ func TestValidateRequest(tester *testing.T) {
 	ctx = context.WithValue(ctx, ContextKeyRequestorId, "nonExemptId")
 	err = validateRequest(ctx, host, request)
 	assert.NoError(tester, err)
+
+	// Test path exemption - success
+	request = MustRequest(tester, http.MethodPost, "/api/util/reverse-lookup", nil)
+	ctx = context.WithValue(context.Background(), ContextKeyRequestCSRFExempt, false)
+	err = validateRequest(ctx, host, request)
+	assert.NoError(tester, err)
 }
 
 func TestRespond(t *testing.T) {


### PR DESCRIPTION
## Description

Reloading a SOC page such as a PCAP job, can result in the batched DNS lookups being requested before the server info response arrives. The server would then fail the batch lookup due to the missing CSRF token. This is unnecessary for a READ ONLY operation. It's using POST method only to avoid potential complications caused by GET requests containing a body.

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments
