### PR TITLE
Rename Detection Engineer agent to DetectionEngineer

### DIFF
--- a/server/modules/assistant/agentic.go
+++ b/server/modules/assistant/agentic.go
@@ -33,20 +33,20 @@ func (ac *AssistantCoordinator) setupAgentic() {
 			Name:           "Orchestrator",
 			IsOrchestrator: true,
 			AllowedSkills:  []string{},
-			CanDelegateTo:  []string{"Investigator", "Detection Engineer"},
+			CanDelegateTo:  []string{"Investigator", "DetectionEngineer"},
 			Prompt:         prompts["prompt_agent_orchestrator"],
 		},
 		"Investigator": {
 			Name:          "Investigator",
 			AllowedSkills: []string{"Hunt", "Playbooks", "Respond"},
-			CanDelegateTo: []string{"Detection Engineer"},
+			CanDelegateTo: []string{"DetectionEngineer"},
 			Prompt:        prompts["prompt_agent_investigator"],
 			Description: "Investigates alerts, explains events and records, and answers open questions about activity in event data. " +
 				"Also acknowledges alerts, escalates to cases, and looks up cases. " +
 				"Objectives must include all identifiers verbatim.",
 		},
-		"Detection Engineer": {
-			Name:          "Detection Engineer",
+		"DetectionEngineer": {
+			Name:          "DetectionEngineer",
 			AllowedSkills: []string{"Detections", "Tuning", "Hunt"},
 			CanDelegateTo: []string{},
 			Prompt:        prompts["prompt_agent_engineer"],

--- a/server/modules/assistant/agentic_test.go
+++ b/server/modules/assistant/agentic_test.go
@@ -84,9 +84,9 @@ func TestAssistantCoordinator_InitAgenticToggle(t *testing.T) {
 		err := ac.Init(module.ModuleConfig{
 			"agentic": true,
 			"agentMapping": map[string]any{
-				"Orchestrator":       "Classic",
-				"Investigator":       "Classic",
-				"Detection Engineer": "Classic",
+				"Orchestrator":      "Classic",
+				"Investigator":      "Classic",
+				"DetectionEngineer": "Classic",
 			},
 		})
 		assert.NoError(t, err)
@@ -100,34 +100,34 @@ func TestAssistantCoordinator_InitAgenticToggle(t *testing.T) {
 		assert.Len(t, ac.agents, 3)
 		assert.Equal(t, "Classic", ac.agentMapping["Orchestrator"])
 		assert.Equal(t, "Classic", ac.agentMapping["Investigator"])
-		assert.Equal(t, "Classic", ac.agentMapping["Detection Engineer"])
+		assert.Equal(t, "Classic", ac.agentMapping["DetectionEngineer"])
 
 		// The agentic flag, agent list, and mapping are exposed to clients.
 		assert.True(t, srv.Config.ClientParams.AssistantParams.Agentic)
 		assert.Len(t, srv.Config.ClientParams.AssistantParams.AvailableAgents, 3)
 		assert.Equal(t, map[string]string{
-			"Orchestrator":       "Classic",
-			"Investigator":       "Classic",
-			"Detection Engineer": "Classic",
+			"Orchestrator":      "Classic",
+			"Investigator":      "Classic",
+			"DetectionEngineer": "Classic",
 		}, srv.Config.ClientParams.AssistantParams.AgentMapping)
 
 		// Delegation topology: hub-and-spoke plus the Investigator -> Engineer
 		// handoff edge; the Engineer is terminal.
-		assert.ElementsMatch(t, []string{"Investigator", "Detection Engineer"}, ac.agents["Orchestrator"].CanDelegateTo)
-		assert.Equal(t, []string{"Detection Engineer"}, ac.agents["Investigator"].CanDelegateTo)
-		assert.Empty(t, ac.agents["Detection Engineer"].CanDelegateTo)
+		assert.ElementsMatch(t, []string{"Investigator", "DetectionEngineer"}, ac.agents["Orchestrator"].CanDelegateTo)
+		assert.Equal(t, []string{"DetectionEngineer"}, ac.agents["Investigator"].CanDelegateTo)
+		assert.Empty(t, ac.agents["DetectionEngineer"].CanDelegateTo)
 
 		// Skill wiring is a permission boundary: Tuning (the write skill) is
 		// Engineer-only, and the Orchestrator holds no skills.
 		assert.ElementsMatch(t, []string{"Hunt", "Playbooks", "Respond"}, ac.agents["Investigator"].AllowedSkills)
-		assert.ElementsMatch(t, []string{"Detections", "Tuning", "Hunt"}, ac.agents["Detection Engineer"].AllowedSkills)
+		assert.ElementsMatch(t, []string{"Detections", "Tuning", "Hunt"}, ac.agents["DetectionEngineer"].AllowedSkills)
 		assert.Empty(t, ac.agents["Orchestrator"].AllowedSkills)
 
 		// Delegate tools are registered under both the agent name and the
 		// sanitized tool name.
 		for _, key := range []string{
 			"Investigator", "delegate_to_Investigator",
-			"Detection Engineer", "delegate_to_Detection_Engineer",
+			"DetectionEngineer", "delegate_to_DetectionEngineer",
 		} {
 			_, ok := ac.DelegationLibrary[key]
 			assert.True(t, ok, "missing delegate registration for %s", key)
@@ -157,12 +157,12 @@ func TestAssistantCoordinator_InitAgenticToggle(t *testing.T) {
 		// The exposed mapping only includes the surviving agent.
 		assert.Equal(t, map[string]string{"Investigator": "Classic"}, srv.Config.ClientParams.AssistantParams.AgentMapping)
 
-		// No delegate tool is registered for the dropped Detection Engineer, so
+		// No delegate tool is registered for the dropped DetectionEngineer, so
 		// the Investigator's CanDelegateTo edge degrades to no tool rather than
 		// a delegate targeting an agent that cannot run.
-		_, ok := ac.DelegationLibrary["Detection Engineer"]
+		_, ok := ac.DelegationLibrary["DetectionEngineer"]
 		assert.False(t, ok)
-		_, ok = ac.DelegationLibrary["delegate_to_Detection_Engineer"]
+		_, ok = ac.DelegationLibrary["delegate_to_DetectionEngineer"]
 		assert.False(t, ok)
 		_, ok = ac.DelegationLibrary["Investigator"]
 		assert.True(t, ok)


### PR DESCRIPTION
## Why

The agent name is load-bearing in more places than a display label: it is a Go map key, the **`agentMapping` config key**, and therefore a segment of the SOC setting id (`...assistant.agentMapping.Detection Engineer`). The embedded space made that identifier awkward to target in config.

Renamed to `DetectionEngineer`, matching the single-token style of `Orchestrator` and `Investigator`.

## Changes

- `agentic.go` — map key, `Name`, and both `CanDelegateTo` references.
- `agentic_test.go` — updated expectations, including the derived tool name.

The generated delegate tool name changes from `delegate_to_Detection_Engineer` to `delegate_to_DetectionEngineer` (`sanitizeDelegateToolName` no longer has a space to substitute).

## Coordination

- Companion config change in securityonion (`defaults.yaml` + `soc_soc.yaml` agentMapping key) — must land together, or `validateAgentMappings` drops the agent.
- **The agentic prompts are not in this repo.** They are built from `src2/agentic/*.md` at image build (see `Dockerfile`). If any prompt refers to "Detection Engineer" by name, update it in lockstep.

No back-compat alias: any deployment overriding this agent must update its pillar to the new key.

## Tests

`go test ./server/modules/assistant/...` passes.