### PR TITLE
Report Bulk Acks

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -176,6 +176,8 @@ const i18n = {
       ackMultipleTip: 'Acknowledging groups of alerts may take a while and will continue in the background.',
       ackPartialSuccess: 'The acknowledge request encountered an unexpected problem. Some events may not have been acknowledged.',
       ackSingleTip: 'Acknowledged alert and removed from view.',
+      ackTaskError: 'Error acknowledging alerts: {errors}',
+      ackTaskSuccess: 'Successfully acknowledged {count} alerts.',
       ackUndoMultipleTip: 'Reverting acknowledgment on groups of alerts may take a while and will continue in the background.',
       ackUndoSingleTip: 'Reverted acknowledgement and removed from view.',
       actions: 'Actions',

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -173,6 +173,7 @@ const huntComponent = {
       showAckManyDialog: false,
       ackManyArgs: [],
       ackManyVerb: '',
+      runningAckTasks: [],
       fieldValueDialogVisible: false,
       fieldValueDialogKey: '',
       fieldValueDialogValue: '',
@@ -221,6 +222,7 @@ const huntComponent = {
     this.stopRefreshTimer();
     this.$root.unsubscribe('detections:bulkUpdate', this.bulkUpdateReport);
     this.$root.unsubscribe('related:bulkCreate', this.bulkUpdateReport);
+    this.$root.unsubscribe('events:ack', this.ackTaskReport);
 
     if (this.isCategory('alerts')) {
       window.removeEventListener('resize', this.calculateEventColumnWidth);
@@ -245,6 +247,7 @@ const huntComponent = {
 
     if (this.isCategory('alerts')) {
       window.addEventListener('resize', this.calculateEventColumnWidth);
+      this.$root.subscribe('events:ack', this.ackTaskReport);
     }
   },
   watch: {
@@ -912,6 +915,11 @@ const huntComponent = {
           });
           if (response.data && response.data.errors && response.data.errors.length > 0) {
             this.$root.showWarning(this.i18n.ackPartialSuccess);
+          }
+          // When the ack runs asynchronously the backend returns a task id per host; track
+          // them so we can report the outcome when the 'events:ack' broadcast arrives.
+          if (response.data && response.data.taskIds && response.data.taskIds.length > 0) {
+            this.runningAckTasks.push(...response.data.taskIds);
           }
         }
         if (this.isCategory('alerts')) {
@@ -2802,6 +2810,23 @@ const huntComponent = {
 
           this.$root.showInfo(msg, true);
         }
+      }
+    },
+    ackTaskReport(status) {
+      // ignore broadcasts for other clients.
+      const ids = status.taskIds || [];
+      if (!ids.some(id => this.runningAckTasks.includes(id))) return;
+
+      // One action spans every host's task; clear them all and report once.
+      this.runningAckTasks = this.runningAckTasks.filter(id => !ids.includes(id));
+
+      if (status.success) {
+        const msg = this.$root.replaceActionVar(this.i18n.ackTaskSuccess, 'count', (status.updated || 0).toLocaleString())
+        this.$root.showInfo(msg, true);
+      } else {
+        let errors = (status.errors || []).join('; ');
+        const msg = this.$root.replaceActionVar(this.i18n.ackTaskError, 'errors', errors);
+        this.$root.showError(msg);
       }
     },
     startManualSync(engine, type) {

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -1446,6 +1446,48 @@ test('getDisplayedQueryVar', () => {
   expect(comp.getDisplayedQueryVar()).toBe('querySearch');
 });
 
+test('ackTaskReport - ignores untracked task', () => {
+  comp.runningAckTasks = ['task-a'];
+  comp.$root.info = false;
+  comp.$root.error = false;
+
+  comp.ackTaskReport({ taskIds: ['task-b'], success: true, updated: 5, errors: [] });
+
+  expect(comp.$root.info).toBe(false);
+  expect(comp.$root.error).toBe(false);
+  expect(comp.runningAckTasks).toEqual(['task-a']);
+});
+
+test('ackTaskReport - success shows count and removes task', () => {
+  comp.runningAckTasks = ['task-a', 'task-b'];
+
+  comp.ackTaskReport({ taskIds: ['task-a'], success: true, updated: 1234, errors: [] });
+
+  expect(comp.$root.info).toBe(true);
+  expect(comp.$root.infoMessage).toBe('Successfully acknowledged 1,234 alerts.');
+  expect(comp.runningAckTasks).toEqual(['task-b']);
+});
+
+test('ackTaskReport - failure shows error breakdown and removes task', () => {
+  comp.runningAckTasks = ['task-a'];
+
+  comp.ackTaskReport({ taskIds: ['task-a'], success: false, updated: 0, errors: ['boom', 'kaboom'] });
+
+  expect(comp.$root.error).toBe(true);
+  expect(comp.$root.errorMessage).toBe('Error acknowledging alerts: boom; kaboom');
+  expect(comp.runningAckTasks).toEqual([]);
+});
+
+test('ackTaskReport - multi-host clears every tracked id with one banner', () => {
+  comp.runningAckTasks = ['nodeA:1', 'nodeB:7', 'other'];
+
+  comp.ackTaskReport({ taskIds: ['nodeA:1', 'nodeB:7'], success: true, updated: 1200, errors: [] });
+
+  expect(comp.$root.info).toBe(true);
+  expect(comp.$root.infoMessage).toBe('Successfully acknowledged 1,200 alerts.');
+  expect(comp.runningAckTasks).toEqual(['other']);
+});
+
 test('bulkUpdateReport - error', () => {
   let stats = {
     error: 1,

--- a/model/event.go
+++ b/model/event.go
@@ -176,6 +176,21 @@ type EventUpdateResults struct {
 	UpdatedCount int `json:"updatedCount" example:"1"`
 	// The number of events the were left unmodified
 	UnchangedCount int `json:"unchangedCount" example:"0"`
+	// The Elasticsearch task ids when the update runs asynchronously (one per host); empty for synchronous updates
+	TaskIds []string `json:"taskIds,omitempty"`
+}
+
+// EventAckStatus is broadcast to clients when an asynchronous acknowledge/update task
+// completes. Clients correlate it to their originating request via TaskIds.
+type EventAckStatus struct {
+	// The Elasticsearch task ids (one per host) that this status pertains to
+	TaskIds []string `json:"taskIds"`
+	// Whether the asynchronous update completed without any errors
+	Success bool `json:"success"`
+	// The total number of events that were updated
+	Updated int `json:"updated"`
+	// Any errors encountered while completing the asynchronous update
+	Errors []string `json:"errors"`
 }
 
 func NewEventUpdateResults() *EventUpdateResults {

--- a/server/modules/elastic/converter.go
+++ b/server/modules/elastic/converter.go
@@ -1059,6 +1059,21 @@ func convertFromElasticUpdateResults(store *ElasticEventstore, esJson string, re
 	return err
 }
 
+// convertFromElasticAsyncUpdateResults parses the response returned by an UpdateByQuery
+// submitted with wait_for_completion=false, which has the shape {"task":"nodeId:taskId"}.
+func convertFromElasticAsyncUpdateResults(esJson string) (string, error) {
+	esResults := make(map[string]interface{})
+	err := json.LoadJson([]byte(esJson), &esResults)
+	if err != nil {
+		return "", err
+	}
+	taskId, ok := esResults["task"].(string)
+	if !ok || taskId == "" {
+		return "", errors.New("Elasticsearch response did not contain an async task id")
+	}
+	return taskId, nil
+}
+
 func ConvertObjectToDocumentMap(name string, obj interface{}, schemaPrefix string) map[string]interface{} {
 	doc := make(map[string]interface{})
 	doc[schemaPrefix+name] = obj

--- a/server/modules/elastic/elasticeventstore.go
+++ b/server/modules/elastic/elasticeventstore.go
@@ -31,7 +31,16 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const MAX_ERROR_LENGTH = 4096
+const (
+	MAX_ERROR_LENGTH = 4096
+	// ASYNC_UPDATE_MAX_WAIT bounds how long a single async update task will be watched before giving up.
+	ASYNC_UPDATE_MAX_WAIT = 30 * time.Minute
+	// ASYNC_UPDATE_POLL_TIMEOUT is how long each Tasks.Get call blocks server-side waiting for completion.
+	ASYNC_UPDATE_POLL_TIMEOUT = 30 * time.Second
+	ASYNC_UPDATE_PAUSE        = time.Second
+	// ASYNC_UPDATE_MAX_ERRORS caps how many individual errors are broadcast to the client
+	ASYNC_UPDATE_MAX_ERRORS = 5
+)
 
 type FieldDefinition struct {
 	name         string
@@ -448,6 +457,7 @@ func (store *ElasticEventstore) Update(ctx context.Context, criteria *model.Even
 		query, err = convertToElasticUpdateRequest(store, criteria)
 		if err == nil {
 			var response string
+			var asyncTasks []asyncTaskRef
 
 			for idx, client := range store.esAllClients {
 				logger.WithField("clientHost", store.hostUrls[idx]).Debug("Sending request to client")
@@ -462,11 +472,44 @@ func (store *ElasticEventstore) Update(ctx context.Context, criteria *model.Even
 							logger.WithError(err).WithField("clientHost", store.hostUrls[idx]).Error("Encountered error while updating elasticsearch")
 							results.Errors = append(results.Errors, err.Error())
 						}
+					} else {
+						// The update is running asynchronously; capture the node-specific task id
+						// so a background goroutine can watch it to completion and report the outcome.
+						taskId, taskErr := convertFromElasticAsyncUpdateResults(response)
+						if taskErr == nil {
+							asyncTasks = append(asyncTasks, asyncTaskRef{client: client, hostUrl: store.hostUrls[idx], taskId: taskId})
+						} else {
+							logger.WithError(taskErr).WithField("clientHost", store.hostUrls[idx]).Error("Encountered error while parsing asynchronous elasticsearch update response")
+							results.Errors = append(results.Errors, taskErr.Error())
+						}
 					}
 				} else {
 					logger.WithError(err).WithField("clientHost", store.hostUrls[idx]).Error("Encountered error while updating elasticsearch")
 					results.Errors = append(results.Errors, err.Error())
 				}
+			}
+
+			if criteria.Asynchronous && len(asyncTasks) > 0 {
+				// The returned task ids are the correlation tokens the client tracks (one per
+				// host); the watcher polls every node's task and broadcasts a single aggregated
+				// result carrying all of them.
+				taskIds := make([]string, len(asyncTasks))
+				for i, task := range asyncTasks {
+					taskIds[i] = task.taskId
+				}
+				results.TaskIds = taskIds
+
+				noTimeOutCtx := context.Background()
+				val := ctx.Value(web.ContextKeyRunAsUsername)
+				if val != nil {
+					if username, ok := val.(string); ok {
+						noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRunAsUsername, username)
+					}
+				}
+				noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRequestorId, ctx.Value(web.ContextKeyRequestorId).(string))
+				noTimeOutCtx = log.NewContext(noTimeOutCtx, log.FromContext(ctx))
+
+				go store.watchAsyncUpdate(noTimeOutCtx, asyncTasks, taskIds)
 			}
 		}
 
@@ -695,6 +738,150 @@ func (store *ElasticEventstore) updateDocuments(ctx context.Context, client *ela
 	}).Debug("Update finished")
 
 	return jsonStr, err
+}
+
+// asyncTaskRef pairs an Elasticsearch task id with the client that submitted it. Task ids are
+// node-specific, so the task must be polled on the same client that created it.
+type asyncTaskRef struct {
+	client  *elasticsearch.Client
+	hostUrl string
+	taskId  string
+}
+
+// watchAsyncUpdate watches all of the supplied asynchronous update tasks to completion, then
+// broadcasts a single aggregated result so the initiating client can report success or failure.
+func (store *ElasticEventstore) watchAsyncUpdate(ctx context.Context, tasks []asyncTaskRef, taskIds []string) {
+	logger := log.FromContext(ctx).WithField("taskIds", taskIds)
+
+	status := store.aggregateAsyncUpdate(ctx, tasks, taskIds)
+
+	logger.WithFields(log.Fields{
+		"success": status.Success,
+		"updated": status.Updated,
+		"errors":  status.Errors,
+	}).Info("Asynchronous event update task finished; broadcasting result")
+
+	store.server.Host.Broadcast("events:ack", "events", status)
+}
+
+// aggregateAsyncUpdate watches every supplied task to completion and combines their results into a
+// single status carrying the total updated count and any errors across all hosts.
+func (store *ElasticEventstore) aggregateAsyncUpdate(ctx context.Context, tasks []asyncTaskRef, taskIds []string) model.EventAckStatus {
+	status := model.EventAckStatus{
+		TaskIds: taskIds,
+		Success: true,
+		Errors:  make([]string, 0),
+	}
+
+	for _, task := range tasks {
+		updated, errs := store.waitForUpdateTask(ctx, task)
+		status.Updated += updated
+		if len(errs) > 0 {
+			status.Success = false
+			status.Errors = append(status.Errors, errs...)
+		}
+	}
+
+	// Avoid broadcasting an unbounded error string; the full set is preserved in the server logs.
+	if len(status.Errors) > ASYNC_UPDATE_MAX_ERRORS {
+		remaining := len(status.Errors) - ASYNC_UPDATE_MAX_ERRORS
+		status.Errors = append(status.Errors[:ASYNC_UPDATE_MAX_ERRORS:ASYNC_UPDATE_MAX_ERRORS],
+			fmt.Sprintf("...and %d more error(s)", remaining))
+	}
+
+	return status
+}
+
+// waitForUpdateTask polls a single update task until it completes (or times out) and returns the
+// number of updated documents along with any errors encountered.
+func (store *ElasticEventstore) waitForUpdateTask(ctx context.Context, task asyncTaskRef) (int, []string) {
+	deadline := time.Now().Add(ASYNC_UPDATE_MAX_WAIT)
+	for {
+		time.Sleep(ASYNC_UPDATE_PAUSE)
+
+		res, err := task.client.Tasks.Get(
+			task.taskId,
+			task.client.Tasks.Get.WithContext(ctx),
+			task.client.Tasks.Get.WithWaitForCompletion(true),
+			task.client.Tasks.Get.WithTimeout(ASYNC_UPDATE_POLL_TIMEOUT),
+		)
+		if err != nil {
+			return 0, []string{err.Error()}
+		}
+
+		body, readErr := io.ReadAll(res.Body)
+		res.Body.Close()
+		if readErr != nil {
+			return 0, []string{readErr.Error()}
+		}
+
+		if res.IsError() {
+			return 0, []string{fmt.Sprintf("error retrieving task %s: %s", task.taskId, store.truncate(string(body)))}
+		}
+
+		parsed := gjson.ParseBytes(body)
+		if !parsed.Get("completed").Bool() {
+			if time.Now().After(deadline) {
+				return 0, []string{fmt.Sprintf("timed out waiting for task %s to complete", task.taskId)}
+			}
+			// Tasks.Get returned before the task finished (server-side poll timeout); keep waiting.
+			continue
+		}
+
+		updated, errs, rawErrs := parseAsyncUpdateOutcome(parsed)
+		if len(rawErrs) > 0 {
+			// Preserve the verbatim Elasticsearch error/failure JSON in the server logs while the
+			// client only receives the human-readable reasons in errs.
+			log.FromContext(ctx).WithFields(log.Fields{
+				"taskId": task.taskId,
+				"errors": rawErrs,
+			}).Error("Asynchronous Elasticsearch update reported errors")
+		}
+		return updated, errs
+	}
+}
+
+// parseAsyncUpdateOutcome extracts the updated count and any errors from a completed Tasks.Get
+// response (shape: {"completed":true,"task":{...},"response":{...},"error":{...}}). The returned
+// errs are human-readable messages safe to surface to clients; rawErrs carries the verbatim
+// Elasticsearch error/failure JSON for server-side logging.
+func parseAsyncUpdateOutcome(parsed gjson.Result) (updated int, errs []string, rawErrs []string) {
+	errs = make([]string, 0)
+	rawErrs = make([]string, 0)
+
+	if topErr := parsed.Get("error"); topErr.Exists() {
+		rawErrs = append(rawErrs, topErr.Raw)
+		errs = append(errs, asyncErrorReason(topErr))
+	}
+
+	resp := parsed.Get("response")
+	updated = int(resp.Get("updated").Int())
+
+	if resp.Get("timed_out").Bool() {
+		errs = append(errs, "timeout while updating documents in Elasticsearch")
+	}
+	for _, f := range resp.Get("failures").Array() {
+		rawErrs = append(rawErrs, f.Raw)
+		errs = append(errs, asyncErrorReason(f))
+	}
+
+	return updated, errs, rawErrs
+}
+
+// asyncErrorReason returns a concise, human-readable message from an Elasticsearch error object.
+// Bulk failures nest the detail under "cause"; top-level task errors are flat. It falls back to a
+// generic message when neither a reason nor a type is present.
+func asyncErrorReason(errObj gjson.Result) string {
+	if cause := errObj.Get("cause"); cause.Exists() {
+		errObj = cause
+	}
+	if reason := errObj.Get("reason").String(); reason != "" {
+		return reason
+	}
+	if errType := errObj.Get("type").String(); errType != "" {
+		return errType
+	}
+	return "an unexpected error occurred while updating events in Elasticsearch"
 }
 
 func (store *ElasticEventstore) refreshCache(ctx context.Context) {

--- a/server/modules/elastic/elasticeventstore_test.go
+++ b/server/modules/elastic/elasticeventstore_test.go
@@ -18,13 +18,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apex/log"
-	"github.com/apex/log/handlers/memory"
 	"github.com/security-onion-solutions/securityonion-soc/model"
 	"github.com/security-onion-solutions/securityonion-soc/server"
 	modmock "github.com/security-onion-solutions/securityonion-soc/server/modules/mock"
 
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
 )
 
 func TestFieldMapping(tester *testing.T) {
@@ -1407,9 +1408,9 @@ func TestPopulateJobFromDocQuery_TunnelPath(t *testing.T) {
 	client, transport := modmock.NewMockClient(t)
 	srv := server.NewFakeAuthorizedServer(nil)
 	store := &ElasticEventstore{
-		esClient:          client,
-		server:            srv,
-		index:             "myIndex",
+		esClient:           client,
+		server:             srv,
+		index:              "myIndex",
 		lookupTunnelParent: true,
 	}
 
@@ -1454,9 +1455,9 @@ func TestPopulateJobFromDocQuery_ZeekPath_Injection(t *testing.T) {
 	client, transport := modmock.NewMockClient(t)
 	srv := server.NewFakeAuthorizedServer(nil)
 	store := &ElasticEventstore{
-		esClient:          client,
-		server:            srv,
-		index:             "myIndex",
+		esClient: client,
+		server:   srv,
+		index:    "myIndex",
 	}
 
 	// 1. Initial response with missing IP/Port and malicious fuid
@@ -1520,7 +1521,7 @@ func TestMSearch_Index_Injection(t *testing.T) {
 
 	reqs := transport.GetRequests()
 	assert.NotEmpty(t, reqs)
-	
+
 	var foundReq *http.Request
 	for _, req := range reqs {
 		if req.Body != nil {
@@ -1576,7 +1577,7 @@ func TestScroll_InjectionAttacks(t *testing.T) {
 	transport.AddResponse(&http.Response{
 		StatusCode: 200,
 		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
-		Body: io.NopCloser(strings.NewReader(`{"took": 1, "timed_out": false, "_shards": {"total": 1, "successful": 1, "failed": 0}, "hits":{"total":2, "hits":[]}}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"took": 1, "timed_out": false, "_shards": {"total": 1, "successful": 1, "failed": 0}, "hits":{"total":2, "hits":[]}}`)),
 	}, nil)
 
 	_, err := store.Scroll(ctx, criteria, []string{attackIndex})
@@ -1603,4 +1604,160 @@ func TestScroll_InjectionAttacks(t *testing.T) {
 		body, _ := io.ReadAll(scrollReq.Body)
 		assert.Contains(t, string(body), `"scroll_id":"my-scroll-id\" OR { \"injected\": \"scroll\" }"`)
 	}
+}
+
+func TestConvertFromElasticAsyncUpdateResults(t *testing.T) {
+	taskId, err := convertFromElasticAsyncUpdateResults(`{"task":"node-1:42"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, "node-1:42", taskId)
+
+	_, err = convertFromElasticAsyncUpdateResults(`{"updated":3,"noops":0}`)
+	assert.Error(t, err, "a synchronous response has no task id")
+
+	_, err = convertFromElasticAsyncUpdateResults(`{"task":""}`)
+	assert.Error(t, err, "an empty task id is not valid")
+
+	_, err = convertFromElasticAsyncUpdateResults(`not json`)
+	assert.Error(t, err)
+}
+
+func TestParseAsyncUpdateOutcome(t *testing.T) {
+	// Success: all documents updated, no conflicts/failures.
+	updated, errs, rawErrs := parseAsyncUpdateOutcome(gjson.Parse(`{"completed":true,"response":{"updated":5,"version_conflicts":0,"timed_out":false,"failures":[]}}`))
+	assert.Equal(t, 5, updated)
+	assert.Empty(t, errs)
+	assert.Empty(t, rawErrs)
+
+	// Version conflicts are intentionally tolerated (conflicts=proceed); not surfaced as errors.
+	updated, errs, rawErrs = parseAsyncUpdateOutcome(gjson.Parse(`{"completed":true,"response":{"updated":3,"version_conflicts":2,"timed_out":false,"failures":[]}}`))
+	assert.Equal(t, 3, updated)
+	assert.Empty(t, errs)
+	assert.Empty(t, rawErrs)
+
+	// Bulk failures surface a human-readable reason to the client and the raw JSON for logging.
+	_, errs, rawErrs = parseAsyncUpdateOutcome(gjson.Parse(`{"completed":true,"response":{"updated":1,"failures":[{"cause":{"type":"mapper_parsing_exception","reason":"boom"}}]}}`))
+	assert.Equal(t, []string{"boom"}, errs)
+	assert.Len(t, rawErrs, 1)
+	assert.Contains(t, rawErrs[0], "mapper_parsing_exception")
+
+	// Timeout is surfaced.
+	_, errs, _ = parseAsyncUpdateOutcome(gjson.Parse(`{"completed":true,"response":{"updated":0,"timed_out":true,"failures":[]}}`))
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "timeout")
+
+	// A top-level task error: reason preferred, raw JSON retained for logging.
+	_, errs, rawErrs = parseAsyncUpdateOutcome(gjson.Parse(`{"completed":true,"error":{"type":"script_exception","reason":"bad script"},"response":{}}`))
+	assert.Equal(t, []string{"bad script"}, errs)
+	assert.Len(t, rawErrs, 1)
+	assert.Contains(t, rawErrs[0], "script_exception")
+
+	// When no reason is present, fall back to the type.
+	_, errs, _ = parseAsyncUpdateOutcome(gjson.Parse(`{"completed":true,"error":{"type":"script_exception"},"response":{}}`))
+	assert.Equal(t, []string{"script_exception"}, errs)
+
+	// When neither reason nor type is present, fall back to a generic message.
+	_, errs, _ = parseAsyncUpdateOutcome(gjson.Parse(`{"completed":true,"error":{},"response":{}}`))
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "unexpected error")
+}
+
+func TestWaitForUpdateTaskSuccess(t *testing.T) {
+	client, transport := modmock.NewMockClient(t)
+	store := &ElasticEventstore{}
+	transport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		Body:       io.NopCloser(strings.NewReader(`{"completed":true,"response":{"updated":7,"version_conflicts":0,"timed_out":false,"failures":[]}}`)),
+	}, nil)
+
+	updated, errs := store.waitForUpdateTask(context.Background(), asyncTaskRef{client: client, taskId: "node-1:42"})
+	assert.Equal(t, 7, updated)
+	assert.Empty(t, errs)
+}
+
+func TestWaitForUpdateTaskFailure(t *testing.T) {
+	client, transport := modmock.NewMockClient(t)
+	store := &ElasticEventstore{}
+	transport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		Body:       io.NopCloser(strings.NewReader(`{"completed":true,"response":{"updated":1,"version_conflicts":0,"timed_out":false,"failures":[{"cause":{"type":"mapper_parsing_exception","reason":"boom"}}]}}`)),
+	}, nil)
+
+	updated, errs := store.waitForUpdateTask(context.Background(), asyncTaskRef{client: client, taskId: "node-1:42"})
+	assert.Equal(t, 1, updated)
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "boom")
+}
+
+func TestAggregateAsyncUpdate(t *testing.T) {
+	store := &ElasticEventstore{}
+
+	okClient, okTransport := modmock.NewMockClient(t)
+	okTransport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		Body:       io.NopCloser(strings.NewReader(`{"completed":true,"response":{"updated":7,"version_conflicts":0,"timed_out":false,"failures":[]}}`)),
+	}, nil)
+
+	failClient, failTransport := modmock.NewMockClient(t)
+	failTransport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		Body:       io.NopCloser(strings.NewReader(`{"completed":true,"response":{"updated":3,"version_conflicts":0,"timed_out":false,"failures":[{"cause":{"type":"mapper_parsing_exception","reason":"boom"}}]}}`)),
+	}, nil)
+
+	tasks := []asyncTaskRef{
+		{client: okClient, taskId: "node-1:1"},
+		{client: failClient, taskId: "node-2:2"},
+	}
+	status := store.aggregateAsyncUpdate(context.Background(), tasks, []string{"node-1:1", "node-2:2"})
+
+	assert.Equal(t, []string{"node-1:1", "node-2:2"}, status.TaskIds)
+	assert.Equal(t, 10, status.Updated) // counts summed across both hosts (7 + 3)
+	assert.False(t, status.Success)     // one host reported a failure
+	assert.Equal(t, []string{"boom"}, status.Errors)
+}
+
+func TestAggregateAsyncUpdateCapsErrors(t *testing.T) {
+	store := &ElasticEventstore{}
+
+	failures := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		failures = append(failures, fmt.Sprintf(`{"cause":{"type":"mapper_parsing_exception","reason":"boom-%d"}}`, i))
+	}
+	body := fmt.Sprintf(`{"completed":true,"response":{"updated":0,"version_conflicts":0,"timed_out":false,"failures":[%s]}}`, strings.Join(failures, ","))
+
+	client, transport := modmock.NewMockClient(t)
+	transport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil)
+
+	status := store.aggregateAsyncUpdate(context.Background(), []asyncTaskRef{{client: client, taskId: "node-1:1"}}, []string{"node-1:1"})
+
+	assert.False(t, status.Success)
+	// 8 failures -> first 5 plus a single summary line.
+	assert.Len(t, status.Errors, ASYNC_UPDATE_MAX_ERRORS+1)
+	assert.Equal(t, "boom-0", status.Errors[0])
+	assert.Equal(t, "boom-4", status.Errors[4])
+	assert.Equal(t, "...and 3 more error(s)", status.Errors[ASYNC_UPDATE_MAX_ERRORS])
+}
+
+func TestWatchAsyncUpdate(t *testing.T) {
+	store := NewElasticEventstore(server.NewFakeAuthorizedServer(nil))
+
+	client, transport := modmock.NewMockClient(t)
+	transport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		Body:       io.NopCloser(strings.NewReader(`{"completed":true,"response":{"updated":4,"version_conflicts":0,"timed_out":false,"failures":[]}}`)),
+	}, nil)
+
+	// With no active websocket connections the broadcast is a no-op; this verifies the full
+	// watch-and-broadcast path runs to completion without panicking.
+	assert.NotPanics(t, func() {
+		store.watchAsyncUpdate(context.Background(), []asyncTaskRef{{client: client, taskId: "node-1:1"}}, []string{"node-1:1"})
+	})
 }


### PR DESCRIPTION
Success or failure, when bulk acking alerts there is now a notification sent back to the user when the action completes. It indicates how many alerts where modified or gives a handful of errors if there were problems.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->