### PR TITLE
Fix Docs

### DIFF
--- a/model/assistant.go
+++ b/model/assistant.go
@@ -452,7 +452,7 @@ type PendingToolApproval struct {
 	SessionId string          `json:"sessionId"`
 	ToolUseId string          `json:"toolUseId"`
 	ToolName  string          `json:"toolName"`
-	Input     json.RawMessage `json:"input,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty" swaggertype:"object"`
 }
 
 type ModelUsageStats struct {


### PR DESCRIPTION
Swagger doesn't know how to mark `json.RawMessage` in it's documentation so I added a tag to treat it like an object.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->