### PR TITLE
Fix Tool Links in Nav

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -102,7 +102,8 @@
 }
 
 .v-list-item > .v-list-item__prepend i.fa {
-  margin-right: 16px !important;
+  margin-right: 8px !important;
+  margin-left: -4px !important;
 }
 
 .v-navigation-drawer__content .v-list-item--active {


### PR DESCRIPTION
Small margin changes should allow every tool, including Osquery Manager, to show without being truncated.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->