### PR TITLE
Apply Strictness Requirements

### DIFF
--- a/server/modules/assistant/gemini_adapter.go
+++ b/server/modules/assistant/gemini_adapter.go
@@ -591,7 +591,7 @@ func handleStreamError(err error, firstSend bool, writer *sseEventWriter, logger
 		// No response sent to client yet - fabricate error response
 		logger.WithFields(log.Fields{
 			"model": model,
-		}).WithError(err).Error("first response error from gemini")
+		}).WithError(err).Error("first response error from the LLM")
 
 		var body *io.PipeWriter
 		response, body := fabricateResponse(http.StatusInternalServerError)
@@ -608,7 +608,7 @@ func handleStreamError(err error, firstSend bool, writer *sseEventWriter, logger
 	// Error after partial response sent to client
 	logger.WithFields(log.Fields{
 		"model": model,
-	}).WithError(err).Error("subsequent response error from gemini")
+	}).WithError(err).Error("subsequent response error from the LLM")
 
 	writer.writeError(err.Error())
 	writer.writeDone()

--- a/server/modules/assistant/openai_responses_adapter.go
+++ b/server/modules/assistant/openai_responses_adapter.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
+	"strings"
 	"sync"
 
 	"github.com/security-onion-solutions/securityonion-soc/model"
@@ -435,7 +437,11 @@ func convertToolConfigToOpenAI(req *model.ChatRequest) []responses.ToolUnionPara
 
 func convertPropertyToOpenAI(prop *model.ToolSchemaProperty) map[string]any {
 	result := map[string]any{
-		"type": prop.Type,
+		"type": []string{prop.Type},
+	}
+
+	if strings.EqualFold(prop.Type, "object") {
+		result["additionalProperties"] = false
 	}
 
 	if prop.Description != "" {
@@ -450,10 +456,19 @@ func convertPropertyToOpenAI(prop *model.ToolSchemaProperty) map[string]any {
 	if len(prop.Items) > 0 {
 		if prop.Type == "object" {
 			items := make(map[string]any)
+			names := make([]string, 0, len(prop.Items))
 			for itemName, itemSchema := range prop.Items {
-				items[itemName] = convertPropertyToOpenAI(&itemSchema)
+				names = append(names, itemName)
+				child := convertPropertyToOpenAI(&itemSchema)
+				// strict mode lists every property in `required`; the schema model
+				// can't express per-field optionality at the nested level, so make
+				// each field nullable to keep optional fields satisfiable.
+				child["type"] = append(child["type"].([]string), "null")
+				items[itemName] = child
 			}
+			slices.Sort(names)
 			result["properties"] = items
+			result["required"] = names
 		} else if prop.Type == "array" {
 			for _, itemSchema := range prop.Items {
 				result["items"] = convertPropertyToOpenAI(&itemSchema)
@@ -474,17 +489,25 @@ func convertJSONSchemaToOpenAI(schema *model.ToolSchema) map[string]any {
 		"type": schema.Type,
 	}
 
+	allPropNames := make([]string, 0, len(schema.Properties))
+
 	if len(schema.Properties) > 0 {
 		properties := make(map[string]any)
 		for propName, propSchema := range schema.Properties {
-			properties[propName] = convertPropertyToOpenAI(&propSchema)
+			allPropNames = append(allPropNames, propName)
+			prop := convertPropertyToOpenAI(&propSchema)
+			if !slices.Contains(schema.Required, propName) {
+				prop["type"] = append(prop["type"].([]string), "null")
+			}
+			properties[propName] = prop
 		}
 		result["properties"] = properties
 	}
 
-	if len(schema.Required) > 0 {
-		result["required"] = schema.Required
-	}
+	slices.Sort(allPropNames)
+	result["required"] = allPropNames
+
+	result["additionalProperties"] = false
 
 	return result
 }

--- a/server/modules/assistant/openai_responses_adapter_test.go
+++ b/server/modules/assistant/openai_responses_adapter_test.go
@@ -878,7 +878,7 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				Type: "string",
 			},
 			want: map[string]any{
-				"type": "string",
+				"type": []string{"string"},
 			},
 		},
 		{
@@ -887,7 +887,7 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				Type: "integer",
 			},
 			want: map[string]any{
-				"type": "integer",
+				"type": []string{"integer"},
 			},
 		},
 		{
@@ -896,7 +896,7 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				Type: "boolean",
 			},
 			want: map[string]any{
-				"type": "boolean",
+				"type": []string{"boolean"},
 			},
 		},
 		{
@@ -905,7 +905,7 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				Type: "number",
 			},
 			want: map[string]any{
-				"type": "number",
+				"type": []string{"number"},
 			},
 		},
 		{
@@ -915,7 +915,7 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				Description: "The user's name",
 			},
 			want: map[string]any{
-				"type":        "string",
+				"type":        []string{"string"},
 				"description": "The user's name",
 			},
 		},
