### PR TITLE
Resolve agent adapters from configured model, not a hardcoded SOAI default

### DIFF
--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -409,13 +409,12 @@ func (ac *AssistantCoordinator) IsRunning() bool {
 	return ac.isRunning
 }
 
-func splitModelAdapter(aiModel string) (string, string) {
-	parts := strings.SplitN(aiModel, "@", 2)
-	if len(parts) == 1 {
-		parts = append(parts, "SOAI")
-	}
-
-	return parts[0], parts[1]
+// splitModelAdapter splits a legacy "id@adapter" selector; hasAdapter reports
+// whether an explicit "@adapter" was present. Callers must not assume a default
+// adapter when it is false (a bare id uses the configured model's own adapter).
+func splitModelAdapter(aiModel string) (id string, adapter string, hasAdapter bool) {
+	id, adapter, hasAdapter = strings.Cut(aiModel, "@")
+	return id, adapter, hasAdapter
 }
 
 func estimateRequestChars(req *model.ChatRequest) int {
@@ -444,6 +443,7 @@ func (ac *AssistantCoordinator) validateModelSelectors() {
 	models := ac.srv.Config.ClientParams.AssistantParams.AvailableModels
 
 	seen := map[string]string{}
+	seenID := map[string]string{}
 	for i := range models {
 		m := &models[i]
 		if !m.Enabled {
@@ -460,6 +460,17 @@ func (ac *AssistantCoordinator) validateModelSelectors() {
 			}).Error("model is missing required displayName; disabling it")
 			m.Enabled = false
 			continue
+		}
+
+		// Two enabled models sharing an id make bare-id resolution ambiguous.
+		if owner, dup := seenID[m.ID]; dup {
+			logger.WithFields(log.Fields{
+				"modelId":    m.ID,
+				"firstModel": owner,
+				"alsoModel":  m.LegacySelector(),
+			}).Warn("multiple enabled models share an id; bare-id selectors (e.g. agent mappings) resolve to the first configured one")
+		} else {
+			seenID[m.ID] = m.LegacySelector()
 		}
 
 		if strings.Contains(m.DisplayName, "@") {
@@ -508,15 +519,26 @@ func (ac *AssistantCoordinator) resolveModel(selector string) *model.ModelParame
 		}
 	}
 
-	// Pass 2: legacy id@adapter.
-	modelId, adapterName := splitModelAdapter(selector)
+	// Pass 2: legacy "id@adapter" (matches both), or a bare id (matches id alone
+	// and uses that model's own adapter). Prefer an enabled model, else first match.
+	modelId, adapterName, hasAdapter := splitModelAdapter(selector)
+	var fallback *model.ModelParameters
 	for i := range models {
-		if models[i].ID == modelId && models[i].Adapter == adapterName {
+		if models[i].ID != modelId {
+			continue
+		}
+		if hasAdapter && models[i].Adapter != adapterName {
+			continue
+		}
+		if models[i].Enabled {
 			return &models[i]
+		}
+		if fallback == nil {
+			fallback = &models[i]
 		}
 	}
 
-	return nil
+	return fallback
 }
 
 // resolveAgent resolves an agent name to its definition and the model that
@@ -559,9 +581,14 @@ func (ac *AssistantCoordinator) resolveAdapterName(selector string) string {
 		return params.Adapter
 	}
 
-	_, adapterName := splitModelAdapter(selector)
+	// No model matched: honor an explicit "@adapter" (a registered adapter with
+	// no AvailableModels entry); otherwise return the selector verbatim so the
+	// caller reports it rather than falling back to a phantom default adapter.
+	if _, adapterName, hasAdapter := splitModelAdapter(selector); hasAdapter {
+		return adapterName
+	}
 
-	return adapterName
+	return selector
 }
 
 func (ac *AssistantCoordinator) checkRequestSize(req *model.ChatRequest, params *model.ModelParameters) error {

--- a/server/modules/assistant/assistant_test.go
+++ b/server/modules/assistant/assistant_test.go
@@ -3271,8 +3271,21 @@ func TestResolveAdapterName(t *testing.T) {
 	// Unconfigured model falls back to the legacy split so a registered adapter
 	// without an AvailableModels entry can still answer.
 	assert.Equal(t, "MyAdapter", ac.resolveAdapterName("other@MyAdapter"))
-	// Bare selector with no match keeps the historical SOAI default.
-	assert.Equal(t, "SOAI", ac.resolveAdapterName("unknown"))
+	// A bare, unresolved selector is returned verbatim, not a phantom default.
+	assert.Equal(t, "unknown", ac.resolveAdapterName("unknown"))
+}
+
+// Regression guard: an agent mapped by bare model id to a non-SOAI adapter must
+// route to that model's real adapter, as the non-agentic DisplayName path does.
+func TestResolveAdapterNameAgenticHonorsModelAdapter(t *testing.T) {
+	ac := newResolveTestCoordinator([]model.ModelParameters{
+		{ID: "sonnet", DisplayName: "Claude Sonnet", Adapter: "SOAIDEV", Enabled: true},
+	})
+	ac.isAgentic = true
+	ac.agents = map[string]model.AgentParameters{"Orchestrator": {Name: "Orchestrator"}}
+	ac.agentMapping = map[string]string{"Orchestrator": "sonnet"}
+
+	assert.Equal(t, "SOAIDEV", ac.resolveAdapterName("Orchestrator"))
 }
 
 // captureAdapter records the ChatRequest handed to it so tests can assert what


### PR DESCRIPTION
## Problem

Enabling agentic mode fails at the balance/health check with:

```
assistant adapter not found: SOAI ... unable to get assistant health
```

on deployments that configure adapters under a different name (e.g. `SOAIDEV`/`SOAIPROD`) and have **no** adapter literally named `SOAI`. Non-agentic mode works fine on the same config.

## Root cause

Both modes resolve a selector to a model and use that model's `.Adapter`, but they feed different selectors:

- **Non-agentic** → the model's **DisplayName** → `resolveModel` pass 1 → returns the model with its real adapter. ✅
- **Agentic** → an agent name → `agentMapping[name]` = a bare model **id** (e.g. `sonnet`) → `resolveModel("sonnet")` missed pass 1 and fell to the legacy `id@adapter` path, where `splitModelAdapter` fabricated `("sonnet", "SOAI")` and required `Adapter == "SOAI"`. With a renamed adapter nothing matched, and resolution fell through to the hardcoded `SOAI` default.

So agentic mode silently ignored the operator's adapter config.

## Fix

- `splitModelAdapter` no longer injects a `SOAI` default; it reports whether an explicit `@adapter` was present.
- `resolveModel` pass 2: a bare id matches on **id alone** and uses that model's **own** configured adapter (preferring an enabled model). Explicit `id@adapter` still matches both, so legacy sessions are unaffected.
- `resolveAdapterName` returns an unresolved bare selector verbatim instead of inventing `SOAI`, so real misconfiguration surfaces as `adapter not found: <selector>`.
- `validateModelSelectors` warns once at startup if two enabled models share an id (the only new ambiguity bare-id resolution introduces).

Agentic now resolves the same source of truth as non-agentic, and the stock `agentMapping` (bare id `sonnet`) keeps working unchanged.

## Tests

- Updated `TestResolveAdapterName` (it asserted the old phantom-`SOAI` behavior).
- Added `TestResolveAdapterNameAgenticHonorsModelAdapter` as a regression guard.
- `go test ./server/modules/assistant/...` passes.