### PR TITLE
Allow Segments to Wrap

### DIFF
--- a/html/css/modern.css
+++ b/html/css/modern.css
@@ -106,6 +106,16 @@ html, body, * {
   border-radius: var(--so-radius-pill) !important;
 }
 
+.toolbar-container {
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.toolbar-col {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .circle-button {
   background-color: rgba(var(--v-theme-primary));
   color: rgba(var(--v-theme-button_icon_color)) !important;

--- a/html/pages/assistant.html
+++ b/html/pages/assistant.html
@@ -86,7 +86,7 @@
 			</v-card-actions>
 		</v-card>
 	</v-dialog>
-	<v-row align="stretch" class="ga-3" style="flex-wrap: nowrap;">
+	<v-row align="stretch" class="ga-3 flex-wrap">
 		<v-col v-if="adaptersMap.get(modelsMap.get(currentModel)?.adapter)?.protocol === 'securityonion_ai_cloud'">
 			<div class="so-stat-pill" data-aid="assistant_credits_remaining">
 				<div class="so-stat-text">

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -56,8 +56,8 @@
 						</v-card-actions>
 					</v-card>
 				</v-dialog>
-			<v-row align="start" class="no-print" style="gap: 8px; flex-wrap: nowrap;">
-				<v-col style="flex: 1 1 auto; min-width: 0;" class="pa-0">
+			<v-row align="start" class="no-print toolbar-container">
+				<v-col class="toolbar-col pa-0">
 					<v-toolbar class="so-toolbar elevation-0" variant="flat">
 						<v-textarea :clearable="isAdvanced()" :auto-grow="isAdvanced()" :readonly="!isAdvanced()" :disabled="loading()" @input="queryAltered = true"
 							@change="queryModified" class="mx-2" v-model="$data[getDisplayedQueryVar()]" :hint="isAdvanced() && queryAltered ? i18n.queryHelp : ''"


### PR DESCRIPTION
On the hunt pages, we put the search box, time window, and options in 3 segments on 1 line. As the page shrinks, the controls tend to be unusable as they resize to stay on the same horizontal line, usually this causes the search box to balloon vertically. A similar toolbar setup is used on the OnionAI page.

Allowing each segment to wrap to a new row when necessary helps maintain the functionality of the site.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->