@@ -926,11 +926,14 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				Default: "default_value",
 			},
 			want: map[string]any{
-				"type":    "string",
+				"type":    []string{"string"},
 				"default": "default_value",
 			},
 		},
 		{
+			// Strict mode: a nested object must declare additionalProperties:false,
+			// list every field in required, and make each field nullable so the
+			// model may omit semantically-optional fields by passing null.
 			name: "object with properties",
 			prop: &model.ToolSchemaProperty{
 				Type: "object",
@@ -940,11 +943,13 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				},
 			},
 			want: map[string]any{
-				"type": "object",
+				"type":                 []string{"object"},
+				"additionalProperties": false,
 				"properties": map[string]any{
-					"name": map[string]any{"type": "string"},
-					"age":  map[string]any{"type": "integer"},
+					"name": map[string]any{"type": []string{"string", "null"}},
+					"age":  map[string]any{"type": []string{"integer", "null"}},
 				},
+				"required": []string{"age", "name"},
 			},
 		},
 		{
@@ -956,8 +961,38 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				},
 			},
 			want: map[string]any{
-				"type":  "array",
-				"items": map[string]any{"type": "string"},
+				"type":  []string{"array"},
+				"items": map[string]any{"type": []string{"string"}},
+			},
+		},
+		{
+			// Mirrors the add_overrides schema: an array whose items are an object.
+			// The item object must carry additionalProperties/required and nullable
+			// fields, which is the case that originally tripped OpenAI strict mode.
+			name: "array of objects",
+			prop: &model.ToolSchemaProperty{
+				Type: "array",
+				Items: map[string]model.ToolSchemaProperty{
+					"override": {
+						Type: "object",
+						Items: map[string]model.ToolSchemaProperty{
+							"type":  {Type: "string"},
+							"count": {Type: "integer"},
+						},
+					},
+				},
+			},
+			want: map[string]any{
+				"type": []string{"array"},
+				"items": map[string]any{
+					"type":                 []string{"object"},
+					"additionalProperties": false,
+					"properties": map[string]any{
+						"type":  map[string]any{"type": []string{"string", "null"}},
+						"count": map[string]any{"type": []string{"integer", "null"}},
+					},
+					"required": []string{"count", "type"},
+				},
 			},
 		},
 		{
@@ -974,15 +1009,19 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				},
 			},
 			want: map[string]any{
-				"type": "object",
+				"type":                 []string{"object"},
+				"additionalProperties": false,
 				"properties": map[string]any{
 					"config": map[string]any{
-						"type": "object",
+						"type":                 []string{"object", "null"},
+						"additionalProperties": false,
 						"properties": map[string]any{
-							"settings": map[string]any{"type": "string"},
+							"settings": map[string]any{"type": []string{"string", "null"}},
 						},
+						"required": []string{"settings"},
 					},
 				},
+				"required": []string{"config"},
 			},
 		},
 		{
@@ -992,7 +1031,8 @@ func TestConvertPropertyToOpenAI(t *testing.T) {
 				Items: map[string]model.ToolSchemaProperty{},
 			},
 			want: map[string]any{
-				"type": "object",
+				"type":                 []string{"object"},
+				"additionalProperties": false,
 			},
 		},
 	}
@@ -1017,15 +1057,21 @@ func TestConvertJSONSchemaToOpenAI(t *testing.T) {
 			want:   nil,
 		},
 		{
+			// Strict mode always emits required + additionalProperties, even with
+			// no properties (required is then the empty set).
 			name: "simple schema with type only",
 			schema: &model.ToolSchema{
 				Type: "object",
 			},
 			want: map[string]any{
-				"type": "object",
+				"type":                 "object",
+				"required":             []string{},
+				"additionalProperties": false,
 			},
 		},
 		{
+			// No Required list: every property is optional, so each becomes
+			// nullable, but all are still listed in required for strict mode.
 			name: "schema with properties",
 			schema: &model.ToolSchema{
 				Type: "object",
@@ -1037,23 +1083,30 @@ func TestConvertJSONSchemaToOpenAI(t *testing.T) {
 			want: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"name": map[string]any{"type": "string"},
-					"age":  map[string]any{"type": "integer"},
+					"name": map[string]any{"type": []string{"string", "null"}},
+					"age":  map[string]any{"type": []string{"integer", "null"}},
 				},
+				"required":             []string{"age", "name"},
+				"additionalProperties": false,
 			},
 		},
 		{
-			name: "schema with required fields",
+			// Required is only meaningful relative to declared properties; with no
+			// properties there is nothing to require.
+			name: "schema with required fields but no properties",
 			schema: &model.ToolSchema{
 				Type:     "object",
 				Required: []string{"name", "email"},
 			},
 			want: map[string]any{
-				"type":     "object",
-				"required": []string{"name", "email"},
+				"type":                 "object",
+				"required":             []string{},
+				"additionalProperties": false,
 			},
 		},
 		{
+			// "name" is required (kept non-nullable); "email" is optional and so is
+			// made nullable. Both appear in required.
 			name: "schema with both properties and required",
 			schema: &model.ToolSchema{
 				Type: "object",
@@ -1066,10 +1119,11 @@ func TestConvertJSONSchemaToOpenAI(t *testing.T) {
 			want: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"name":  map[string]any{"type": "string"},
-					"email": map[string]any{"type": "string"},
+					"name":  map[string]any{"type": []string{"string"}},
+					"email": map[string]any{"type": []string{"string", "null"}},
 				},
-				"required": []string{"name"},
+				"required":             []string{"email", "name"},
+				"additionalProperties": false,
 			},
 		},
 		{
@@ -1079,7 +1133,9 @@ func TestConvertJSONSchemaToOpenAI(t *testing.T) {
 				Properties: map[string]model.ToolSchemaProperty{},
 			},
 			want: map[string]any{
-				"type": "object",
+				"type":                 "object",
+				"required":             []string{},
+				"additionalProperties": false,
 			},
 		},
 	}


### PR DESCRIPTION
The OpenAI chat and responses adapters both specify that the requests are strict. To live up to that, we needed to refactor how we converted the ToolConfig for OpenAI adapters. Strict refers to how strictly tools define their schema and how strict the LLM will follow those changes. For example, `strict: true` requires that every parameter be passed with no additions, this means that every `object` parameter must list all it's props as required and every optional param must accept null. This results in the LLM specifying every parameter when calling a tool and leaving no room for the LLM to pass a parameter that isn't in the schema.

Also updated a log line to no longer mention a specific adapter when an error comes up.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->