### PR TITLE
Assistant: Per-Delegation Token Tracking

### DIFF
--- a/html/css/modern.css
+++ b/html/css/modern.css
@@ -1234,8 +1234,8 @@ dfn {
   overflow-y: auto;
 }
 
-/* Per-invocation credit cost shown beside a delegate's agent name. */
-.delegation-child-credits {
+/* Per-invocation stats (credits, output tokens) beside a delegate's agent name. */
+.delegation-child-stat {
   font-variant-numeric: tabular-nums;
 }
 

--- a/html/js/routes/assistant.streaming.js
+++ b/html/js/routes/assistant.streaming.js
@@ -561,6 +561,14 @@ globalThis.AssistantStreaming = (function() {
       return cs.messages.reduce((sum, m) => sum + ((m.usage && m.usage.credits) || 0), 0);
     },
 
+    // Output tokens this delegate's own turns generated — the number its per-sub-session
+    // output-token budget constrains. Leaf-scoped like delegateOwnCredits.
+    delegateOwnOutputTokens(delegateToolUse) {
+      const cs = delegateToolUse && delegateToolUse.childSession;
+      if (!cs || !Array.isArray(cs.messages)) return 0;
+      return cs.messages.reduce((sum, m) => sum + ((m.usage && m.usage.output_tokens) || 0), 0);
+    },
+
     // Whether the collapsed sub-agent region has anything worth showing — avoids an empty
     // expandable when the only activity so far is a still-pending tool shown outside.
     delegationHasCollapsedContent(delegateToolUse) {

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -6290,6 +6290,31 @@ test('delegateOwnCredits returns 0 when there is no child session', () => {
   expect(comp.delegateOwnCredits({ childSession: {} })).toBe(0);
 });
 
+test('delegateOwnOutputTokens sums only the delegate\'s own direct child messages', () => {
+  const delegate = { childSession: { messages: [
+    { usage: { output_tokens: 300, input_tokens: 9000, credits: 5 } },
+    { usage: { output_tokens: 120 } },
+    { /* no usage */ },
+    { usage: { credits: 2 } }, // no output_tokens field
+  ] } };
+  expect(comp.delegateOwnOutputTokens(delegate)).toBe(420);
+});
+
+test('delegateOwnOutputTokens excludes grandchild delegations', () => {
+  const delegate = { childSession: { messages: [
+    { usage: { output_tokens: 100 }, toolUses: [
+      { name: 'delegate_to_reviewer', childSession: { messages: [{ usage: { output_tokens: 999 } }] } },
+    ] },
+  ] } };
+  expect(comp.delegateOwnOutputTokens(delegate)).toBe(100);
+});
+
+test('delegateOwnOutputTokens returns 0 when there is no child session', () => {
+  expect(comp.delegateOwnOutputTokens(null)).toBe(0);
+  expect(comp.delegateOwnOutputTokens({})).toBe(0);
+  expect(comp.delegateOwnOutputTokens({ childSession: {} })).toBe(0);
+});
+
 // Floating tool tests
 test('sendMessage marks floating tool as skipped when sending new message', async () => {
   const floatingTool = {

--- a/html/pages/delegation-child.html
+++ b/html/pages/delegation-child.html
@@ -6,7 +6,11 @@
         <span class="font-weight-medium text-body-2">{{ toolUse.childSession.agentName || ctx.i18n.assistantDelegateAgent }}</span>
         <template v-if="ctx.delegateOwnCredits(toolUse) > 0">
           <span class="text-medium-emphasis mx-2">·</span>
-          <span class="text-body-2 text-primary delegation-child-credits" data-aid="assistant_delegation_credits">{{ ctx.formatCount(ctx.delegateOwnCredits(toolUse)) }} {{ ctx.i18n.creditsLowercase }}</span>
+          <span class="text-body-2 text-primary delegation-child-stat" data-aid="assistant_delegation_credits">{{ ctx.formatCount(ctx.delegateOwnCredits(toolUse)) }} {{ ctx.i18n.creditsLowercase }}</span>
+        </template>
+        <template v-if="ctx.delegateOwnOutputTokens(toolUse) > 0">
+          <span class="text-medium-emphasis mx-2">·</span>
+          <span class="text-body-2 text-green delegation-child-stat" data-aid="assistant_delegation_tokens">{{ ctx.formatCount(ctx.delegateOwnOutputTokens(toolUse)) }} {{ ctx.i18n.tokensLowercase }}</span>
         </template>
       </v-expansion-panel-title>
       <v-expansion-panel-text>


### PR DESCRIPTION
## Description

- Added per-delegation output token tracking on the Assistant page, which is located next to the credit tally for each delegation in an agentic session.

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments