### PR TITLE
Add PostgreSQL Assistantstore with hardened access control

### DIFF
--- a/server/modules/postgres/postgres.go
+++ b/server/modules/postgres/postgres.go
@@ -80,6 +80,13 @@ func (pg *Postgres) Init(cfg module.ModuleConfig) error {
 		return fmt.Errorf("unable to grant privileges to app user: %w", err)
 	}
 
+	// BIGSERIAL/SERIAL columns create implicit sequences that also need USAGE/SELECT granted to the app user.
+	if _, err := adminPool.Exec(context.Background(),
+		fmt.Sprintf("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %q", username)); err != nil {
+		adminPool.Close()
+		return fmt.Errorf("unable to grant sequence privileges to app user: %w", err)
+	}
+
 	adminPool.Close()
 
 	// Now connect as the application user for normal operations
@@ -117,6 +124,7 @@ func (pg *Postgres) Init(cfg module.ModuleConfig) error {
 			ChatIndex:    module.GetStringDefault(cfg, "esChatIndex", "*:so-assistant-chat"),
 			SessionIndex: module.GetStringDefault(cfg, "esSessionIndex", "*:so-assistant-session"),
 			SchemaPrefix: module.GetStringDefault(cfg, "esSchemaPrefix", "so_"),
+			PageSize:     module.GetIntDefault(cfg, "esMigrationPageSize", 1000),
 		}
 	}
 
@@ -192,6 +200,18 @@ func (pg *Postgres) initSchema(ctx context.Context, adminPool *pgxpool.Pool) err
 			name TEXT PRIMARY KEY,
 			completed_time TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
