### PR TITLE
Add guard for when ES is mostly unavailable 

### DIFF
--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -877,15 +877,19 @@ func (e *SuricataEngine) logDuplicates(duplicates map[string]DuplicateInfo) {
 }
 
 // applyUserState applies user preferences from Elasticsearch to detections
-func (e *SuricataEngine) applyUserState(ctx context.Context, detections []*model.Detection) error {
+func (e *SuricataEngine) applyUserState(ctx context.Context, dets []*model.Detection) error {
 	existingDetections, err := e.getAllSuricataDetections(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get existing detections: %w", err)
 	}
 
+	if err := e.checkExistingDetectionsPlausible(existingDetections, dets); err != nil {
+		return err
+	}
+
 	stats := &StateStats{}
 
-	for _, det := range detections {
+	for _, det := range dets {
 		if existing, exists := existingDetections[det.PublicID]; exists {
 			e.applyExistingRuleState(det, existing, stats)
 		} else {
@@ -894,8 +898,38 @@ func (e *SuricataEngine) applyUserState(ctx context.Context, detections []*model
 		e.ApplyFilters(det)
 	}
 
-	e.logStateApplication(stats, len(detections))
+	e.logStateApplication(stats, len(dets))
 	return nil
+}
+
+// checkExistingDetectionsPlausible guards against a silently empty read of the
+// detection store: a cross-cluster search with an unavailable remote returns
+// zero hits and no error. If the state file shows a prior import but the store
+// is empty, fail the sync rather than redeploy every rule at vendor defaults.
+// Mirrors the guards in the ElastAlert and Strelka engines.
+func (e *SuricataEngine) checkExistingDetectionsPlausible(existing map[string]*model.Detection, parsed []*model.Detection) error {
+	if len(existing) != 0 || len(parsed) == 0 {
+		return nil
+	}
+
+	state, err := detections.ReadStateFile(e.IOManager, e.StateFilePath)
+	if err != nil {
+		e.logger().WithError(err).Error("unable to read state file while validating detection store read")
+		return detections.ErrStateFileNoCommunity
+	}
+
+	if state == nil || *state == 0 {
+		// first import, empty store expected
+		return nil
+	}
+
+	e.logger().WithFields(log.Fields{
+		"parsedRules":   len(parsed),
+		"existingRules": 0,
+		"stateFilePath": e.StateFilePath,
+	}).Error("state file present but detection store returned 0 detections, aborting sync to avoid redeploying rules at vendor defaults")
+
+	return detections.ErrStateFileNoCommunity
 }
 
 // applyExistingRuleState applies state from existing ES detection

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -906,7 +906,6 @@ func (e *SuricataEngine) applyUserState(ctx context.Context, dets []*model.Detec
 // detection store: a cross-cluster search with an unavailable remote returns
 // zero hits and no error. If the state file shows a prior import but the store
 // is empty, fail the sync rather than redeploy every rule at vendor defaults.
-// Mirrors the guards in the ElastAlert and Strelka engines.
 func (e *SuricataEngine) checkExistingDetectionsPlausible(existing map[string]*model.Detection, parsed []*model.Detection) error {
 	if len(existing) != 0 || len(parsed) == 0 {
 		return nil

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -1680,6 +1680,122 @@ func TestApplyUserState(t *testing.T) {
 	assert.True(t, detections[1].IsEnabled)
 }
 
+// An empty store read with a state file present must abort the sync, not
+// redeploy every rule at its vendor default.
+func TestApplyUserStateEmptyStoreGuard(t *testing.T) {
+	newParsedRules := func() []*model.Detection {
+		return []*model.Detection{
+			{
+				PublicID:  "1001",
+				Content:   `alert tcp any any -> any any (msg:"Test Rule 1"; sid:1001;)`,
+				IsEnabled: true, // vendor default
+				Ruleset:   "ETOPEN",
+			},
+		}
+	}
+
+	tests := []struct {
+		Name          string
+		StateFile     []byte
+		StateFileErr  error
+		ExpectedErr   error
+		ExpectEnabled bool
+	}{
+		{
+			Name:          "State File Present, Empty Store Aborts Sync",
+			StateFile:     []byte("1753304832"),
+			ExpectedErr:   detections.ErrStateFileNoCommunity,
+			ExpectEnabled: true, // untouched, sync aborted
+		},
+		{
+			Name:          "No State File Is A First Import",
+			StateFileErr:  os.ErrNotExist,
+			ExpectedErr:   nil,
+			ExpectEnabled: true,
+		},
+		{
+			Name:          "Unreadable State File Aborts Sync",
+			StateFileErr:  errors.New("permission denied"),
+			ExpectedErr:   detections.ErrStateFileNoCommunity,
+			ExpectEnabled: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			detStore := servermock.NewMockDetectionstore(ctrl)
+			iom := mock.NewMockIOManager(ctrl)
+
+			eng := &SuricataEngine{
+				srv: &server.Server{
+					Detectionstore: detStore,
+					Context:        ctx,
+				},
+				IOManager: iom,
+				SyncSchedulerParams: detections.SyncSchedulerParams{
+					StateFilePath: "stateFilePath",
+				},
+				isRunning: true,
+			}
+
+			// the silently-empty read
+			detStore.EXPECT().GetAllDetections(ctx, gomock.Any()).Return(map[string]*model.Detection{}, nil)
+			iom.EXPECT().ReadFile("stateFilePath").Return(test.StateFile, test.StateFileErr)
+
+			parsed := newParsedRules()
+			err := eng.applyUserState(ctx, parsed)
+
+			assert.Equal(t, test.ExpectedErr, err)
+			assert.Equal(t, test.ExpectEnabled, parsed[0].IsEnabled)
+		})
+	}
+}
+
+// A populated store must not read the state file.
+func TestApplyUserStateGuardSkippedWhenStorePopulated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	iom := mock.NewMockIOManager(ctrl)
+
+	eng := &SuricataEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+			Context:        ctx,
+		},
+		IOManager: iom,
+		SyncSchedulerParams: detections.SyncSchedulerParams{
+			StateFilePath: "stateFilePath",
+		},
+		isRunning: true,
+	}
+
+	parsed := []*model.Detection{
+		{
+			PublicID:  "1001",
+			Content:   `alert tcp any any -> any any (msg:"Test Rule 1"; sid:1001;)`,
+			IsEnabled: true,
+			Ruleset:   "ETOPEN",
+		},
+	}
+
+	detStore.EXPECT().GetAllDetections(ctx, gomock.Any()).Return(map[string]*model.Detection{
+		"1001": {PublicID: "1001", IsEnabled: false, Ruleset: "ETOPEN"},
+	}, nil)
+	// no iom.ReadFile expectation: the guard must short-circuit
+
+	err := eng.applyUserState(ctx, parsed)
+
+	assert.NoError(t, err)
+	assert.False(t, parsed[0].IsEnabled, "user's disabled state should be applied")
+}
+
 // Test writeAllRulesFile method
 func TestWriteAllRulesFile(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
Guards against a silently empty read of the detection store: a cross-cluster search with an unavailable remote returns zero hits and no error. If the state file shows a prior import but the store is empty, fail the sync rather than redeploy every rule at vendor defaults.
