### PR TITLE
Alerts: Group Metrics UI Fix

### DIFF
--- a/html/css/modern.css
+++ b/html/css/modern.css
@@ -937,6 +937,12 @@ dfn {
   container-type: inline-size;
 }
 
+.group-metrics-col:has(.expanded-row) {
+  flex: 0 0 100%;
+  max-width: 100%;
+  container-type: inline-size;
+}
+
 .split-toolbar {
   position: sticky;
   top: 0;

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -878,6 +878,7 @@ const i18n = {
       invalidDetectionSuricataNewLine: 'Newline characters are not allowed in Suricata rules. The rule must fit on one line.',
       ioWait: 'I/O Wait',
       invalidCidrOrVar: 'Invalid CIDR Notation or Suricata Variable',
+      investigated: 'Investigated',
       ip: 'IP',
       ipCidr: 'IP - CIDR Notation or Suricata Variable',
       job: 'Job',

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -296,7 +296,7 @@
 					<v-expand-transition>
 						<div v-if="isExpandedSection('hunt-groups')">
 							<v-row>
-								<v-col v-for="(group, groupIdx) in groupBys" :class="['groupBy', { 'known-width': isCategory('alerts') }]">
+								<v-col v-for="(group, groupIdx) in groupBys" class="group-metrics-col">
 									<div v-if="group.chart_type" class="chart-container">
 										<router-link class="mx-1" :to="buildGroupWithoutOptionsRoute(groupIdx)" :title="i18n.showTable" style="text-decoration: none; cursor: 'pointer'" :data-aid="'groups_table_toggle_' + category" :aria-label="i18n.showTable">
 											<v-icon class="theme-icon">fa-table-cells</v-icon>


### PR DESCRIPTION
## Description

- Remedied layout issues on the Group Metrics section of the Alerts page. These issues were showing up when the user executed long queries.

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments