### PR TITLE
Cogburn/data aid fix

### DIFF
--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -173,7 +173,7 @@
 			</v-row>
 			<v-row v-if="loaded" class="ga-3">
 				<v-col v-if="isCategory('hunt') || isCategory('dashboards')">
-					<div class="so-stat-pill" data-aid="stat_total_alerts">
+					<div class="so-stat-pill" data-aid="stat_query_name">
 						<div class="so-stat-text">
 							<div class="so-stat-label">{{ i18n.queryName }}</div>
 							<div class="so-stat-value">{{ queryName }}</div>


### PR DESCRIPTION
## Description

Copy and pasted an existing stat pill block in order to create a new one for the query name pill on Dashboards and Hunt. I forgot to update the data-aid property at the time, this PR fixes it.

## Related Issues

Related to the PR that displays the query name in Dashboards and Hunt as the problem was created in that PR.

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->