### PR TITLE
UI Improvements to Collapsible Section Panels and Table Entries

### DIFF
--- a/html/css/app.css
+++ b/html/css/app.css
@@ -289,6 +289,12 @@ th:hover, th.is-sorted, .solid {
   overflow-x: hidden;
 }
 
+/* vuetify disables selection on every th; field keys in expanded rows must stay copyable */
+th.expansion {
+  user-select: text !important;
+  -webkit-user-select: text !important;
+}
+
 th.sortable {
   white-space: nowrap;
 }

--- a/html/js/routes/aimetrics.js
+++ b/html/js/routes/aimetrics.js
@@ -283,6 +283,7 @@ routes.push({ path: '/aimetrics/:userId?/:sessionId?', name: 'aimetrics', compon
       this.saveSetting('relativeTimeValue', this.relativeTimeValue, 24);
       this.saveSetting('relativeTimeUnit', this.relativeTimeUnit, RELATIVE_TIME_HOURS);
       this.saveSetting('autoRefreshInterval', this.autoRefreshInterval, 0);
+      this.saveSetting('collapsedSections', JSON.stringify(this.collapsedSections), '[]');
       localStorage['timezone'] = this.zone;
     },
     loadLocalSettings() {
@@ -300,6 +301,7 @@ routes.push({ path: '/aimetrics/:userId?/:sessionId?', name: 'aimetrics', compon
       if (localStorage['settings.aimetrics.relativeTimeUnit']) this.relativeTimeUnit = parseInt(localStorage['settings.aimetrics.relativeTimeUnit']);
       if (localStorage['timezone']) this.zone = localStorage['timezone'];
       if (localStorage['settings.aimetrics.autoRefreshInterval']) this.autoRefreshInterval = parseInt(localStorage['settings.aimetrics.autoRefreshInterval']);
+      if (localStorage['settings.aimetrics.collapsedSections']) this.collapsedSections = JSON.parse(localStorage['settings.aimetrics.collapsedSections']);
     },
     buildUserLink(userId) {
       return { name: 'aimetrics', params: { userId: userId } };
@@ -545,6 +547,7 @@ routes.push({ path: '/aimetrics/:userId?/:sessionId?', name: 'aimetrics', compon
       } else {
         this.collapsedSections.splice(this.collapsedSections.indexOf(item), 1);
       }
+      this.saveLocalSettings();
     },
     isExpandedSection(item) {
       return (this.collapsedSections.indexOf(item) == -1);

--- a/html/js/routes/aimetrics.test.js
+++ b/html/js/routes/aimetrics.test.js
@@ -1662,6 +1662,21 @@ test('toggleShowSection removes item from collapsed sections', () => {
   expect(comp.collapsedSections).not.toContain('section1');
 });
 
+test('collapsedSections persist across reloads', () => {
+  comp.collapsedSections = [];
+
+  comp.toggleShowSection('aimetrics-graphs');
+  expect(comp.collapsedSections).toEqual(['aimetrics-graphs']);
+
+  comp.collapsedSections = [];
+  comp.loadLocalSettings();
+  expect(comp.collapsedSections).toEqual(['aimetrics-graphs']);
+
+  // back to all-expanded clears the stored setting
+  comp.toggleShowSection('aimetrics-graphs');
+  expect(localStorage['settings.aimetrics.collapsedSections']).toBeUndefined();
+});
+
 test('isExpandedSection returns true when section not collapsed', () => {
   comp.collapsedSections = ['section2'];
   

--- a/html/js/routes/hunt.js
+++ b/html/js/routes/hunt.js
@@ -2300,6 +2300,7 @@ const huntComponent = {
       this.saveSetting('showDetailsPanel', this.showDetailsPanel, this.isCategory('alerts'));
       this.saveSetting('advanced', this.advanced, false);
       this.saveSetting('gridLayoutExpansions', this.gridLayoutExpansions, false);
+      this.saveSetting('collapsedSections', JSON.stringify(this.collapsedSections), '[]');
     },
     loadLocalSettings() {
       // Global settings
@@ -2323,6 +2324,7 @@ const huntComponent = {
       if (localStorage[prefix + '.advanced']) this.advanced = localStorage[prefix + '.advanced'] == 'true';
       if (localStorage[prefix + '.gridLayoutExpansions']) this.gridLayoutExpansions = localStorage[prefix + '.gridLayoutExpansions'] == 'true';
       if (localStorage[prefix + '.autoRefreshInterval']) this.autoRefreshInterval = parseInt(localStorage[prefix + '.autoRefreshInterval']);
+      if (localStorage[prefix + '.collapsedSections']) this.collapsedSections = JSON.parse(localStorage[prefix + '.collapsedSections']);
 
       if (localStorage['settings.case.mruCases']) this.mruCases = JSON.parse(localStorage['settings.case.mruCases']);
     },
@@ -2332,6 +2334,7 @@ const huntComponent = {
       } else {
         this.collapsedSections.splice(this.collapsedSections.indexOf(item), 1);
       }
+      this.saveLocalSettings();
     },
     isExpandedSection(item) {
       return (this.collapsedSections.indexOf(item) == -1);
@@ -2794,7 +2797,7 @@ const huntComponent = {
     calculateEventColumnWidth() {
       const el = this.$refs?.eventColumn?.$el || this.$refs?.eventColumn;
       this.eventColumnWidth = el?.clientWidth || 0;
-      if (this.eventColumnWidth === 0) {
+      if (this.eventColumnWidth === 0 && this.isExpandedSection('hunt-events')) {
         setTimeout(() => {
           this.calculateEventColumnWidth();
         }, 300);

--- a/html/js/routes/hunt.test.js
+++ b/html/js/routes/hunt.test.js
@@ -165,6 +165,25 @@ test('saveTimezone', () => {
   expect(comp.zone).toBe("Foo/Bar");
 });
 
+test('collapsedSections persist across reloads', () => {
+  const origParams = comp.params;
+  comp.params = {};
+  comp.collapsedSections = [];
+
+  comp.toggleShowSection('hunt-graphs');
+  expect(comp.collapsedSections).toEqual(['hunt-graphs']);
+
+  comp.collapsedSections = [];
+  comp.loadLocalSettings();
+  expect(comp.collapsedSections).toEqual(['hunt-graphs']);
+
+  // back to all-expanded clears the stored setting
+  comp.toggleShowSection('hunt-graphs');
+  expect(localStorage['settings.' + comp.category + '.collapsedSections']).toBeUndefined();
+
+  comp.params = origParams;
+});
+
 test('removeFilter', () => {
   comp.query = "abc def | groupby foo bar*";
   comp.$router.resolve = jest.fn();

--- a/html/pages/hunt.html
+++ b/html/pages/hunt.html
@@ -465,7 +465,7 @@
 																						<v-icon :alt="i18n.addColumnHeader" :color="isColumnHeader(kvp.key) ? 'info' : ''" :title="i18n.addColumnHeaderHelp">fa-table-columns</v-icon>
 																					</v-btn>
 																				</div>
-																				<div :id="'events_fields_' + category + '_' + kvp.key" class="d-inline-block expansion va-middle" v-text="kvp.key" :data-aid="'events_field_name_' + category"></div>
+																				<div :id="'events_fields_' + category + '_' + kvp.key" class="d-inline-block expansion va-middle ml-2" v-text="kvp.key" :data-aid="'events_field_name_' + category"></div>
 																			</th>
 																			<td class="expansion va-middle" :data-aid="'events_field_value_' + category">
 																				<div class="quick-action-trigger d-inline-block expansion hardwrap" @click="toggleQuickAction($event, item, -1, kvp.key, kvp.value)">{{kvp.key.endsWith('detection.author') ? $root.tryLocalize(kvp.value) : kvp.value}}<span class="resolved-host" v-if="$root.tryResolveAlias(kvp.key, kvp.value)"> - {{ $root.tryResolveAlias(kvp.key, kvp.value) }}</span></div>
@@ -759,7 +759,7 @@
 																				<v-icon :alt="i18n.addColumnHeader" :color="isColumnHeader(kvp.key) ? 'info' : ''" :title="i18n.addColumnHeaderHelp">fa-table-columns</v-icon>
 																			</v-btn>
 																		</div>
-																		<div :id="'events_fields_' + category + '_' + kvp.key" class="d-inline-block expansion va-middle" v-text="kvp.key" :data-aid="'events_field_name_' + category"></div>
+																		<div :id="'events_fields_' + category + '_' + kvp.key" class="d-inline-block expansion va-middle ml-2" v-text="kvp.key" :data-aid="'events_field_name_' + category"></div>
 																	</th>
 																	<td class="expansion va-middle" :data-aid="'events_field_value_' + category">
 																		<div class="quick-action-trigger d-inline-block expansion hardwrap" @click="toggleQuickAction($event, item, -1, kvp.key, kvp.value)">{{kvp.key.endsWith('detection.author') ? $root.tryLocalize(kvp.value) : kvp.value}}<span class="resolved-host" v-if="$root.tryResolveAlias(kvp.key, kvp.value)"> - {{ $root.tryResolveAlias(kvp.key, kvp.value) }}</span></div>


### PR DESCRIPTION
## Description

- Section panel collapsing is now persisted through local storage. [#16154](https://github.com/Security-Onion-Solutions/securityonion/issues/16154)
- Fields listed under event details tables are now properly highlightable (like they were before the Vuetify upgrade), enabling easier copying. [#16155](https://github.com/Security-Onion-Solutions/securityonion/issues/16155)

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments