### PR TITLE
Log Memory Usage

### DIFF
--- a/model/assistant.go
+++ b/model/assistant.go
@@ -16,7 +16,17 @@ import (
 
 const (
 	MessageTagContextCompression = "context_compression"
+
+	SessionTagMemory    = "memory"
+	SessionTagEmbed     = "embed"
+	SessionTagReconcile = "reconcile"
 )
+
+// MemorySessionTags marks sessions created by the background memory pipeline
+// (and the live-chat embedding path) to hold agent usage records. Tagged
+// sessions are excluded from GetSessions unless GetSessionsWithMemorySessions
+// is passed, and are never scanned for memories themselves.
+var MemorySessionTags = []string{SessionTagMemory, SessionTagEmbed, SessionTagReconcile}
 
 // @Description A user message to be added to a session.
 type IncomingMessage struct {
@@ -329,6 +339,9 @@ type ChatConfig struct {
 	// for this request. Used to enforce a per-sub-session output-token budget.
 	MaxTokens       int
 	IncludeMemories bool
+	// MemorySessionId is the chat session the retrieved memories serve; embedding
+	// token usage on the memory-fetch path is recorded against it.
+	MemorySessionId string
 }
 
 func WithAutoExecuteTools(autoExecute bool) ChatOpt {
@@ -337,9 +350,10 @@ func WithAutoExecuteTools(autoExecute bool) ChatOpt {
 	}
 }
 
-func WithMemories() ChatOpt {
+func WithMemories(sessionId string) ChatOpt {
 	return func(config *ChatConfig) {
 		config.IncludeMemories = true
+		config.MemorySessionId = sessionId
 	}
 }
 

--- a/model/assistant_test.go
+++ b/model/assistant_test.go
@@ -16,7 +16,8 @@ import (
 func TestApplyChatOptsWithMemories(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, ApplyChatOpts(WithMemories()).IncludeMemories)
+	assert.True(t, ApplyChatOpts(WithMemories("chat_123_abc")).IncludeMemories)
+	assert.Equal(t, "chat_123_abc", ApplyChatOpts(WithMemories("chat_123_abc")).MemorySessionId)
 	assert.False(t, ApplyChatOpts().IncludeMemories)
 }
 

--- a/model/assistantsessionopts.go
+++ b/model/assistantsessionopts.go
@@ -3,14 +3,15 @@ package model
 import "time"
 
 type GetSessionsOpts struct {
-	includeDeleted  bool
-	userId          string
-	sessionId       string
-	usage           bool
-	descendants     bool
-	skipMessageMeta bool
-	start           time.Time
-	end             time.Time
+	includeDeleted        bool
+	includeMemorySessions bool
+	userId                string
+	sessionId             string
+	usage                 bool
+	descendants           bool
+	skipMessageMeta       bool
+	start                 time.Time
+	end                   time.Time
 }
 
 func (gso *GetSessionsOpts) IncludeDeleted() bool {
@@ -46,11 +47,25 @@ func (gso *GetSessionsOpts) MessageMeta() bool {
 	return !gso.skipMessageMeta
 }
 
+// IncludeMemorySessions reports whether sessions tagged as memory-pipeline
+// bookkeeping (MemorySessionTags) should be returned. Off by default: these
+// sessions exist to record background agent token usage and are only shown in
+// the admin management views.
+func (gso *GetSessionsOpts) IncludeMemorySessions() bool {
+	return gso.includeMemorySessions
+}
+
 type GetSessionsOpt func(*GetSessionsOpts)
 
 func GetSessionsWithIncludeDeleted(includeDeleted bool) GetSessionsOpt {
 	return func(gso *GetSessionsOpts) {
 		gso.includeDeleted = includeDeleted
+	}
+}
+
+func GetSessionsWithMemorySessions(includeMemorySessions bool) GetSessionsOpt {
+	return func(gso *GetSessionsOpts) {
+		gso.includeMemorySessions = includeMemorySessions
 	}
 }
 

--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -695,6 +695,15 @@ func (h *AssistantHandler) UpdateSession(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// don't allow any actions involving reserved tags
+	for _, reservedTag := range model.MemorySessionTags {
+		if strings.EqualFold(reservedTag, updateReq.Tag) {
+			web.Respond(w, r, http.StatusBadRequest, "reserved tag")
+
+			return
+		}
+	}
+
 	sessions, err := h.server.Assistantstore.GetSessions(ctx, model.GetSessionsWithSessionId(sessionId))
 	if err != nil {
 		logger.WithError(err).Error("unable to get session")
@@ -916,6 +925,7 @@ func (h *AssistantHandler) GetSessionsAdmin(w http.ResponseWriter, r *http.Reque
 		model.GetSessionsWithRange(start, end),
 		model.GetSessionsWithIncludeDeleted(true),
 		model.GetSessionsWithUsage(true),
+		model.GetSessionsWithMemorySessions(true),
 	}
 
 	if userId != "" {
@@ -958,7 +968,7 @@ func (h *AssistantHandler) ManageSessionHistory(w http.ResponseWriter, r *http.R
 	userId := chi.URLParam(r, "userId")
 	sessionId := chi.URLParam(r, "sessionId")
 
-	sessions, err := h.server.Assistantstore.GetSessions(ctx, model.GetSessionsWithUserId(userId), model.GetSessionsWithSessionId(sessionId), model.GetSessionsWithIncludeDeleted(true))
+	sessions, err := h.server.Assistantstore.GetSessions(ctx, model.GetSessionsWithUserId(userId), model.GetSessionsWithSessionId(sessionId), model.GetSessionsWithIncludeDeleted(true), model.GetSessionsWithMemorySessions(true))
 	if err != nil {
 		logger.WithError(err).Error("unable to manage sessions")
 		web.Respond(w, r, http.StatusInternalServerError, err)

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -735,13 +735,22 @@ func TestManageSessionHistory(t *testing.T) {
 		},
 	}
 
-	// Set up mock expectations
+	// Set up mock expectations; the management view must include memory sessions
 	mockAssistantStore.EXPECT().GetSessions(
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
-	).Return(mockSessions, nil)
+		gomock.Any(),
+	).DoAndReturn(func(_ context.Context, opts ...model.GetSessionsOpt) ([]*model.AssistantSession, error) {
+		applied := &model.GetSessionsOpts{}
+		for _, opt := range opts {
+			opt(applied)
+		}
+		assert.True(t, applied.IncludeMemorySessions())
+
+		return mockSessions, nil
+	})
 
 	mockAssistantStore.EXPECT().GetChatHistory(gomock.Any(), sessionId).Return(mockHistory, nil)
 
@@ -793,6 +802,7 @@ func TestManageSessionHistoryNotFound(t *testing.T) {
 
 	// Mock GetSessions to return empty result
 	mockAssistantStore.EXPECT().GetSessions(
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
@@ -1589,6 +1599,65 @@ func TestUpdateSessionTagAlreadyExists(t *testing.T) {
 
 	// Verify response
 	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestUpdateSessionReservedTag(t *testing.T) {
+	type testCase struct {
+		Action string
+		Tag    string
+	}
+
+	cases := []testCase{}
+	for _, tag := range model.MemorySessionTags {
+		cases = append(cases, testCase{Action: "add", Tag: tag}, testCase{Action: "remove", Tag: tag})
+	}
+
+	// guard is case-insensitive
+	cases = append(cases, testCase{Action: "add", Tag: "Memory"})
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s-%s", tc.Action, tc.Tag), func(t *testing.T) {
+			srv := &Server{
+				Authorizer: &rbac.FakeAuthorizer{Authorized: true},
+			}
+			ctrl := gomock.NewController(t)
+			mockAssistantStore := mock.NewMockAssistantstore(ctrl)
+			defer ctrl.Finish()
+
+			srv.Assistantstore = mockAssistantStore
+
+			handler := NewAssistantHandler(srv)
+
+			sessionId := "test-session-123"
+			requestBody := model.UpdateSessionRequest{
+				Action: tc.Action,
+				Tag:    tc.Tag,
+			}
+
+			jsonBody, _ := json.Marshal(requestBody)
+			req := httptest.NewRequest("PUT", fmt.Sprintf("/assistant/sessions/%s", sessionId), bytes.NewBuffer(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set URL params
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("sessionId", sessionId)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+			// Add required context values
+			ctx := context.WithValue(req.Context(), web.ContextKeyRequestorId, "test-user-123")
+			ctx = context.WithValue(ctx, web.ContextKeyRequestStart, time.Now())
+			ctx = context.WithValue(ctx, web.ContextKeyRequestId, "test-request-456")
+			req = req.WithContext(ctx)
+
+			w := httptest.NewRecorder()
+
+			// No store expectations: any GetSessions/UpdateSessionTags call means
+			// the guard fell through and gomock fails the test.
+			handler.UpdateSession(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
 }
 
 func TestUpdateSessionRemoveTagAttachedToCase(t *testing.T) {
@@ -2658,11 +2727,20 @@ func TestGetSessions(t *testing.T) {
 	handler := NewAssistantHandler(srv)
 
 	// A child (delegated) session must be filtered out of the top-level list.
-	mockStore.EXPECT().GetSessions(gomock.Any(), gomock.Any()).Return([]*model.AssistantSession{
-		{SessionId: "top-1"},
-		{SessionId: "child-1", ParentSessionId: "top-1"},
-		{SessionId: "top-2"},
-	}, nil)
+	mockStore.EXPECT().GetSessions(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, opts ...model.GetSessionsOpt) ([]*model.AssistantSession, error) {
+		applied := &model.GetSessionsOpts{}
+		for _, opt := range opts {
+			opt(applied)
+		}
+		// The user-facing list must keep the default memory-session exclusion.
+		assert.False(t, applied.IncludeMemorySessions())
+
+		return []*model.AssistantSession{
+			{SessionId: "top-1"},
+			{SessionId: "child-1", ParentSessionId: "top-1"},
+			{SessionId: "top-2"},
+		}, nil
+	})
 
 	req := withAssistantContext(httptest.NewRequest("GET", "/assistant/sessions", nil))
 	w := httptest.NewRecorder()
@@ -2676,6 +2754,38 @@ func TestGetSessions(t *testing.T) {
 	for _, s := range got {
 		assert.Empty(t, s.ParentSessionId)
 	}
+}
+
+func TestGetSessionsAdmin_IncludesMemorySessions(t *testing.T) {
+	srv, _, mockStore := newAssistantTestServer(t, true)
+	handler := NewAssistantHandler(srv)
+
+	mockStore.EXPECT().GetSessions(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, opts ...model.GetSessionsOpt) ([]*model.AssistantSession, error) {
+		applied := &model.GetSessionsOpts{}
+		for _, opt := range opts {
+			opt(applied)
+		}
+		// The management view returns everything, memory sessions included.
+		assert.True(t, applied.IncludeMemorySessions())
+		assert.True(t, applied.IncludeDeleted())
+
+		return []*model.AssistantSession{{SessionId: "chat-1-memory", Tags: []string{model.SessionTagMemory}}}, nil
+	})
+
+	params := url.Values{
+		"range":    {"2025-01-01 00:00:00 - 2025-01-31 23:59:59"},
+		"format":   {"2006-01-02 15:04:05"},
+		"timezone": {"UTC"},
+	}
+	req := withAssistantContext(httptest.NewRequest("GET", "/assistant/admin/sessions?"+params.Encode(), nil))
+	w := httptest.NewRecorder()
+
+	handler.GetSessionsAdmin(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []*model.AssistantSession
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 1)
 }
 
 func TestGetSessions_StoreError(t *testing.T) {

--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -839,7 +839,7 @@ func (ac *AssistantCoordinator) prepareChatRequest(ctx context.Context, aiModel 
 		if strings.EqualFold(latest.Role, "user") {
 			content := messageText(latest)
 			if content != "" {
-				ac.addMemoriesToPrompt(ctx, req, content)
+				ac.addMemoriesToPrompt(ctx, req, content, config.MemorySessionId)
 			}
 		}
 	}
@@ -852,10 +852,10 @@ func (ac *AssistantCoordinator) prepareChatRequest(ctx context.Context, aiModel 
 	return req, adapter, nil
 }
 
-func (ac *AssistantCoordinator) addMemoriesToPrompt(ctx context.Context, req *model.ChatRequest, content string) {
+func (ac *AssistantCoordinator) addMemoriesToPrompt(ctx context.Context, req *model.ChatRequest, content string, sourceSessionId string) {
 	logger := log.FromContext(ctx)
 
-	user, global, err := ac.fetchMemoriesForPrompt(ctx, content)
+	user, global, err := ac.fetchMemoriesForPrompt(ctx, content, sourceSessionId)
 	if err != nil {
 		// log error but send request without memories
 		logger.WithError(err).Warnf("failed to fetch memories for prompt, sending without memories")

--- a/server/modules/assistant/chat_session.go
+++ b/server/modules/assistant/chat_session.go
@@ -33,7 +33,7 @@ func (ac *AssistantCoordinator) ChatInSession(ctx context.Context, incMsg *model
 	newMsg := newUserMessage(incMsg.Msg)
 	messages = append(messages, newMsg)
 
-	response, err := ac.Send(ctx, incMsg.Model, messages, model.WithMemories())
+	response, err := ac.Send(ctx, incMsg.Model, messages, model.WithMemories(incMsg.SessionId))
 	if err != nil {
 		logger.WithFields(log.Fields{
 			"sessionId": incMsg.SessionId,
@@ -86,7 +86,7 @@ func (ac *AssistantCoordinator) ChatStreamInSession(ctx context.Context, incMsg 
 	newMsg := newUserMessage(incMsg.Msg)
 	messages = append(messages, newMsg)
 
-	response, aux, err := ac.SendStream(noTimeOutCtx, incMsg.Model, messages, model.WithMemories())
+	response, aux, err := ac.SendStream(noTimeOutCtx, incMsg.Model, messages, model.WithMemories(incMsg.SessionId))
 	if err != nil {
 		logger.WithFields(log.Fields{
 			"sessionId": incMsg.SessionId,

--- a/server/modules/assistant/memory.go
+++ b/server/modules/assistant/memory.go
@@ -127,6 +127,14 @@ func (ac *AssistantCoordinator) scanForMemories(ctx context.Context, logger *log
 		return
 	}
 
+	// Only needed to label the Reconcile usage records; reconcileMemories
+	// re-resolves for itself and reports its own error, so a failure here just
+	// skips Reconcile usage recording.
+	var reconcileSelector string
+	if _, reconcileModel, err := ac.resolveMemoryAgent("Reconcile"); err == nil {
+		reconcileSelector = reconcileModel.Selector()
+	}
+
 	logger.Info("scanning for sessions that need memory processing")
 
 	queryResults, err := ac.srv.Assistantstore.FindSessionsPendingMemoryScan(ctx)
@@ -144,7 +152,8 @@ func (ac *AssistantCoordinator) scanForMemories(ctx context.Context, logger *log
 		}).Info("scanning for memories to add")
 
 		// Extract
-		facts, err := ac.extractFacts(ctx, sessionDetails, memoryAgent, memoryModel)
+		facts, extractExchange, err := ac.extractFacts(ctx, sessionDetails, memoryAgent, memoryModel)
+		ac.recordAgentSession(ctx, model.SessionTagMemory, sessionDetails.Session.SessionId, memoryModel.Selector(), extractExchange)
 		if err != nil {
 			logger.WithError(err).Error("unable to extract facts")
 			continue
@@ -179,6 +188,8 @@ func (ac *AssistantCoordinator) scanForMemories(ctx context.Context, logger *log
 				continue
 			}
 
+			ac.recordEmbedUsage(ctx, sessionDetails.Session.SessionId, embedModel.Selector(), res, justFacts)
+
 			if len(res.Embeddings) != len(facts) {
 				logger.WithFields(log.Fields{
 					"embeddingsCount": len(res.Embeddings),
@@ -212,7 +223,10 @@ func (ac *AssistantCoordinator) scanForMemories(ctx context.Context, logger *log
 			logger.Info("reconciling against existing memories")
 
 			// Reconcile
-			memChanges, err := ac.reconcileMemories(sesOwnerCtx, mems)
+			memChanges, reconcileExchanges, err := ac.reconcileMemories(sesOwnerCtx, mems)
+			for _, exchange := range reconcileExchanges {
+				ac.recordAgentSession(ctx, model.SessionTagReconcile, sessionDetails.Session.SessionId, reconcileSelector, exchange)
+			}
 			if err != nil {
 				logger.WithError(err).Error("unable to reconcile memories")
 				continue
@@ -241,6 +255,8 @@ func (ac *AssistantCoordinator) scanForMemories(ctx context.Context, logger *log
 					logger.WithError(err).Error("unable to embed")
 					continue
 				}
+
+				ac.recordEmbedUsage(ctx, sessionDetails.Session.SessionId, embedModel.Selector(), res, justFacts)
 
 				if len(res.Embeddings) != len(reembed) {
 					logger.WithFields(log.Fields{
@@ -324,7 +340,10 @@ func (ac *AssistantCoordinator) filterFactsByUserPerms(ctx context.Context, fact
 	return filtered
 }
 
-func (ac *AssistantCoordinator) extractFacts(ctx context.Context, details *model.AssistantSessionDetails, memoryAgent *model.Agent, memoryModel *model.ModelParameters) ([]*model.ExtractedFact, error) {
+// extractFacts also returns the request/response exchange whenever the send
+// itself succeeded — even when the response content is unusable — so the
+// caller can record the token usage that was spent either way.
+func (ac *AssistantCoordinator) extractFacts(ctx context.Context, details *model.AssistantSessionDetails, memoryAgent *model.Agent, memoryModel *model.ModelParameters) ([]*model.ExtractedFact, []*model.Message, error) {
 	logger := log.FromContext(ctx)
 	ts := buildMemoryExtractTranscript(details)
 
@@ -346,19 +365,21 @@ func (ac *AssistantCoordinator) extractFacts(ctx context.Context, details *model
 
 	err := ac.setupAgent(ctx, req, memoryAgent)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	adapter, ok := ac.adapters[memoryModel.Adapter]
 	if !ok {
 		logger.WithField("adapterName", memoryModel.Adapter).Error("Memory Agent's model references unknown adapter")
-		return nil, fmt.Errorf("unknown adapter for memory model")
+		return nil, nil, fmt.Errorf("unknown adapter for memory model")
 	}
 
 	msg, err := adapter.SendMessage(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	exchange := []*model.Message{req.Messages[0], msg}
 
 	var jsn string
 	for _, cb := range msg.ContentBlocks {
@@ -368,14 +389,14 @@ func (ac *AssistantCoordinator) extractFacts(ctx context.Context, details *model
 	}
 
 	if len(jsn) == 0 {
-		return nil, fmt.Errorf("no returned content from Extraction agent")
+		return nil, exchange, fmt.Errorf("no returned content from Extraction agent")
 	}
 
 	extracted := []*model.ExtractedFact{}
 
 	err = json.Unmarshal([]byte(jsn), &extracted)
 	if err != nil {
-		return nil, err
+		return nil, exchange, err
 	}
 
 	normalized := make([]*model.ExtractedFact, 0, len(extracted))
@@ -401,12 +422,15 @@ func (ac *AssistantCoordinator) extractFacts(ctx context.Context, details *model
 		}
 	}
 
-	return normalized, nil
+	return normalized, exchange, nil
 }
 
-func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*model.Memory) (ops []*model.ReconciledMemory, err error) {
+// reconcileMemories also returns the request/response exchanges collected so
+// far — one per Reconcile agent call, even on a mid-loop error — so the caller
+// can record the token usage that was spent either way.
+func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*model.Memory) (ops []*model.ReconciledMemory, exchanges [][]*model.Message, err error) {
 	if ac.store == nil {
-		return nil, ErrNoDatabase
+		return nil, nil, ErrNoDatabase
 	}
 
 	logger := log.FromContext(ctx)
@@ -414,13 +438,13 @@ func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*m
 	// retrieve agent and setup before looping
 	agentParams, modelParams, err := ac.resolveMemoryAgent("Reconcile")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	adapter, ok := ac.adapters[modelParams.Adapter]
 	if !ok {
 		logger.WithField("adapterName", modelParams.Adapter).Error("Reconcile Agent's model references unknown adapter")
-		return nil, fmt.Errorf("unknown adapter for memory model")
+		return nil, nil, fmt.Errorf("unknown adapter for memory model")
 	}
 
 	canWriteSelf, canWriteGlobal := ac.memoryPerms(ctx, "write")
@@ -441,14 +465,14 @@ func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*m
 		if canWriteGlobal && ac.maxGlobalMemoriesToReconcile > 0 {
 			nearby, err = ac.store.FindNearbyMemories(ctx, mem.Embedding, mem.ModelID, database.GlobalMemories(), database.WithMinSimilarity(ac.mem2memProximityThreshold), database.WithLimit(ac.maxGlobalMemoriesToReconcile))
 			if err != nil {
-				return nil, err
+				return nil, exchanges, err
 			}
 		}
 
 		if mem.TargetUserId != nil && ac.maxUserMemoriesToReconcile > 0 {
 			userNearby, err := ac.store.FindNearbyMemories(ctx, mem.Embedding, mem.ModelID, database.UserMemories(*mem.TargetUserId), database.WithMinSimilarity(ac.mem2memProximityThreshold), database.WithLimit(ac.maxUserMemoriesToReconcile))
 			if err != nil {
-				return nil, err
+				return nil, exchanges, err
 			}
 
 			nearby = append(nearby, userNearby...)
@@ -504,7 +528,7 @@ func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*m
 
 		rawBody, err := json.Marshal(body)
 		if err != nil {
-			return nil, err
+			return nil, exchanges, err
 		}
 
 		req := &model.ChatRequest{
@@ -525,13 +549,15 @@ func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*m
 
 		err = ac.setupAgent(ctx, req, agentParams)
 		if err != nil {
-			return nil, err
+			return nil, exchanges, err
 		}
 
 		msg, err := adapter.SendMessage(ctx, req)
 		if err != nil {
-			return nil, err
+			return nil, exchanges, err
 		}
+
+		exchanges = append(exchanges, []*model.Message{req.Messages[0], msg})
 
 		var rawResult string
 		for _, cb := range msg.ContentBlocks {
@@ -541,14 +567,14 @@ func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*m
 		}
 
 		if len(rawResult) == 0 {
-			return nil, fmt.Errorf("no returned content from Reconcile agent")
+			return nil, exchanges, fmt.Errorf("no returned content from Reconcile agent")
 		}
 
 		changes := model.MemoryOperations{}
 
 		err = json.Unmarshal([]byte(rawResult), &changes)
 		if err != nil {
-			return nil, err
+			return nil, exchanges, err
 		}
 
 		changes.RemoveInvalid(body.Neighbors)
@@ -607,7 +633,7 @@ func (ac *AssistantCoordinator) reconcileMemories(ctx context.Context, mems []*m
 		}
 	}
 
-	return ops, nil
+	return ops, exchanges, nil
 }
 
 func (ac *AssistantCoordinator) applyMemories(ctx context.Context, memories []*model.ReconciledMemory) (created int, updated int, deleted int, errMap map[string]string) {
@@ -685,7 +711,7 @@ func buildMemoryExtractTranscript(details *model.AssistantSessionDetails) string
 	return strings.Join(lines, "\n\n")
 }
 
-func (ac *AssistantCoordinator) fetchMemoriesForPrompt(ctx context.Context, content string) (user []*model.NearbyMemory, global []*model.NearbyMemory, err error) {
+func (ac *AssistantCoordinator) fetchMemoriesForPrompt(ctx context.Context, content string, sourceSessionId string) (user []*model.NearbyMemory, global []*model.NearbyMemory, err error) {
 	if ac.store == nil {
 		return nil, nil, ErrNoDatabase
 	}
@@ -714,6 +740,17 @@ func (ac *AssistantCoordinator) fetchMemoriesForPrompt(ctx context.Context, cont
 	resp, err := ac.Embed(ctx, embedModel.Selector(), []string{content})
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Record the embedding spend off the chat hot path; the chat must not wait
+	// on, or fail because of, usage bookkeeping.
+	if sourceSessionId != "" {
+		go func() {
+			recCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second*10)
+			defer cancel()
+
+			ac.recordEmbedUsage(recCtx, sourceSessionId, embedModel.Selector(), resp, []string{content})
+		}()
 	}
 
 	if len(resp.Embeddings) != 1 {

--- a/server/modules/assistant/memory_test.go
+++ b/server/modules/assistant/memory_test.go
@@ -134,10 +134,10 @@ func newReconcileTestCoordinator(mDB *mockdb.MockDB, adapter server.AssistantAda
 func TestMemoryNoDB(t *testing.T) {
 	ac := &AssistantCoordinator{srv: &server.Server{}}
 
-	_, err := ac.reconcileMemories(context.Background(), []*model.Memory{{}})
+	_, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{{}})
 	assert.ErrorIs(t, err, ErrNoDatabase)
 
-	_, _, err = ac.fetchMemoriesForPrompt(context.Background(), "what do I like")
+	_, _, err = ac.fetchMemoriesForPrompt(context.Background(), "what do I like", "")
 	assert.ErrorIs(t, err, ErrNoDatabase)
 }
 
@@ -477,7 +477,7 @@ func TestExtractFacts(t *testing.T) {
 	ac := &AssistantCoordinator{adapters: map[string]server.AssistantAdapter{"TestAdapter": adapter}}
 	details, memoryAgent, memoryModel := extractTestFixtures()
 
-	facts, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
+	facts, _, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
 
 	assert.NoError(t, err)
 	if assert.Len(t, facts, 1) {
@@ -508,7 +508,7 @@ func TestExtractFactsLastTextBlockWins(t *testing.T) {
 	ac := &AssistantCoordinator{adapters: map[string]server.AssistantAdapter{"TestAdapter": adapter}}
 	details, memoryAgent, memoryModel := extractTestFixtures()
 
-	facts, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
+	facts, _, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
 
 	assert.NoError(t, err)
 	if assert.Len(t, facts, 1) {
@@ -520,7 +520,7 @@ func TestExtractFactsUnknownAdapter(t *testing.T) {
 	ac := &AssistantCoordinator{adapters: map[string]server.AssistantAdapter{}}
 	details, memoryAgent, memoryModel := extractTestFixtures()
 
-	_, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
+	_, _, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown adapter for memory model")
@@ -534,7 +534,7 @@ func TestExtractFactsSendError(t *testing.T) {
 	ac := &AssistantCoordinator{adapters: map[string]server.AssistantAdapter{"TestAdapter": adapter}}
 	details, memoryAgent, memoryModel := extractTestFixtures()
 
-	_, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
+	_, _, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
 
 	assert.ErrorIs(t, err, sendErr)
 }
@@ -546,7 +546,7 @@ func TestExtractFactsNoTextContent(t *testing.T) {
 	ac := &AssistantCoordinator{adapters: map[string]server.AssistantAdapter{"TestAdapter": adapter}}
 	details, memoryAgent, memoryModel := extractTestFixtures()
 
-	_, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
+	_, _, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no returned content")
@@ -559,7 +559,7 @@ func TestExtractFactsBadJSON(t *testing.T) {
 	ac := &AssistantCoordinator{adapters: map[string]server.AssistantAdapter{"TestAdapter": adapter}}
 	details, memoryAgent, memoryModel := extractTestFixtures()
 
-	_, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
+	_, _, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
 
 	assert.Error(t, err)
 }
@@ -571,7 +571,7 @@ func TestExtractFactsEmptyArray(t *testing.T) {
 	ac := &AssistantCoordinator{adapters: map[string]server.AssistantAdapter{"TestAdapter": adapter}}
 	details, memoryAgent, memoryModel := extractTestFixtures()
 
-	facts, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
+	facts, _, err := ac.extractFacts(context.Background(), details, memoryAgent, memoryModel)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, facts)
@@ -615,7 +615,7 @@ func TestReconcileMemoriesInvalidAgent(t *testing.T) {
 	ac := newReconcileTestCoordinator(&mockdb.MockDB{}, &scriptedAdapter{})
 	delete(ac.memoryAgents, "Reconcile")
 
-	_, err := ac.reconcileMemories(context.Background(), nil)
+	_, _, err := ac.reconcileMemories(context.Background(), nil)
 
 	assert.ErrorIs(t, err, ErrInvalidAgent)
 }
@@ -624,7 +624,7 @@ func TestReconcileMemoriesUnknownAdapter(t *testing.T) {
 	ac := newReconcileTestCoordinator(&mockdb.MockDB{}, &scriptedAdapter{})
 	ac.adapters = map[string]server.AssistantAdapter{}
 
-	_, err := ac.reconcileMemories(context.Background(), nil)
+	_, _, err := ac.reconcileMemories(context.Background(), nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown adapter for memory model")
@@ -634,7 +634,7 @@ func TestReconcileMemoriesEmptyInput(t *testing.T) {
 	mDB := &mockdb.MockDB{}
 	ac := newReconcileTestCoordinator(mDB, &scriptedAdapter{})
 
-	ops, err := ac.reconcileMemories(context.Background(), nil)
+	ops, _, err := ac.reconcileMemories(context.Background(), nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ops)
@@ -654,7 +654,7 @@ func TestReconcileMemoriesNoNeighborsAdds(t *testing.T) {
 
 	mem := reconcileTestMem()
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	if assert.Len(t, ops, 1) {
@@ -676,7 +676,7 @@ func TestReconcileMemoriesFindNearbyError(t *testing.T) {
 	mDB.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(&mockdb.MockRows{}, queryErr)
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.ErrorIs(t, err, queryErr)
 	assert.Nil(t, ops)
@@ -694,7 +694,7 @@ func TestReconcileMemoriesUpdate(t *testing.T) {
 
 	mem := reconcileTestMem()
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	if assert.Len(t, ops, 1) {
@@ -738,7 +738,7 @@ func TestReconcileMemoriesUpdateSameContent(t *testing.T) {
 
 	mem := reconcileTestMem()
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	if assert.Len(t, ops, 1) {
@@ -761,7 +761,7 @@ func TestReconcileMemoriesAddChangedContent(t *testing.T) {
 
 	mem := reconcileTestMem()
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	if assert.Len(t, ops, 1) {
@@ -783,7 +783,7 @@ func TestReconcileMemoriesNoop(t *testing.T) {
 		id: "n1", memoryText: "user likes tea", modelId: "embed-model", similarity: 0.99,
 	}))
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.NoError(t, err)
 	assert.Empty(t, ops)
@@ -806,7 +806,7 @@ func TestReconcileMemoriesDeletesAndAdd(t *testing.T) {
 
 	mem := reconcileTestMem()
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	if assert.Len(t, ops, 3) {
@@ -850,7 +850,7 @@ func TestReconcileMemoriesUserScoped(t *testing.T) {
 	mem := reconcileTestMem()
 	mem.TargetUserId = util.Ptr("user-1")
 
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	assert.Empty(t, ops)
@@ -914,7 +914,7 @@ func TestReconcileMemoriesUpdateScopeMatchesTarget(t *testing.T) {
 			mem := reconcileTestMem()
 			mem.TargetUserId = util.Ptr("user-1")
 
-			ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+			ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 			assert.NoError(t, err)
 			if assert.Len(t, ops, 1) {
@@ -954,7 +954,7 @@ func TestReconcileMemoriesWriteSelfOnlyOmitsGlobalNeighbors(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "user-1")
 
-	ops, err := ac.reconcileMemories(ctx, []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(ctx, []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	assert.Empty(t, ops)
@@ -983,7 +983,7 @@ func TestReconcileMemoriesNoWriteGlobalSkipsGlobalCandidate(t *testing.T) {
 	ac.srv.Authorizer = &opAuthorizer{allowed: map[string]bool{"write_self": true}}
 
 	// a global candidate from a session owner without write_global is dropped
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ops)
@@ -1006,7 +1006,7 @@ func TestReconcileMemoriesNoWriteSelfSkipsUserCandidate(t *testing.T) {
 	mem.TargetUserId = util.Ptr("user-1")
 
 	// a user-scoped candidate from a session owner without write_self is dropped
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{mem})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ops)
@@ -1026,7 +1026,7 @@ func TestReconcileMemoriesInvalidOpsRemoved(t *testing.T) {
 	}))
 
 	// the ADD is invalid (carries a TargetId) and is dropped; the DELETE still applies
-	ops, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	ops, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.NoError(t, err)
 	assert.Len(t, ops, 1)
@@ -1045,7 +1045,7 @@ func TestReconcileMemoriesSendError(t *testing.T) {
 		id: "n1", memoryText: "user likes tea", modelId: "embed-model", similarity: 0.9,
 	}))
 
-	rec, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	rec, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.Empty(t, rec)
 	assert.ErrorIs(t, err, sendErr)
@@ -1061,7 +1061,7 @@ func TestReconcileMemoriesEmptyResponse(t *testing.T) {
 		id: "n1", memoryText: "user likes tea", modelId: "embed-model", similarity: 0.9,
 	}))
 
-	rec, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	rec, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.Empty(t, rec)
 	assert.Error(t, err)
@@ -1078,7 +1078,7 @@ func TestReconcileMemoriesTextlessResponse(t *testing.T) {
 		id: "n1", memoryText: "user likes tea", modelId: "embed-model", similarity: 0.9,
 	}))
 
-	rec, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	rec, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.Empty(t, rec)
 	assert.Error(t, err)
@@ -1095,7 +1095,7 @@ func TestReconcileMemoriesBadJSON(t *testing.T) {
 		id: "n1", memoryText: "user likes tea", modelId: "embed-model", similarity: 0.9,
 	}))
 
-	rec, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
+	rec, _, err := ac.reconcileMemories(context.Background(), []*model.Memory{reconcileTestMem()})
 
 	assert.Empty(t, rec)
 	assert.Error(t, err)
@@ -1138,6 +1138,7 @@ func newScanTestCoordinator(store server.Assistantstore, mDB *mockdb.MockDB, ext
 	return &AssistantCoordinator{
 		store: newTestMemoryStore(mDB),
 		srv: &server.Server{
+			Context:        context.Background(),
 			DB:             mDB,
 			Authorizer:     &opAuthorizer{allowed: map[string]bool{"write_self": true, "write_global": true}},
 			Assistantstore: store,
@@ -1170,6 +1171,14 @@ func newScanTestCoordinator(store server.Assistantstore, mDB *mockdb.MockDB, ext
 	}
 }
 
+// allowUsageRecording permits the usage-bookkeeping store calls the scanner
+// makes (see memory_usage.go) without asserting them; tests that verify the
+// recording itself set explicit expectations instead.
+func allowUsageRecording(store *servermock.MockAssistantstore) {
+	store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+}
+
 func scanTestSession(sessionId string) *model.AssistantSessionDetails {
 	details := &model.AssistantSessionDetails{
 		Session: &model.AssistantSession{SessionId: sessionId},
@@ -1188,10 +1197,37 @@ func TestScanForMemoriesAddsExtractedFact(t *testing.T) {
 	store.EXPECT().FindSessionsPendingMemoryScan(gomock.Any()).Return([]*model.AssistantSessionDetails{scanTestSession("sess-1")}, nil)
 	store.EXPECT().UpdateSessionMemoryScanIndex(gomock.Any(), "sess-1", 1).Return(nil)
 
+	// each agent call lands its exchange in its own new tagged session linked
+	// to the scanned session
+	createdByTag := map[string]*model.AssistantSession{}
+	savedBySession := map[string][]*model.StoredMessage{}
+	store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, session *model.AssistantSession) error {
+		if assert.Len(t, session.Tags, 1) {
+			createdByTag[session.Tags[0]] = session
+		}
+		return nil
+	}).AnyTimes()
+	store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, sm *model.StoredMessage) error {
+		savedBySession[sm.SessionId] = append(savedBySession[sm.SessionId], sm)
+		return nil
+	}).AnyTimes()
+
+	extractUsage := &model.Usage{InputTokens: 11, OutputTokens: 3}
+	embedUsage := &model.Usage{InputTokens: 7}
+
 	extract := &scriptedAdapter{send: func(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
-		return textResponse(`[{"fact":"prefers dark mode","scope":"user"}]`), nil
+		msg := textResponse(`[{"fact":"prefers dark mode","scope":"user"}]`)
+		msg.Usage = extractUsage
+		return msg, nil
 	}}
-	embed := singleEmbedAdapter()
+	embed := &embedAdapter{embedFn: func(ctx context.Context, req *model.EmbeddingRequest) (*model.EmbeddingResponse, error) {
+		embeddings := make([][]float32, 0, len(req.Input))
+		for range req.Input {
+			embeddings = append(embeddings, []float32{0.1})
+		}
+
+		return &model.EmbeddingResponse{Model: req.Model, Embeddings: embeddings, Usage: embedUsage}, nil
+	}}
 	reconcile := &scriptedAdapter{send: func(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
 		t.Error("Reconcile agent should not be consulted when there are no neighbors")
 		return nil, errors.New("unexpected call")
@@ -1230,6 +1266,29 @@ func TestScanForMemoriesAddsExtractedFact(t *testing.T) {
 	}
 	// permission filtering and reconciliation ran as the session owner
 	assert.Equal(t, "user-1", ac.srv.Authorizer.(*opAuthorizer).lastRequestorId)
+
+	// the Memory and Embed spend was recorded: one throwaway session per call,
+	// holding the request and the usage-carrying response
+	if assert.Contains(t, createdByTag, model.SessionTagMemory) {
+		memorySession := createdByTag[model.SessionTagMemory]
+		assert.Equal(t, "sess-1", memorySession.EntityId)
+
+		if msgs := savedBySession[memorySession.SessionId]; assert.Len(t, msgs, 2) {
+			assert.Equal(t, "user", msgs[0].Message.Role)
+			assert.Equal(t, extractUsage, msgs[1].Message.Usage)
+		}
+	}
+	if assert.Contains(t, createdByTag, model.SessionTagEmbed) {
+		embedSession := createdByTag[model.SessionTagEmbed]
+		assert.Equal(t, "sess-1", embedSession.EntityId)
+
+		if msgs := savedBySession[embedSession.SessionId]; assert.Len(t, msgs, 2) {
+			assert.Equal(t, "user", msgs[0].Message.Role)
+			assert.Equal(t, embedUsage, msgs[1].Message.Usage)
+		}
+	}
+	assert.NotContains(t, createdByTag, model.SessionTagReconcile)
+
 	mDB.AssertExpectations(t)
 }
 
@@ -1262,6 +1321,7 @@ func TestScanForMemoriesContinuesAfterFailedSession(t *testing.T) {
 	}, nil)
 	// only the session that scanned cleanly advances its index
 	store.EXPECT().UpdateSessionMemoryScanIndex(gomock.Any(), "sess-2", 1).Return(nil)
+	allowUsageRecording(store)
 
 	calls := 0
 	extract := &scriptedAdapter{send: func(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
@@ -1287,6 +1347,20 @@ func TestScanForMemoriesUpdateReembeds(t *testing.T) {
 	store := servermock.NewMockAssistantstore(ctrl)
 	store.EXPECT().FindSessionsPendingMemoryScan(gomock.Any()).Return([]*model.AssistantSessionDetails{scanTestSession("sess-1")}, nil)
 	store.EXPECT().UpdateSessionMemoryScanIndex(gomock.Any(), "sess-1", 1).Return(nil)
+
+	// collect where usage records land: extract, both embed rounds, and reconcile
+	tagBySessionId := map[string]string{}
+	var savedTags []string
+	store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, session *model.AssistantSession) error {
+		if assert.Len(t, session.Tags, 1) {
+			tagBySessionId[session.SessionId] = session.Tags[0]
+		}
+		return nil
+	}).AnyTimes()
+	store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, sm *model.StoredMessage) error {
+		savedTags = append(savedTags, tagBySessionId[sm.SessionId])
+		return nil
+	}).AnyTimes()
 
 	extract := &scriptedAdapter{send: func(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
 		return textResponse(`[{"fact":"prefers dark mode","scope":"user"}]`), nil
@@ -1325,6 +1399,17 @@ func TestScanForMemoriesUpdateReembeds(t *testing.T) {
 	if assert.NotNil(t, embed.lastEmbedReq) {
 		assert.Equal(t, []string{"user likes green tea"}, embed.lastEmbedReq.Input)
 	}
+
+	// every agent call was recorded as its own two-message session: extract,
+	// fact embed, reconcile, re-embed
+	assert.Equal(t, []string{
+		"memory", "memory",
+		"embed", "embed",
+		"reconcile", "reconcile",
+		"embed", "embed",
+	}, savedTags)
+	assert.Len(t, tagBySessionId, 4)
+
 	mDB.AssertExpectations(t)
 }
 
@@ -1335,6 +1420,7 @@ func TestScanForMemoriesEmbedErrorSkipsSession(t *testing.T) {
 	// no UpdateSessionMemoryScanIndex expectation: the session must stay pending
 	store := servermock.NewMockAssistantstore(ctrl)
 	store.EXPECT().FindSessionsPendingMemoryScan(gomock.Any()).Return([]*model.AssistantSessionDetails{scanTestSession("sess-1")}, nil)
+	allowUsageRecording(store)
 
 	extract := &scriptedAdapter{send: func(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
 		return textResponse(`[{"fact":"prefers dark mode","scope":"user"}]`), nil
@@ -1355,6 +1441,7 @@ func TestScanForMemoriesEmbedCountMismatchSkipsSession(t *testing.T) {
 	// no UpdateSessionMemoryScanIndex expectation: the session must stay pending
 	store := servermock.NewMockAssistantstore(ctrl)
 	store.EXPECT().FindSessionsPendingMemoryScan(gomock.Any()).Return([]*model.AssistantSessionDetails{scanTestSession("sess-1")}, nil)
+	allowUsageRecording(store)
 
 	extract := &scriptedAdapter{send: func(ctx context.Context, req *model.ChatRequest) (*model.Message, error) {
 		return textResponse(`[{"fact":"prefers dark mode","scope":"user"}]`), nil
@@ -1521,7 +1608,7 @@ func newFetchTestCoordinator(mDB *mockdb.MockDB, embed *embedAdapter, allowed ma
 func TestFetchMemoriesForPromptMissingRequestor(t *testing.T) {
 	ac := newFetchTestCoordinator(&mockdb.MockDB{}, singleEmbedAdapter(), map[string]bool{"read_authored": true})
 
-	_, _, err := ac.fetchMemoriesForPrompt(context.Background(), "what do I like")
+	_, _, err := ac.fetchMemoriesForPrompt(context.Background(), "what do I like", "")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing RequestorId")
@@ -1531,13 +1618,67 @@ func TestFetchMemoriesForPromptNoReadSelf(t *testing.T) {
 	embed := singleEmbedAdapter()
 	ac := newFetchTestCoordinator(&mockdb.MockDB{}, embed, map[string]bool{"read_global": true})
 
-	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like")
+	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like", "")
 
 	// without read_authored the fetch is a silent no-op: no error, no embed call
 	assert.NoError(t, err)
 	assert.Nil(t, user)
 	assert.Nil(t, global)
 	assert.Nil(t, embed.lastEmbedReq)
+}
+
+func TestFetchMemoriesForPromptRecordsEmbedUsage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mDB := &mockdb.MockDB{}
+	mDB.On("Query", mock.Anything, sqlContains("target_user_id = $3"),
+		mock.Anything, "embed-model", "user-1", 0.7, 5).
+		Return(neighborRows(), nil)
+
+	embedUsage := &model.Usage{InputTokens: 4}
+	embed := &embedAdapter{embedFn: func(ctx context.Context, req *model.EmbeddingRequest) (*model.EmbeddingResponse, error) {
+		return &model.EmbeddingResponse{Model: req.Model, Embeddings: [][]float32{{0.1}}, Usage: embedUsage}, nil
+	}}
+
+	ac := newFetchTestCoordinator(mDB, embed, map[string]bool{"read_authored": true})
+
+	// recording runs on a goroutine off the chat hot path; a failing save must
+	// stay invisible to the chat
+	saved := make(chan *model.StoredMessage, 2)
+	store := servermock.NewMockAssistantstore(ctrl)
+	store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, session *model.AssistantSession) error {
+		assert.Equal(t, []string{model.SessionTagEmbed}, session.Tags)
+		assert.Equal(t, "chat-1", session.EntityId)
+
+		return nil
+	})
+	store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, sm *model.StoredMessage) error {
+		saved <- sm
+		return errors.New("save failed")
+	}).Times(2)
+	ac.srv.Assistantstore = store
+
+	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like", "chat-1")
+
+	assert.NoError(t, err)
+	assert.Empty(t, user)
+	assert.Empty(t, global)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case sm := <-saved:
+			if strings.EqualFold(sm.Message.Role, "assistant") {
+				assert.Equal(t, embedUsage, sm.Message.Usage)
+			} else {
+				if assert.Len(t, sm.Message.ContentBlocks, 1) {
+					assert.Equal(t, "what do I like", sm.Message.ContentBlocks[0].Text)
+				}
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("embed usage was never recorded")
+		}
+	}
 }
 
 func TestFetchMemoriesForPromptUserAndGlobal(t *testing.T) {
@@ -1558,7 +1699,7 @@ func TestFetchMemoriesForPromptUserAndGlobal(t *testing.T) {
 	embed := singleEmbedAdapter()
 	ac := newFetchTestCoordinator(mDB, embed, map[string]bool{"read_authored": true, "read_global": true})
 
-	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like")
+	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like", "")
 
 	assert.NoError(t, err)
 	if assert.Len(t, user, 1) {
@@ -1585,7 +1726,7 @@ func TestFetchMemoriesForPromptSelfOnlySkipsGlobal(t *testing.T) {
 
 	ac := newFetchTestCoordinator(mDB, singleEmbedAdapter(), map[string]bool{"read_authored": true})
 
-	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like")
+	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like", "")
 
 	assert.NoError(t, err)
 	assert.Len(t, user, 1)
@@ -1602,7 +1743,7 @@ func TestFetchMemoriesForPromptZeroLimitsSkipQueries(t *testing.T) {
 	ac.maxUserMemoriesToInclude = 0
 	ac.maxGlobalMemoriesToInclude = 0
 
-	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like")
+	user, global, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like", "")
 
 	// a limit of zero disables that scope entirely: no LIMIT 0 round trips
 	assert.NoError(t, err)
@@ -1619,7 +1760,7 @@ func TestFetchMemoriesForPromptEmbedError(t *testing.T) {
 
 	ac := newFetchTestCoordinator(&mockdb.MockDB{}, embed, map[string]bool{"read_authored": true})
 
-	_, _, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like")
+	_, _, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like", "")
 
 	assert.ErrorIs(t, err, embedErr)
 }
@@ -1631,7 +1772,7 @@ func TestFetchMemoriesForPromptEmbedCountMismatch(t *testing.T) {
 
 	ac := newFetchTestCoordinator(&mockdb.MockDB{}, embed, map[string]bool{"read_authored": true})
 
-	_, _, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like")
+	_, _, err := ac.fetchMemoriesForPrompt(memoryTestCtx(), "what do I like", "")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "expected 1 embedding")
@@ -1697,7 +1838,7 @@ func TestPrepareChatRequestInjectsMemories(t *testing.T) {
 
 	ac, _ := newMemoryPromptTestCoordinator(mDB, singleEmbedAdapter())
 
-	req, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories()))
+	req, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories("")))
 
 	assert.NoError(t, err)
 	assert.Equal(t,
@@ -1727,7 +1868,7 @@ func TestPrepareChatRequestUsageCountErrorLogged(t *testing.T) {
 
 	ac, _ := newMemoryPromptTestCoordinator(mDB, singleEmbedAdapter())
 
-	req, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories()))
+	req, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories("")))
 
 	// a failed usage-count update is telemetry only; the request still carries
 	// the memories
@@ -1761,7 +1902,7 @@ func TestPrepareChatRequestMemoriesSkipNonUserTurn(t *testing.T) {
 		{Role: "assistant", ContentBlocks: []model.ContentBlock{{Type: "text", Text: "you like tea"}}},
 	}
 
-	req, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", messages, false, model.ApplyChatOpts(model.WithMemories()))
+	req, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", messages, false, model.ApplyChatOpts(model.WithMemories("")))
 
 	assert.NoError(t, err)
 	assert.Equal(t, "base-append", req.SystemAppend)
@@ -1774,7 +1915,7 @@ func TestPrepareChatRequestMemoriesFetchErrorSendsWithout(t *testing.T) {
 	}}
 	ac, _ := newMemoryPromptTestCoordinator(&mockdb.MockDB{}, embed)
 
-	req, adapter, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories()))
+	req, adapter, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories("")))
 
 	// retrieval failure downgrades to a memory-less request, not an error
 	assert.NoError(t, err)
@@ -1807,7 +1948,7 @@ func TestPrepareChatRequestSizeCheckCountsMemories(t *testing.T) {
 		}
 	}
 
-	_, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories()))
+	_, _, err := ac.prepareChatRequest(memoryTestCtx(), "chat-model@ChatAdapter", []*model.Message{userTextMessage("what do I like")}, false, model.ApplyChatOpts(model.WithMemories("")))
 
 	assert.ErrorIs(t, err, ErrRequestTooLarge)
 	waitForSignal(t, counted, "usage count update")

--- a/server/modules/assistant/memory_usage.go
+++ b/server/modules/assistant/memory_usage.go
@@ -1,0 +1,83 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+
+	"github.com/apex/log"
+	"github.com/google/uuid"
+)
+
+// recordAgentSession persists one background-agent exchange (request and
+// response messages, in order) into a new tagged session. Ownership and
+// metrics attribution follow the caller's context: the scanner records as
+// SYSTEM, the live-chat embedding path as the chatting user.
+func (ac *AssistantCoordinator) recordAgentSession(ctx context.Context, tag string, sourceSessionId string, modelSelector string, msgs []*model.Message) {
+	if len(msgs) == 0 || sourceSessionId == "" || ac.srv == nil || ac.srv.Assistantstore == nil {
+		return
+	}
+
+	logger := log.FromContext(ctx).WithFields(log.Fields{
+		"memorySessionTag": tag,
+		"sourceSessionId":  sourceSessionId,
+	})
+
+	session := &model.AssistantSession{
+		SessionId: uuid.NewString(),
+		Title:     fmt.Sprintf("%s usage for session %s", tag, sourceSessionId),
+		EntityId:  sourceSessionId,
+		Tags:      []string{tag},
+		Model:     modelSelector,
+	}
+
+	err := ac.srv.Assistantstore.CreateSession(ctx, session)
+	if err != nil {
+		logger.WithError(err).Warn("unable to create memory usage session; agent usage not recorded")
+		return
+	}
+
+	for _, msg := range msgs {
+		err = ac.srv.Assistantstore.SaveChat(ctx, msg.PrepareForStorage(session.SessionId, nil, modelSelector))
+		if err != nil {
+			logger.WithError(err).Warn("unable to save memory agent usage message")
+		}
+	}
+}
+
+// recordEmbedUsage saves the the embedding conversation as a session
+func (ac *AssistantCoordinator) recordEmbedUsage(ctx context.Context, sourceSessionId string, modelSelector string, resp *model.EmbeddingResponse, inputs []string) {
+	if resp == nil {
+		return
+	}
+
+	blocks := make([]model.ContentBlock, 0, len(inputs))
+	for _, input := range inputs {
+		blocks = append(blocks, model.ContentBlock{Type: "text", Text: input})
+	}
+
+	request := &model.Message{
+		Role:          "user",
+		ContentBlocks: blocks,
+	}
+
+	response := &model.Message{
+		Id:   uuid.NewString(),
+		Role: "assistant",
+		ContentBlocks: []model.ContentBlock{
+			{
+				Type: "text",
+				Text: fmt.Sprintf("Embedded %d input(s) using %s", len(inputs), resp.Model),
+			},
+		},
+		Usage: resp.Usage,
+	}
+
+	ac.recordAgentSession(ctx, model.SessionTagEmbed, sourceSessionId, modelSelector, []*model.Message{request, response})
+}

--- a/server/modules/assistant/memory_usage_test.go
+++ b/server/modules/assistant/memory_usage_test.go
@@ -1,0 +1,197 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	servermock "github.com/security-onion-solutions/securityonion-soc/server/mock"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func newUsageTestCoordinator(store server.Assistantstore) *AssistantCoordinator {
+	return &AssistantCoordinator{
+		srv: &server.Server{
+			Assistantstore: store,
+		},
+	}
+}
+
+func TestRecordAgentSessionSavesExchange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	usage := &model.Usage{InputTokens: 11, OutputTokens: 3, Credits: 2}
+
+	request := &model.Message{Role: "user", ContentBlocks: []model.ContentBlock{{Type: "text", Text: "reconcile these"}}}
+	response := textResponse(`{"operations":[]}`)
+	response.Usage = usage
+
+	var sessionId string
+	var saved []*model.StoredMessage
+
+	store := servermock.NewMockAssistantstore(ctrl)
+	store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, session *model.AssistantSession) error {
+		sessionId = session.SessionId
+		assert.Regexp(t, `^[A-Za-z0-9-_]{5,50}$`, session.SessionId)
+		assert.Equal(t, []string{model.SessionTagReconcile}, session.Tags)
+		assert.Equal(t, "src-1", session.EntityId)
+		assert.Equal(t, "rec-model@Adapter", session.Model)
+		assert.NotEmpty(t, session.Title)
+		assert.Empty(t, session.ParentSessionId)
+
+		return nil
+	})
+	store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, sm *model.StoredMessage) error {
+		saved = append(saved, sm)
+		return nil
+	}).Times(2)
+
+	ac := newUsageTestCoordinator(store)
+
+	ac.recordAgentSession(context.Background(), model.SessionTagReconcile, "src-1", "rec-model@Adapter", []*model.Message{request, response})
+
+	// both messages land in the newly created session, request first, the
+	// response carrying the usage
+	if assert.Len(t, saved, 2) {
+		assert.Equal(t, sessionId, saved[0].SessionId)
+		assert.Equal(t, sessionId, saved[1].SessionId)
+		assert.Equal(t, "rec-model@Adapter", saved[0].Model)
+		assert.Equal(t, "user", saved[0].Message.Role)
+		assert.Equal(t, "assistant", saved[1].Message.Role)
+		assert.Nil(t, saved[0].Message.Usage)
+		assert.Equal(t, usage, saved[1].Message.Usage)
+	}
+}
+
+func TestRecordAgentSessionCreatesNewSessionPerCall(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	sessionIds := map[string]bool{}
+
+	store := servermock.NewMockAssistantstore(ctrl)
+	store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, session *model.AssistantSession) error {
+		sessionIds[session.SessionId] = true
+		return nil
+	}).Times(2)
+	store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+
+	ac := newUsageTestCoordinator(store)
+
+	// same source, same tag: still two independent throwaway sessions
+	ac.recordAgentSession(context.Background(), model.SessionTagMemory, "src-1", "m", []*model.Message{textResponse("one")})
+	ac.recordAgentSession(context.Background(), model.SessionTagMemory, "src-1", "m", []*model.Message{textResponse("two")})
+
+	assert.Len(t, sessionIds, 2)
+}
+
+func TestRecordAgentSessionNoOps(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// no expectations: none of these may touch the store
+	store := servermock.NewMockAssistantstore(ctrl)
+
+	ac := newUsageTestCoordinator(store)
+	ac.recordAgentSession(context.Background(), model.SessionTagMemory, "src-1", "m", nil)
+	ac.recordAgentSession(context.Background(), model.SessionTagMemory, "", "m", []*model.Message{textResponse("hi")})
+
+	noSrv := &AssistantCoordinator{}
+	noSrv.recordAgentSession(context.Background(), model.SessionTagMemory, "src-1", "m", []*model.Message{textResponse("hi")})
+
+	noStore := &AssistantCoordinator{srv: &server.Server{}}
+	noStore.recordAgentSession(context.Background(), model.SessionTagMemory, "src-1", "m", []*model.Message{textResponse("hi")})
+}
+
+func TestRecordAgentSessionSwallowsStoreErrors(t *testing.T) {
+	t.Run("create fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// no SaveChat expectation: a failed create skips the saves entirely
+		store := servermock.NewMockAssistantstore(ctrl)
+		store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(errors.New("create down"))
+
+		ac := newUsageTestCoordinator(store)
+
+		assert.NotPanics(t, func() {
+			ac.recordAgentSession(context.Background(), model.SessionTagMemory, "src-1", "m", []*model.Message{textResponse("hi")})
+		})
+	})
+
+	t.Run("save fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// the second message is still attempted after the first save fails
+		store := servermock.NewMockAssistantstore(ctrl)
+		store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(nil)
+		store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).Return(errors.New("save down")).Times(2)
+
+		ac := newUsageTestCoordinator(store)
+
+		assert.NotPanics(t, func() {
+			ac.recordAgentSession(context.Background(), model.SessionTagMemory, "src-1", "m", []*model.Message{textResponse("in"), textResponse("out")})
+		})
+	})
+}
+
+func TestRecordEmbedUsage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	usage := &model.Usage{InputTokens: 7}
+
+	var saved []*model.StoredMessage
+
+	store := servermock.NewMockAssistantstore(ctrl)
+	store.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, session *model.AssistantSession) error {
+		assert.Equal(t, []string{model.SessionTagEmbed}, session.Tags)
+		assert.Equal(t, "src-1", session.EntityId)
+
+		return nil
+	})
+	store.EXPECT().SaveChat(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, sm *model.StoredMessage) error {
+		saved = append(saved, sm)
+		return nil
+	}).Times(2)
+
+	ac := newUsageTestCoordinator(store)
+
+	ac.recordEmbedUsage(context.Background(), "src-1", "embed-model@Adapter", &model.EmbeddingResponse{
+		Model:      "embed-model",
+		Embeddings: [][]float32{{0.1}, {0.2}},
+		Usage:      usage,
+	}, []string{"fact one", "fact two"})
+
+	if assert.Len(t, saved, 2) {
+		// the request mirrors the embedded inputs
+		assert.Equal(t, "user", saved[0].Message.Role)
+		if assert.Len(t, saved[0].Message.ContentBlocks, 2) {
+			assert.Equal(t, "fact one", saved[0].Message.ContentBlocks[0].Text)
+			assert.Equal(t, "fact two", saved[0].Message.ContentBlocks[1].Text)
+		}
+
+		// the response carries the usage
+		assert.Equal(t, "assistant", saved[1].Message.Role)
+		assert.NotEmpty(t, saved[1].Message.Id)
+		assert.Equal(t, usage, saved[1].Message.Usage)
+		if assert.Len(t, saved[1].Message.ContentBlocks, 1) {
+			assert.Equal(t, "Embedded 2 input(s) using embed-model", saved[1].Message.ContentBlocks[0].Text)
+		}
+	}
+
+	// a nil response must not touch the store
+	ac2 := newUsageTestCoordinator(servermock.NewMockAssistantstore(ctrl))
+	ac2.recordEmbedUsage(context.Background(), "src-1", "embed-model@Adapter", nil, []string{"fact"})
+}

--- a/server/modules/elastic/elasticassistantstore.go
+++ b/server/modules/elastic/elasticassistantstore.go
@@ -295,7 +295,7 @@ func (store *ElasticAssistantstore) incrementSessionMessageCount(ctx context.Con
 }
 
 func (store *ElasticAssistantstore) GetChatHistory(ctx context.Context, sessionId string) ([]*model.StoredMessage, error) {
-	existing, err := store.GetSessions(ctx, model.GetSessionsWithSessionId(sessionId), model.GetSessionsWithIncludeDeleted(true))
+	existing, err := store.GetSessions(ctx, model.GetSessionsWithSessionId(sessionId), model.GetSessionsWithIncludeDeleted(true), model.GetSessionsWithMemorySessions(true))
 	if err != nil {
 		return nil, err
 	}
@@ -509,15 +509,27 @@ func (store *ElasticAssistantstore) GetSessions(ctx context.Context, opts ...mod
 		boolQuery["must"] = mustQuery
 	}
 
+	mustNot := []any{}
+
 	if !opt.IncludeDeleted() {
-		boolQuery, _ := query["query"].(map[string]any)["bool"].(map[string]any)
-		boolQuery["must_not"] = []any{
-			map[string]any{
-				"exists": map[string]any{
-					"field": store.schemaPrefix + "session.deleteTime",
-				},
+		mustNot = append(mustNot, map[string]any{
+			"exists": map[string]any{
+				"field": store.schemaPrefix + "session.deleteTime",
 			},
-		}
+		})
+	}
+
+	if !opt.IncludeMemorySessions() {
+		mustNot = append(mustNot, map[string]any{
+			"terms": map[string]any{
+				store.schemaPrefix + "session.tags": model.MemorySessionTags,
+			},
+		})
+	}
+
+	if len(mustNot) != 0 {
+		boolQuery, _ := query["query"].(map[string]any)["bool"].(map[string]any)
+		boolQuery["must_not"] = mustNot
 	}
 
 	start, end := opt.Range()
@@ -1334,6 +1346,13 @@ func (store *ElasticAssistantstore) FindSessionsPendingMemoryScan(ctx context.Co
 					map[string]any{
 						"exists": map[string]any{
 							"field": store.schemaPrefix + "session.parentSessionId",
+						},
+					},
+					// Memory-pipeline bookkeeping sessions record agent token usage
+					// and must never be scanned themselves.
+					map[string]any{
+						"terms": map[string]any{
+							store.schemaPrefix + "session.tags": model.MemorySessionTags,
 						},
 					},
 				},

--- a/server/modules/elastic/elasticassistantstore_test.go
+++ b/server/modules/elastic/elasticassistantstore_test.go
@@ -1110,6 +1110,11 @@ func TestFindSessionsPendingMemoryScan(t *testing.T) {
 	assert.Contains(t, string(body), "so_session.lastMemoryScannedIndex")
 	assert.Contains(t, string(body), "so_session.deleteTime")
 	assert.Contains(t, string(body), "so_session.parentSessionId")
+	// memory-usage bookkeeping sessions are never scanned themselves
+	assert.Contains(t, string(body), "so_session.tags")
+	assert.Contains(t, string(body), `"memory"`)
+	assert.Contains(t, string(body), `"embed"`)
+	assert.Contains(t, string(body), `"reconcile"`)
 
 	body, err = io.ReadAll(reqs[1].Body)
 	assert.NoError(t, err)
@@ -1598,7 +1603,7 @@ func TestGetChatHistory(t *testing.T) {
 	assert.Equal(t, "Hello", messages[0].Message.ContentStr)
 	assert.Equal(t, "Hi there!", messages[1].Message.ContentStr)
 
-	// ensure GetSession call does not filter out deleted sessions
+	// ensure GetSession call does not filter out deleted or memory sessions
 	reqs := transport.GetRequests()
 	assert.Len(t, reqs, 3) // One for GetSessions, one for session meta data, one for chat messages
 	body, err := reqs[0].GetBody()
@@ -1606,6 +1611,7 @@ func TestGetChatHistory(t *testing.T) {
 	data, err := io.ReadAll(body)
 	assert.NoError(t, err)
 	assert.NotContains(t, string(data), "deleteTime")
+	assert.NotContains(t, string(data), "so_session.tags")
 }
 
 func TestGetSessions_WithFilters(t *testing.T) {
@@ -1996,10 +2002,104 @@ func TestGetSessions_IncludeDeleted(t *testing.T) {
 	err = json.NewDecoder(reqs[0].Body).Decode(&query)
 	assert.NoError(t, err)
 
-	// Verify must_not clause is NOT present (includeDeleted=true)
+	// includeDeleted=true drops the deleteTime exclusion; the default
+	// memory-session exclusion remains as the only must_not member
+	boolQuery := query["query"].(map[string]any)["bool"].(map[string]any)
+	mustNot, hasMustNot := boolQuery["must_not"].([]any)
+	if assert.True(t, hasMustNot) && assert.Len(t, mustNot, 1) {
+		terms := mustNot[0].(map[string]any)["terms"].(map[string]any)
+		assert.ElementsMatch(t, []any{"memory", "embed", "reconcile"}, terms["so_session.tags"])
+	}
+}
+
+func TestGetSessions_ExcludesMemorySessionsByDefault(t *testing.T) {
+	mockEsClient, transport := modmock.NewMockClient(t)
+
+	store := NewElasticAssistantstore(server.NewFakeAuthorizedServer(nil), mockEsClient, 1000)
+	store.Init("chat-index", "session-index", "so_")
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+	searchResponse := `{
+		"hits": {
+			"total": {
+				"value": 0
+			},
+			"hits": []
+		}
+	}`
+
+	transport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"X-Elastic-Product": []string{"Elasticsearch"},
+		},
+		Body: io.NopCloser(strings.NewReader(searchResponse)),
+	}, nil)
+
+	sessions, err := store.GetSessions(ctx)
+	assert.NoError(t, err)
+	assert.Empty(t, sessions)
+
+	reqs := transport.GetRequests()
+	assert.Len(t, reqs, 1)
+
+	var query map[string]any
+	err = json.NewDecoder(reqs[0].Body).Decode(&query)
+	assert.NoError(t, err)
+
+	// by default both the deleted and the memory-session exclusions apply
+	boolQuery := query["query"].(map[string]any)["bool"].(map[string]any)
+	mustNot, hasMustNot := boolQuery["must_not"].([]any)
+	if assert.True(t, hasMustNot) && assert.Len(t, mustNot, 2) {
+		exists := mustNot[0].(map[string]any)["exists"].(map[string]any)
+		assert.Equal(t, "so_session.deleteTime", exists["field"])
+
+		terms := mustNot[1].(map[string]any)["terms"].(map[string]any)
+		assert.ElementsMatch(t, []any{"memory", "embed", "reconcile"}, terms["so_session.tags"])
+	}
+}
+
+func TestGetSessions_IncludeMemorySessions(t *testing.T) {
+	mockEsClient, transport := modmock.NewMockClient(t)
+
+	store := NewElasticAssistantstore(server.NewFakeAuthorizedServer(nil), mockEsClient, 1000)
+	store.Init("chat-index", "session-index", "so_")
+
+	ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+	searchResponse := `{
+		"hits": {
+			"total": {
+				"value": 0
+			},
+			"hits": []
+		}
+	}`
+
+	transport.AddResponse(&http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"X-Elastic-Product": []string{"Elasticsearch"},
+		},
+		Body: io.NopCloser(strings.NewReader(searchResponse)),
+	}, nil)
+
+	sessions, err := store.GetSessions(ctx, model.GetSessionsWithIncludeDeleted(true), model.GetSessionsWithMemorySessions(true))
+	assert.NoError(t, err)
+	assert.Empty(t, sessions)
+
+	reqs := transport.GetRequests()
+	assert.Len(t, reqs, 1)
+
+	var query map[string]any
+	err = json.NewDecoder(reqs[0].Body).Decode(&query)
+	assert.NoError(t, err)
+
+	// with both include opts no exclusions remain
 	boolQuery := query["query"].(map[string]any)["bool"].(map[string]any)
 	_, hasMustNot := boolQuery["must_not"]
-	assert.False(t, hasMustNot, "must_not clause should not be present when includeDeleted=true")
+	assert.False(t, hasMustNot, "must_not clause should not be present when both include opts are set")
 }
 
 func TestGetSessions_TimeRangeFilter(t *testing.T) {


### PR DESCRIPTION
The previous implementation of Memory didn't create sessions when it interacted with agents. These requests might cost tokens and need to show up in management UIs.

They are given descriptive titles and bundled under the system uuid (all zeros). GetSessions has been updated to exclude these unless a new option is passed and the admin UI uses the new option.

Also, when updating a session's tags, disallow the modification of memory tags. Added a new regression test.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->