### PR TITLE
Prevent Crash

### DIFF
--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -601,6 +601,10 @@ func (e *ElastAlertEngine) SyncLocalDetections(ctx context.Context, detections [
 func (e *ElastAlertEngine) Sync(logger *log.Entry, forceSync bool) error {
 	defer func() {
 		e.resetInterruptSync()
+
+		if r := recover(); r != nil {
+			logger.WithField("recoverValue", r).Error("recovered from an error during an ElastAlert sync")
+		}
 	}()
 
 	// handle write/no-read
@@ -1635,9 +1639,14 @@ func (e *ElastAlertEngine) sigmaToElastAlert(ctx context.Context, det *model.Det
 			return "", fmt.Errorf("unable to unmarshal sigma rule: %w", err)
 		}
 
-		detection := doc["detection"].(map[string]interface{})
-		if detection == nil {
+		detection, ok := doc["detection"].(map[string]interface{})
+		if !ok || detection == nil {
 			return "", fmt.Errorf("sigma rule does not contain a detection section")
+		}
+
+		condition, ok := detection["condition"].(string)
+		if !ok || condition == "" {
+			return "", fmt.Errorf("sigma rule does not contain a condition")
 		}
 
 		for _, f := range filters {
@@ -1651,7 +1660,6 @@ func (e *ElastAlertEngine) sigmaToElastAlert(ctx context.Context, det *model.Det
 			}
 		}
 
-		condition := detection["condition"].(string)
 		detection["condition"] = fmt.Sprintf("(%s) and not 1 of sofilter*", condition)
 
 		raw, err := yaml.Marshal(doc)

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -452,6 +452,54 @@ timestamp_field: '@timestamp'
 	assert.YAMLEq(t, expected, wrappedRule)
 }
 
+func TestSigmaToElastAlertMissingDetection(t *testing.T) {
+	engine := ElastAlertEngine{}
+
+	det := &model.Detection{
+		PublicID: "11111111-1111-1111-1111-111111111111",
+		Content:  `title: Test Detection`,
+		Title:    "Test Detection",
+		Severity: model.SeverityHigh,
+		Overrides: []*model.Override{
+			{
+				Type:      model.OverrideTypeCustomFilter,
+				IsEnabled: true,
+				OverrideParameters: model.OverrideParameters{
+					CustomFilter: util.Ptr(`{"this": ["that"]}`),
+				},
+			},
+		},
+	}
+
+	query, err := engine.sigmaToElastAlert(context.Background(), det)
+	assert.Empty(t, query)
+	assert.ErrorContains(t, err, "does not contain a detection section")
+}
+
+func TestSigmaToElastAlertMissingCondition(t *testing.T) {
+	engine := ElastAlertEngine{}
+
+	det := &model.Detection{
+		PublicID: "11111111-1111-1111-1111-111111111111",
+		Content:  `{"detection": {"selection": {"a": "b"}}}`,
+		Title:    "Test Detection",
+		Severity: model.SeverityHigh,
+		Overrides: []*model.Override{
+			{
+				Type:      model.OverrideTypeCustomFilter,
+				IsEnabled: true,
+				OverrideParameters: model.OverrideParameters{
+					CustomFilter: util.Ptr(`{"this": ["that"]}`),
+				},
+			},
+		},
+	}
+
+	query, err := engine.sigmaToElastAlert(context.Background(), det)
+	assert.Empty(t, query)
+	assert.ErrorContains(t, err, "does not contain a condition")
+}
+
 func TestElastAlertInitUseEsql(t *testing.T) {
 	srv := &server.Server{Config: &config.ServerConfig{}}
 	mod := NewElastAlertEngine(srv)
@@ -1725,6 +1773,31 @@ func TestSyncWriteNoReadFail(t *testing.T) {
 	err := eng.Sync(logger, false)
 	assert.Equal(t, detections.ErrSyncFailed, err)
 	assert.Equal(t, wnr, eng.writeNoRead)
+}
+
+func TestSyncRecoversFromPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().GetDetectionByPublicId(gomock.Any(), "123").DoAndReturn(func(ctx context.Context, publicId string) (*model.Detection, error) {
+		panic("test panic")
+	})
+
+	eng := &ElastAlertEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+		},
+		writeNoRead: util.Ptr("123"),
+	}
+
+	logger := log.WithField("detectionEngine", "test-elastalert")
+
+	var err error
+	assert.NotPanics(t, func() {
+		err = eng.Sync(logger, false)
+	})
+	assert.NoError(t, err)
 }
 
 func TestSyncIncrementalNoChanges(t *testing.T) {

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -298,6 +298,10 @@ func (e *StrelkaEngine) SyncLocalDetections(ctx context.Context, _ []*model.Dete
 func (e *StrelkaEngine) Sync(logger *log.Entry, forceSync bool) error {
 	defer func() {
 		e.resetInterrupt()
+
+		if r := recover(); r != nil {
+			logger.WithField("recoverValue", r).Error("recovered from an error during a Strelka sync")
+		}
 	}()
 
 	if detections.CheckWriteNoRead(e.srv.Context, e.srv.Detectionstore, e.writeNoRead) {

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -1005,6 +1005,31 @@ func TestSyncWriteNoReadFail(t *testing.T) {
 	assert.Equal(t, wnr, eng.writeNoRead)
 }
 
+func TestSyncRecoversFromPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().GetDetectionByPublicId(gomock.Any(), "123").DoAndReturn(func(ctx context.Context, publicId string) (*model.Detection, error) {
+		panic("test panic")
+	})
+
+	eng := &StrelkaEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+		},
+		writeNoRead: util.Ptr("123"),
+	}
+
+	logger := log.WithField("detectionEngine", "test-strelka")
+
+	var err error
+	assert.NotPanics(t, func() {
+		err = eng.Sync(logger, false)
+	})
+	assert.NoError(t, err)
+}
+
 func TestSyncIncrementalNoChanges(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -615,6 +615,10 @@ func (e *SuricataEngine) ExtractDetails(detect *model.Detection) error {
 func (e *SuricataEngine) Sync(logger *log.Entry, forceSync bool) error {
 	defer func() {
 		e.resetInterruptSync()
+
+		if r := recover(); r != nil {
+			logger.WithField("recoverValue", r).Error("recovered from an error during a Suricata sync")
+		}
 	}()
 
 	// Check for sync block at the very start

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -749,6 +749,31 @@ func TestSyncWriteNoReadFail(t *testing.T) {
 	assert.Equal(t, wnr, eng.writeNoRead)
 }
 
+func TestSyncRecoversFromPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().GetDetectionByPublicId(gomock.Any(), "123").DoAndReturn(func(ctx context.Context, publicId string) (*model.Detection, error) {
+		panic("test panic")
+	})
+
+	eng := &SuricataEngine{
+		srv: &server.Server{
+			Detectionstore: detStore,
+		},
+		writeNoRead: util.Ptr("123"),
+	}
+
+	logger := log.WithField("detectionEngine", "test-suricata")
+
+	var err error
+	assert.NotPanics(t, func() {
+		err = eng.Sync(logger, false)
+	})
+	assert.NoError(t, err)
+}
+
 func TestSyncIncrementalNoChanges(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Fix possible crashes in ElastAlert sync.

Add recover to every detection engine's Sync function to prevent the process from crashing.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->