+
+		CREATE TABLE IF NOT EXISTS assistant_migration_failures (
+			id BIGSERIAL PRIMARY KEY,
+			hit_type TEXT NOT NULL,
+			es_id TEXT,
+			session_id TEXT,
+			error_message TEXT NOT NULL,
+			raw_hit JSONB NOT NULL,
+			failed_time TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_assistant_migration_failures_hit_type ON assistant_migration_failures(hit_type);
 	`
 
 	_, err := adminPool.Exec(ctx, schema)

--- a/server/modules/postgres/postgres.go
+++ b/server/modules/postgres/postgres.go
@@ -125,6 +125,7 @@ func (pg *Postgres) Init(cfg module.ModuleConfig) error {
 			SessionIndex: module.GetStringDefault(cfg, "esSessionIndex", "*:so-assistant-session"),
 			SchemaPrefix: module.GetStringDefault(cfg, "esSchemaPrefix", "so_"),
 			PageSize:     module.GetIntDefault(cfg, "esMigrationPageSize", 1000),
+			VerifyCert:   module.GetBoolDefault(cfg, "esVerifyCert", true),
 		}
 	}
 

--- a/server/modules/postgres/postgres_test.go
+++ b/server/modules/postgres/postgres_test.go
@@ -7,6 +7,10 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -266,4 +270,176 @@ func TestMigrateSkipsWhenDataExists(t *testing.T) {
 	// We can't test the full flow without a real DB, but we verify
 	// the function signature and error handling
 	assert.NotNil(t, migrateAssistantData)
+}
+
+// newESStub returns an httptest server that serves pages of hits for esSearchPaged.
+// Each call to _search returns up to pageSize hits from the remaining pool, assigning
+// monotonically increasing sort values so that search_after pagination terminates.
+func newESStub(t *testing.T, totalHits, pageSize int) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	served := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var body struct {
+			Size        int           `json:"size"`
+			SearchAfter []interface{} `json:"search_after"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body.Size != pageSize {
+			http.Error(w, fmt.Sprintf("expected size=%d, got %d", pageSize, body.Size), http.StatusBadRequest)
+			return
+		}
+
+		remaining := totalHits - served
+		if remaining <= 0 {
+			w.Write([]byte(`{"hits":{"hits":[]}}`))
+			return
+		}
+		take := pageSize
+		if take > remaining {
+			take = remaining
+		}
+
+		hits := make([]map[string]interface{}, 0, take)
+		for i := 0; i < take; i++ {
+			served++
+			hits = append(hits, map[string]interface{}{
+				"_id":    fmt.Sprintf("doc-%d", served),
+				"_source": map[string]interface{}{
+					"so_session": map[string]interface{}{
+						"sessionId": fmt.Sprintf("chat_%06d", served),
+						"userId":    "user-1",
+						"title":     "stub",
+					},
+				},
+				"sort": []interface{}{served, fmt.Sprintf("doc-%d", served)},
+			})
+		}
+
+		resp := map[string]interface{}{
+			"hits": map[string]interface{}{"hits": hits},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func TestESSearchPagedDrainsMultiplePages(t *testing.T) {
+	const pageSize = 3
+	const totalHits = 7 // 3 full pages: 3, 3, 1 — last is short → pager stops
+	srv, calls := newESStub(t, totalHits, pageSize)
+
+	cfg := &esMigrationConfig{HostUrl: srv.URL, SchemaPrefix: "so_"}
+	collected := []string{}
+	err := esSearchPaged(
+		context.Background(),
+		srv.Client(),
+		cfg,
+		"idx",
+		map[string]interface{}{"query": map[string]interface{}{"match_all": map[string]interface{}{}}},
+		[]interface{}{map[string]interface{}{"_id": map[string]interface{}{"order": "asc"}}},
+		pageSize,
+		func(hit map[string]interface{}) error {
+			collected = append(collected, hit["_id"].(string))
+			return nil
+		},
+	)
+	assert.NoError(t, err)
+	assert.Len(t, collected, totalHits)
+	assert.Equal(t, "doc-1", collected[0])
+	assert.Equal(t, "doc-7", collected[6])
+	// 3 round-trips: pages of 3, 3, 1. Third page is short so pager exits without a 4th call.
+	assert.Equal(t, 3, *calls)
+}
+
+func TestESSearchPagedStopsAtExactMultiple(t *testing.T) {
+	const pageSize = 3
+	const totalHits = 6 // exact multiple: pager must make a 3rd empty call to detect end
+	srv, calls := newESStub(t, totalHits, pageSize)
+
+	cfg := &esMigrationConfig{HostUrl: srv.URL, SchemaPrefix: "so_"}
+	collected := 0
+	err := esSearchPaged(
+		context.Background(),
+		srv.Client(),
+		cfg,
+		"idx",
+		map[string]interface{}{"query": map[string]interface{}{"match_all": map[string]interface{}{}}},
+		[]interface{}{map[string]interface{}{"_id": map[string]interface{}{"order": "asc"}}},
+		pageSize,
+		func(hit map[string]interface{}) error {
+			collected++
+			return nil
+		},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, totalHits, collected)
+	// 2 full pages of 3, then a 3rd empty page proves drain — 3 calls total.
+	assert.Equal(t, 3, *calls)
+}
+
+func TestESSearchPagedPropagatesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &esMigrationConfig{HostUrl: srv.URL, SchemaPrefix: "so_"}
+	handlerCalled := false
+	err := esSearchPaged(
+		context.Background(),
+		srv.Client(),
+		cfg,
+		"idx",
+		map[string]interface{}{"query": map[string]interface{}{"match_all": map[string]interface{}{}}},
+		[]interface{}{map[string]interface{}{"_id": map[string]interface{}{"order": "asc"}}},
+		10,
+		func(hit map[string]interface{}) error {
+			handlerCalled = true
+			return nil
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.False(t, handlerCalled)
+}
+
+func TestESSearchPagedPropagatesHandlerError(t *testing.T) {
+	srv, _ := newESStub(t, 10, 3)
+	cfg := &esMigrationConfig{HostUrl: srv.URL, SchemaPrefix: "so_"}
+
+	handlerErr := fmt.Errorf("handler aborted")
+	hits := 0
+	err := esSearchPaged(
+		context.Background(),
+		srv.Client(),
+		cfg,
+		"idx",
+		map[string]interface{}{"query": map[string]interface{}{"match_all": map[string]interface{}{}}},
+		[]interface{}{map[string]interface{}{"_id": map[string]interface{}{"order": "asc"}}},
+		3,
+		func(hit map[string]interface{}) error {
+			hits++
+			if hits == 2 {
+				return handlerErr
+			}
+			return nil
+		},
+	)
+	assert.ErrorIs(t, err, handlerErr)
+	assert.Equal(t, 2, hits)
+}
+
+func TestParseSessionFromHitMissingSessionObject(t *testing.T) {
+	// The quarantine path: parseSessionFromHit must return error for a doc without the
+	// so_session object. migrateAssistantData relies on this to drop the hit into the
+	// assistant_migration_failures table.
+	_, err := parseSessionFromHit(map[string]interface{}{"_id": "abc"}, "so_")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing session object")
 }

--- a/server/modules/postgres/postgres_test.go
+++ b/server/modules/postgres/postgres_test.go
@@ -228,6 +228,62 @@ func TestDeleteSessionEmptySessionId(t *testing.T) {
 	assert.Contains(t, err.Error(), "sessionId must not be empty")
 }
 
+func TestGetUsageUnauthorized(t *testing.T) {
+	srv := server.NewFakeUnauthorizedServer()
+	store := NewPostgresAssistantstore(srv, nil)
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "user-1")
+	_, err := store.GetUsage(ctx, time.Time{}, time.Time{})
+	assert.Error(t, err)
+}
+
+func TestSaveChatMissingUserContext(t *testing.T) {
+	srv := server.NewFakeAuthorizedServer(nil)
+	store := NewPostgresAssistantstore(srv, nil)
+
+	// No ContextKeyRequestorId set — must not fall through to insert with empty UserId.
+	ctx := context.Background()
+	err := store.SaveChat(ctx, &model.StoredMessage{
+		SessionId: "chat_123456",
+		Message:   &model.Message{ContentStr: "hello"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing user context")
+}
+
+func TestCreateSessionMissingUserContext(t *testing.T) {
+	srv := server.NewFakeAuthorizedServer(nil)
+	store := NewPostgresAssistantstore(srv, nil)
+
+	ctx := context.Background()
+	err := store.CreateSession(ctx, &model.AssistantSession{
+		SessionId: "chat_123456",
+		Title:     "Test",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing user context")
+}
+
+func TestUpdateSessionTagsMissingUserContext(t *testing.T) {
+	srv := server.NewFakeAuthorizedServer(nil)
+	store := NewPostgresAssistantstore(srv, nil)
+
+	ctx := context.Background()
+	err := store.UpdateSessionTags(ctx, "chat_123456", []string{"shared"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing user context")
+}
+
+func TestDeleteSessionMissingUserContext(t *testing.T) {
+	srv := server.NewFakeAuthorizedServer(nil)
+	store := NewPostgresAssistantstore(srv, nil)
+
+	ctx := context.Background()
+	err := store.DeleteSession(ctx, "chat_123456")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing user context")
+}
+
 func TestFilterSessionsByRbacOwned(t *testing.T) {
 	srv := server.NewFakeAuthorizedServer(nil)
 	store := NewPostgresAssistantstore(srv, nil)

--- a/server/modules/postgres/postgresassistantstore.go
+++ b/server/modules/postgres/postgresassistantstore.go
@@ -113,6 +113,9 @@ func (store *PostgresAssistantstore) SaveChat(ctx context.Context, chat *model.S
 	}
 
 	userId, _ := ctx.Value(web.ContextKeyRequestorId).(string)
+	if userId == "" {
+		return fmt.Errorf("missing user context")
+	}
 	if chat.Id == "" {
 		chat.Id = uuid.New().String()
 	}
@@ -156,6 +159,9 @@ func (store *PostgresAssistantstore) GetChatHistory(ctx context.Context, session
 
 	session := existing[0]
 	userId, _ := ctx.Value(web.ContextKeyRequestorId).(string)
+	if userId == "" {
+		return nil, fmt.Errorf("missing user context")
+	}
 
 	if session.UserId == userId {
 		if err := store.server.CheckAuthorized(ctx, "read_authored", "assistant"); err != nil {
@@ -207,6 +213,9 @@ func (store *PostgresAssistantstore) CreateSession(ctx context.Context, session 
 	}
 
 	userId, _ := ctx.Value(web.ContextKeyRequestorId).(string)
+	if userId == "" {
+		return fmt.Errorf("missing user context")
+	}
 	if session.Id == "" {
 		session.Id = uuid.New().String()
 	}
@@ -386,6 +395,9 @@ func (store *PostgresAssistantstore) UpdateSessionTags(ctx context.Context, sess
 	}
 
 	userId, _ := ctx.Value(web.ContextKeyRequestorId).(string)
+	if userId == "" {
+		return fmt.Errorf("missing user context")
+	}
 
 	tagsJSON, err := json.Marshal(tags)
 	if err != nil {
@@ -402,7 +414,7 @@ func (store *PostgresAssistantstore) UpdateSessionTags(ctx context.Context, sess
 	}
 
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("session not found or not owned by user: %s", sessionId)
+		return fmt.Errorf("session not found")
 	}
 
 	return nil
@@ -418,6 +430,9 @@ func (store *PostgresAssistantstore) DeleteSession(ctx context.Context, sessionI
 	}
 
 	userId, _ := ctx.Value(web.ContextKeyRequestorId).(string)
+	if userId == "" {
+		return fmt.Errorf("missing user context")
+	}
 
 	now := time.Now()
 	result, err := store.pool.Exec(ctx,
@@ -429,13 +444,17 @@ func (store *PostgresAssistantstore) DeleteSession(ctx context.Context, sessionI
 	}
 
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("session not found or not owned by user: %s", sessionId)
+		return fmt.Errorf("session not found")
 	}
 
 	return nil
 }
 
 func (store *PostgresAssistantstore) GetUsage(ctx context.Context, start time.Time, end time.Time) ([]*model.UserUsage, error) {
+	if err := store.server.CheckAuthorized(ctx, "read_all", "assistant"); err != nil {
+		return nil, err
+	}
+
 	rows, err := store.pool.Query(ctx,
 		`SELECT
 			m.user_id,
@@ -551,7 +570,13 @@ func (store *PostgresAssistantstore) populateSessionUsage(ctx context.Context, s
 }
 
 // insertSessionDirect inserts a session with its original metadata (used during migration).
+// Runs the same invariant checks as CreateSession so ES-sourced docs with out-of-spec
+// SessionId or empty Title are quarantined by the caller instead of landing in PG.
 func (store *PostgresAssistantstore) insertSessionDirect(ctx context.Context, session *model.AssistantSession) error {
+	if err := store.validateSession(session); err != nil {
+		return err
+	}
+
 	tagsJSON, err := json.Marshal(session.Tags)
 	if err != nil {
 		tagsJSON = []byte("[]")
@@ -568,7 +593,13 @@ func (store *PostgresAssistantstore) insertSessionDirect(ctx context.Context, se
 }
 
 // insertMessageDirect inserts a message with its original metadata (used during migration).
+// Runs the same invariant checks as SaveChat so malformed ES-sourced messages are
+// quarantined by the caller instead of bypassing the validation the API enforces.
 func (store *PostgresAssistantstore) insertMessageDirect(ctx context.Context, msg *model.StoredMessage) error {
+	if err := store.validateChat(msg); err != nil {
+		return err
+	}
+
 	messageJSON, err := json.Marshal(msg.Message)
 	if err != nil {
 		return fmt.Errorf("failed to marshal message: %w", err)

--- a/server/modules/postgres/postgresmigration.go
+++ b/server/modules/postgres/postgresmigration.go
@@ -22,6 +22,8 @@ import (
 
 const migrationAssistantData = "assistant_data_from_elasticsearch"
 
+const defaultPageSize = 1000
+
 // esMigrationConfig holds the connection info needed to query Elasticsearch directly
 // for the chat migration. We bypass the Assistantstore interface because it enforces
 // RBAC which requires a user context that doesn't exist during module startup.
@@ -32,6 +34,7 @@ type esMigrationConfig struct {
 	ChatIndex    string
 	SessionIndex string
 	SchemaPrefix string
+	PageSize     int
 }
 
 // isMigrationComplete checks whether a named migration has already been recorded as complete.
@@ -47,9 +50,37 @@ func markMigrationComplete(ctx context.Context, pool *pgxpool.Pool, name string)
 	return err
 }
 
+// recordMigrationFailure writes a single bad hit to the quarantine table. Used so that parse
+// or insert failures on one record don't cause silent data loss — the raw source is preserved
+// for later inspection. Errors writing to quarantine are logged but not propagated; we don't
+// want quarantine itself to block the migration.
+func recordMigrationFailure(ctx context.Context, pool *pgxpool.Pool, hitType, esId, sessionId, errMsg string, rawHit map[string]interface{}) {
+	raw, err := json.Marshal(rawHit)
+	if err != nil {
+		raw = []byte("{}")
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO assistant_migration_failures (hit_type, es_id, session_id, error_message, raw_hit)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		hitType, esId, sessionId, errMsg, raw); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"hitType":   hitType,
+			"esId":      esId,
+			"sessionId": sessionId,
+		}).Warn("Failed to record migration failure in quarantine table")
+	}
+}
+
 // migrateAssistantData migrates existing assistant data from Elasticsearch to PostgreSQL.
-// It uses a migrations table to track completion — the migration runs exactly once.
-// Queries ES directly via HTTP to bypass RBAC which requires a user context.
+// It uses a migrations table to track completion — the migration runs exactly once per
+// successful drain. Queries ES directly via HTTP to bypass RBAC which requires a user context.
+//
+// Error semantics:
+//   - Transport/HTTP errors from Elasticsearch return an error and do NOT mark the migration
+//     complete, so a transient outage retries on the next startup. Inserts are idempotent
+//     (ON CONFLICT DO NOTHING) so retry-from-scratch is safe.
+//   - Parse and per-record insert errors are written to assistant_migration_failures and the
+//     migration continues. A summary log line reports the counts at the end.
 func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esCfg *esMigrationConfig, pgStore *PostgresAssistantstore) error {
 	done, err := isMigrationComplete(ctx, pool, migrationAssistantData)
 	if err != nil {
@@ -65,6 +96,11 @@ func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esCfg *esMigr
 		return markMigrationComplete(ctx, pool, migrationAssistantData)
 	}
 
+	pageSize := esCfg.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -72,138 +108,170 @@ func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esCfg *esMigr
 		},
 	}
 
-	sessions, err := fetchSessionsFromES(ctx, client, esCfg)
-	if err != nil {
-		log.WithError(err).Warn("Failed to fetch sessions from Elasticsearch, marking migration complete anyway")
-		return markMigrationComplete(ctx, pool, migrationAssistantData)
+	log.Info("Starting assistant data migration from Elasticsearch to PostgreSQL")
+
+	var migratedSessions, migratedMessages, parseFailures, insertFailures int
+
+	sessionQuery := map[string]interface{}{
+		"query": map[string]interface{}{
+			"term": map[string]interface{}{
+				esCfg.SchemaPrefix + "kind": "session",
+			},
+		},
 	}
 
-	if len(sessions) == 0 {
-		log.Info("No assistant sessions found in Elasticsearch, marking migration complete")
-		return markMigrationComplete(ctx, pool, migrationAssistantData)
+	// Stable sort: @timestamp is written on every so-* document; _id breaks ties.
+	sort := []interface{}{
+		map[string]interface{}{"@timestamp": map[string]interface{}{"order": "asc"}},
+		map[string]interface{}{"_id": map[string]interface{}{"order": "asc"}},
 	}
 
-	log.WithField("sessionCount", len(sessions)).Info("Migrating assistant sessions from Elasticsearch to PostgreSQL")
+	err = esSearchPaged(ctx, client, esCfg, esCfg.SessionIndex, sessionQuery, sort, pageSize, func(hit map[string]interface{}) error {
+		esId, _ := hit["_id"].(string)
 
-	migratedSessions := 0
-	migratedMessages := 0
+		session, err := parseSessionFromHit(hit, esCfg.SchemaPrefix)
+		if err != nil {
+			parseFailures++
+			recordMigrationFailure(ctx, pool, "session", esId, "", err.Error(), hit)
+			return nil
+		}
 
-	for _, session := range sessions {
 		if err := pgStore.insertSessionDirect(ctx, session); err != nil {
-			log.WithError(err).WithField("sessionId", session.SessionId).Warn("Failed to migrate session, skipping")
-			continue
+			insertFailures++
+			recordMigrationFailure(ctx, pool, "session", esId, session.SessionId, err.Error(), hit)
+			return nil
 		}
 		migratedSessions++
 
-		messages, err := fetchMessagesFromES(ctx, client, esCfg, session.SessionId)
-		if err != nil {
-			log.WithError(err).WithField("sessionId", session.SessionId).Warn("Failed to fetch messages, skipping")
-			continue
-		}
-
-		for _, msg := range messages {
-			if err := pgStore.insertMessageDirect(ctx, msg); err != nil {
-				log.WithError(err).WithField("messageId", msg.Id).Warn("Failed to migrate message, skipping")
-				continue
-			}
-			migratedMessages++
-		}
-	}
-
-	log.WithFields(log.Fields{
-		"migratedSessions": migratedSessions,
-		"migratedMessages": migratedMessages,
-		"totalSessions":    len(sessions),
-	}).Info("Assistant data migration complete")
-
-	return markMigrationComplete(ctx, pool, migrationAssistantData)
-}
-
-// fetchSessionsFromES queries Elasticsearch directly for all assistant sessions.
-func fetchSessionsFromES(ctx context.Context, client *http.Client, cfg *esMigrationConfig) ([]*model.AssistantSession, error) {
-	query := map[string]interface{}{
-		"query": map[string]interface{}{
-			"term": map[string]interface{}{
-				cfg.SchemaPrefix + "kind": "session",
-			},
-		},
-		"size": 10000,
-	}
-
-	hits, err := esSearch(ctx, client, cfg, cfg.SessionIndex, query)
-	if err != nil {
-		return nil, err
-	}
-
-	sessions := make([]*model.AssistantSession, 0, len(hits))
-	for _, hit := range hits {
-		session, err := parseSessionFromHit(hit, cfg.SchemaPrefix)
-		if err != nil {
-			log.WithError(err).Warn("Failed to parse session from ES hit, skipping")
-			continue
-		}
-		sessions = append(sessions, session)
-	}
-
-	return sessions, nil
-}
-
-// fetchMessagesFromES queries Elasticsearch directly for all messages in a session.
-func fetchMessagesFromES(ctx context.Context, client *http.Client, cfg *esMigrationConfig, sessionId string) ([]*model.StoredMessage, error) {
-	query := map[string]interface{}{
-		"query": map[string]interface{}{
-			"bool": map[string]interface{}{
-				"must": []interface{}{
-					map[string]interface{}{
-						"term": map[string]interface{}{
-							cfg.SchemaPrefix + "kind": "chat",
+		msgQuery := map[string]interface{}{
+			"query": map[string]interface{}{
+				"bool": map[string]interface{}{
+					"must": []interface{}{
+						map[string]interface{}{
+							"term": map[string]interface{}{
+								esCfg.SchemaPrefix + "kind": "chat",
+							},
 						},
-					},
-					map[string]interface{}{
-						"term": map[string]interface{}{
-							cfg.SchemaPrefix + "chat.sessionId": sessionId,
+						map[string]interface{}{
+							"term": map[string]interface{}{
+								esCfg.SchemaPrefix + "chat.sessionId": session.SessionId,
+							},
 						},
 					},
 				},
 			},
-		},
-		"size": 10000,
-		"sort": []interface{}{
-			map[string]interface{}{
-				"@timestamp": map[string]interface{}{"order": "asc"},
-			},
-		},
-	}
-
-	hits, err := esSearch(ctx, client, cfg, cfg.ChatIndex, query)
-	if err != nil {
-		return nil, err
-	}
-
-	messages := make([]*model.StoredMessage, 0, len(hits))
-	for _, hit := range hits {
-		msg, err := parseMessageFromHit(hit, cfg.SchemaPrefix)
-		if err != nil {
-			log.WithError(err).Warn("Failed to parse message from ES hit, skipping")
-			continue
 		}
-		messages = append(messages, msg)
+
+		msgErr := esSearchPaged(ctx, client, esCfg, esCfg.ChatIndex, msgQuery, sort, pageSize, func(msgHit map[string]interface{}) error {
+			msgEsId, _ := msgHit["_id"].(string)
+
+			msg, err := parseMessageFromHit(msgHit, esCfg.SchemaPrefix)
+			if err != nil {
+				parseFailures++
+				recordMigrationFailure(ctx, pool, "message", msgEsId, session.SessionId, err.Error(), msgHit)
+				return nil
+			}
+
+			if err := pgStore.insertMessageDirect(ctx, msg); err != nil {
+				insertFailures++
+				recordMigrationFailure(ctx, pool, "message", msgEsId, session.SessionId, err.Error(), msgHit)
+				return nil
+			}
+			migratedMessages++
+			return nil
+		})
+
+		if msgErr != nil {
+			// Transport-level failure fetching this session's messages — abort the whole migration.
+			// Returning an error aborts the outer session pager and propagates upward.
+			return fmt.Errorf("failed to page messages for session %s: %w", session.SessionId, msgErr)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
 	}
 
-	return messages, nil
+	summary := log.Fields{
+		"migratedSessions": migratedSessions,
+		"migratedMessages": migratedMessages,
+		"parseFailures":    parseFailures,
+		"insertFailures":   insertFailures,
+	}
+	log.WithFields(summary).Info("Assistant data migration complete")
+	if parseFailures > 0 || insertFailures > 0 {
+		log.WithFields(summary).Warn("Assistant data migration had failures — see assistant_migration_failures table for details")
+	}
+
+	return markMigrationComplete(ctx, pool, migrationAssistantData)
 }
 
-// esSearch performs a raw HTTP search against Elasticsearch.
-func esSearch(ctx context.Context, client *http.Client, cfg *esMigrationConfig, index string, query map[string]interface{}) ([]map[string]interface{}, error) {
+// esSearchPaged repeatedly POSTs /_search with search_after until the index is drained.
+// The baseQuery must NOT contain "size", "sort", or "search_after" — the pager owns those.
+// handler is invoked once per hit in document order; returning an error aborts the scan
+// and is propagated to the caller (distinguishable from transport errors only by context).
+func esSearchPaged(
+	ctx context.Context,
+	client *http.Client,
+	cfg *esMigrationConfig,
+	index string,
+	baseQuery map[string]interface{},
+	sort []interface{},
+	pageSize int,
+	handler func(hit map[string]interface{}) error,
+) error {
+	var searchAfter []interface{}
+
+	for {
+		query := make(map[string]interface{}, len(baseQuery)+3)
+		for k, v := range baseQuery {
+			query[k] = v
+		}
+		query["size"] = pageSize
+		query["sort"] = sort
+		if searchAfter != nil {
+			query["search_after"] = searchAfter
+		}
+
+		hits, lastSort, err := esSearchOnePage(ctx, client, cfg, index, query)
+		if err != nil {
+			return err
+		}
+
+		for _, hit := range hits {
+			if err := handler(hit); err != nil {
+				return err
+			}
+		}
+
+		if len(hits) < pageSize {
+			return nil
+		}
+		if lastSort == nil {
+			// Defensive: if ES returned a full page but no sort values on the last hit,
+			// we'd loop forever. Treat as end-of-stream and log — shouldn't happen given
+			// our sort keys are always populated.
+			log.WithField("index", index).Warn("esSearchPaged: last hit missing sort values, stopping pagination")
+			return nil
+		}
+		searchAfter = lastSort
+	}
+}
+
+// esSearchOnePage runs a single _search against Elasticsearch and returns the hits plus the
+// sort values of the last hit (for use as the next search_after cursor).
+func esSearchOnePage(ctx context.Context, client *http.Client, cfg *esMigrationConfig, index string, query map[string]interface{}) ([]map[string]interface{}, []interface{}, error) {
 	body, err := json.Marshal(query)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	url := fmt.Sprintf("%s/%s/_search", cfg.HostUrl, index)
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if cfg.Username != "" {
@@ -212,17 +280,17 @@ func esSearch(ctx context.Context, client *http.Client, cfg *esMigrationConfig, 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("ES search failed: %d - %s", resp.StatusCode, string(respBody))
+		return nil, nil, fmt.Errorf("ES search failed: %d - %s", resp.StatusCode, string(respBody))
 	}
 
 	var result struct {
@@ -230,24 +298,27 @@ func esSearch(ctx context.Context, client *http.Client, cfg *esMigrationConfig, 
 			Hits []struct {
 				Source map[string]interface{} `json:"_source"`
 				Id     string                 `json:"_id"`
+				Sort   []interface{}          `json:"sort"`
 			} `json:"hits"`
 		} `json:"hits"`
 	}
 
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	hits := make([]map[string]interface{}, 0, len(result.Hits.Hits))
+	var lastSort []interface{}
 	for _, h := range result.Hits.Hits {
 		if h.Source == nil {
 			continue
 		}
 		h.Source["_id"] = h.Id
 		hits = append(hits, h.Source)
+		lastSort = h.Sort
 	}
 
-	return hits, nil
+	return hits, lastSort, nil
 }
 
 // parseSessionFromHit converts an ES _source document to an AssistantSession.

--- a/server/modules/postgres/postgresmigration.go
+++ b/server/modules/postgres/postgresmigration.go
@@ -35,6 +35,7 @@ type esMigrationConfig struct {
 	SessionIndex string
 	SchemaPrefix string
 	PageSize     int
+	VerifyCert   bool
 }
 
 // isMigrationComplete checks whether a named migration has already been recorded as complete.
@@ -104,7 +105,7 @@ func migrateAssistantData(ctx context.Context, pool *pgxpool.Pool, esCfg *esMigr
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !esCfg.VerifyCert},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Introduce a PostgreSQL-backed Assistantstore (sessions, messages, usage) with RBAC checks mirroring the existing Elastic store.
- Migrate existing assistant data from Elasticsearch to PostgreSQL on first startup, with quarantine-on-failure semantics (migrations + assistant_migration_failures tables) and idempotent re-run.
- Security hardening on top of the feature work: CheckAuthorized on GetUsage, reject empty user context on all write paths, run migration inserts through validateSession/validateChat so ES-sourced docs can't bypass invariants, make ES-migration TLS verification configurable (esVerifyCert), and collapse "not found or not owned by user" errors to a generic "session not found".

## Test plan
- [ ] `go test ./server/modules/postgres/...` (29 tests)
- [ ] `go vet ./... && go build ./...` clean
- [ ] Assistant CRUD works for authorized, fails for unauthorized
- [ ] ES→PG migration runs once, quarantines bad docs, skips on retry
- [ ] `esVerifyCert` pillar flag toggles TLS verification