### PR TITLE
Verify Session Ownership

### DIFF
--- a/server/assistanthandler.go
+++ b/server/assistanthandler.go
@@ -141,6 +141,26 @@ func (h *AssistantHandler) PostChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// check if caller owns session
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	ownedByUser, sessionExists, err := h.server.Assistantstore.DoesUserOwnSession(ctx, userId, incMsg.SessionId)
+	if err != nil {
+		logger.WithError(err).Error("unable to check session ownership")
+		web.Respond(w, r, http.StatusInternalServerError, err)
+
+		return
+	}
+
+	// A nonexistent session is fine: it's created as the caller's own on first
+	// chat. Only an existing session owned by someone else is rejected.
+	if sessionExists && !ownedByUser {
+		logger.WithField("assistantSessionId", incMsg.SessionId).Warn("user attempted to post to a session they do not own")
+		web.Respond(w, r, http.StatusForbidden, nil)
+
+		return
+	}
+
 	entityType := r.URL.Query().Get("entityType")
 	entityId := r.URL.Query().Get("entityId")
 
@@ -243,6 +263,29 @@ func (h *AssistantHandler) PostTool(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.WithError(err).Error("unable to decode request body")
 		web.Respond(w, r, http.StatusBadRequest, err)
+
+		return
+	}
+
+	// check if caller owns session
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	ownedByUser, sessionExists, err := h.server.Assistantstore.DoesUserOwnSession(ctx, userId, toolReq.SessionId)
+	if err != nil {
+		logger.WithError(err).Error("unable to check session ownership")
+		web.Respond(w, r, http.StatusInternalServerError, err)
+
+		return
+	}
+
+	if !sessionExists {
+		web.Respond(w, r, http.StatusNotFound, "session does not exist")
+		return
+	}
+
+	if sessionExists && !ownedByUser {
+		logger.WithField("assistantSessionId", toolReq.SessionId).Warn("user attempted to post a tool to a session they do not own")
+		web.Respond(w, r, http.StatusForbidden, nil)
 
 		return
 	}

--- a/server/assistanthandler_test.go
+++ b/server/assistanthandler_test.go
@@ -92,6 +92,8 @@ func TestPostChat(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
+	mockAssistantStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user-123", sessionId).Return(true, true, nil)
+
 	var capturedIncMsg *model.IncomingMessage
 	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), "", "").DoAndReturn(
 		func(ctx context.Context, incMsg *model.IncomingMessage, entityType, entityId string) ([]*model.Message, error) {
@@ -152,6 +154,8 @@ func TestPostChatWithoutHistory(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	w := httptest.NewRecorder()
+
+	mockAssistantStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user-123", gomock.Any()).Return(false, false, nil)
 
 	var capturedIncMsg *model.IncomingMessage
 	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), "", "").DoAndReturn(
@@ -263,6 +267,8 @@ func TestPostTool(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
+	mockAssistantStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user-123", sessionId).Return(true, true, nil)
+
 	var capturedToolReq *model.ToolRequest
 	mockManager.EXPECT().ToolInSession(gomock.Any(), gomock.Any(), "query_events").DoAndReturn(
 		func(ctx context.Context, toolReq *model.ToolRequest, toolName string) ([]*model.Message, error) {
@@ -347,6 +353,8 @@ func TestPostTool_StreamingTopLevelStops(t *testing.T) {
 	srv.AssistantManager = mockManager
 	srv.Assistantstore = mockStore
 
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "top").Return(true, true, nil)
+
 	// The turn carries its session record; it has no parent, so the loop stops
 	// without any store lookup.
 	mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), "query_events").Return(
@@ -375,6 +383,8 @@ func TestPostTool_StreamingDelegationResolves(t *testing.T) {
 	mockStore := mock.NewMockAssistantstore(ctrl)
 	srv.AssistantManager = mockManager
 	srv.Assistantstore = mockStore
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "parent").Return(true, true, nil)
 
 	// First turn: the child sub-agent answers with text only. The turn carries the
 	// child's session record with its parent linkage — no store lookups needed.
@@ -422,6 +432,8 @@ func TestPostTool_StreamingDelegationResolveErrorStillCloses(t *testing.T) {
 	srv.AssistantManager = mockManager
 	srv.Assistantstore = mockStore
 
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "parent").Return(true, true, nil)
+
 	// The child sub-agent answers with text only; its turn carries the child's
 	// session record with the parent linkage.
 	mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), "query_events").Return(
@@ -456,6 +468,8 @@ func TestPostTool_StreamingToolUseStops(t *testing.T) {
 	mockStore := mock.NewMockAssistantstore(ctrl)
 	srv.AssistantManager = mockManager
 	srv.Assistantstore = mockStore
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "parent").Return(true, true, nil)
 
 	mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), "delegate_to_Hunter").Return(
 		&model.StreamedTurn{
@@ -1905,6 +1919,8 @@ func TestPostChatWithEntityTypeAndId(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
+	mockAssistantStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user-123", gomock.Any()).Return(false, false, nil)
+
 	// The handler should forward the entityType/entityId to ChatInSession.
 	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), entityType, entityId).Return([]*model.Message{{
 		Role: "assistant",
@@ -1967,6 +1983,8 @@ func TestPostChatWithEntityTypeAndIdMarkFails(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	w := httptest.NewRecorder()
+
+	mockAssistantStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user-123", gomock.Any()).Return(false, false, nil)
 
 	// ChatInSession should still be called even when alert-mark fails.
 	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), entityType, entityId).Return([]*model.Message{{
@@ -2827,9 +2845,10 @@ func TestPostChat_NonStreamingUpstreamErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			srv, mockManager, _ := newAssistantTestServer(t, true)
+			srv, mockManager, mockStore := newAssistantTestServer(t, true)
 			handler := NewAssistantHandler(srv)
 
+			mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(true, true, nil)
 			mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), "", "").Return(nil, tc.err)
 
 			body, _ := json.Marshal(map[string]any{"msg": "hi", "sessionId": "s1", "model": "m"})
@@ -2845,9 +2864,10 @@ func TestPostChat_NonStreamingUpstreamErrors(t *testing.T) {
 }
 
 func TestPostChat_Streaming(t *testing.T) {
-	srv, mockManager, _ := newAssistantTestServer(t, true)
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
 	handler := NewAssistantHandler(srv)
 
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(true, true, nil)
 	mockManager.EXPECT().ChatStreamInSession(gomock.Any(), gomock.Any(), "", "").Return(
 		sseTextResponse("hello"), &model.AuxMessageData{}, noopFinalize, nil)
 
@@ -2864,9 +2884,10 @@ func TestPostChat_Streaming(t *testing.T) {
 }
 
 func TestPostChat_StreamingUpstreamError(t *testing.T) {
-	srv, mockManager, _ := newAssistantTestServer(t, true)
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
 	handler := NewAssistantHandler(srv)
 
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(true, true, nil)
 	mockManager.EXPECT().ChatStreamInSession(gomock.Any(), gomock.Any(), "", "").Return(
 		nil, nil, nil, errors.New("boom"))
 
@@ -2983,9 +3004,67 @@ func TestRespondChatError(t *testing.T) {
 	}
 }
 
-func TestPostChat_DefaultsSessionId(t *testing.T) {
-	srv, mockManager, _ := newAssistantTestServer(t, true)
+func TestPostChat_SessionNotOwned(t *testing.T) {
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
 	handler := NewAssistantHandler(srv)
+
+	// The session exists but belongs to a different user than the requestor
+	// ("test-user"), so the chat must be rejected before reaching the manager.
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(false, true, nil)
+	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockManager.EXPECT().ChatStreamInSession(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	body, _ := json.Marshal(map[string]any{"msg": "hi", "sessionId": "s1", "model": "m"})
+	req := withAssistantContext(httptest.NewRequest("POST", "/assistant/chat", bytes.NewBuffer(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.PostChat(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestPostChat_SessionLookupError(t *testing.T) {
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
+	handler := NewAssistantHandler(srv)
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(false, false, errors.New("es unavailable"))
+	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	body, _ := json.Marshal(map[string]any{"msg": "hi", "sessionId": "s1", "model": "m"})
+	req := withAssistantContext(httptest.NewRequest("POST", "/assistant/chat", bytes.NewBuffer(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.PostChat(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPostChat_NewSessionAllowed(t *testing.T) {
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
+	handler := NewAssistantHandler(srv)
+
+	// A session that doesn't exist yet isn't owned by anyone; the chat proceeds
+	// and the session is created as the caller's own.
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(false, false, nil)
+	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), "", "").Return([]*model.Message{}, nil)
+
+	body, _ := json.Marshal(map[string]any{"msg": "hi", "sessionId": "s1", "model": "m"})
+	req := withAssistantContext(httptest.NewRequest("POST", "/assistant/chat", bytes.NewBuffer(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.PostChat(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPostChat_DefaultsSessionId(t *testing.T) {
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
+	handler := NewAssistantHandler(srv)
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", gomock.Any()).Return(false, false, nil)
 
 	var capturedIncMsg *model.IncomingMessage
 	mockManager.EXPECT().ChatInSession(gomock.Any(), gomock.Any(), "", "").DoAndReturn(
@@ -3007,8 +3086,10 @@ func TestPostChat_DefaultsSessionId(t *testing.T) {
 }
 
 func TestPostChat_StreamingDowngradeToNonStreaming(t *testing.T) {
-	srv, mockManager, _ := newAssistantTestServer(t, true)
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
 	handler := NewAssistantHandler(srv)
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(true, true, nil)
 
 	// The writer is not an http.Flusher, so despite the SSE Accept header the
 	// handler must fall back to the buffered ChatInSession path.
@@ -3026,8 +3107,10 @@ func TestPostChat_StreamingDowngradeToNonStreaming(t *testing.T) {
 }
 
 func TestPostChat_StreamingFinalizeCalled(t *testing.T) {
-	srv, mockManager, _ := newAssistantTestServer(t, true)
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
 	handler := NewAssistantHandler(srv)
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(true, true, nil)
 
 	finalized := make(chan []byte, 1)
 	finalize := func(rawResponse []byte) error {
@@ -3089,9 +3172,10 @@ func TestPostTool_NonStreamingUpstreamErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			srv, mockManager, _ := newAssistantTestServer(t, true)
+			srv, mockManager, mockStore := newAssistantTestServer(t, true)
 			handler := NewAssistantHandler(srv)
 
+			mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(true, true, nil)
 			mockManager.EXPECT().ToolInSession(gomock.Any(), gomock.Any(), "query_events").Return(nil, tc.err)
 
 			body, _ := json.Marshal(model.ToolRequest{SessionId: "s1", ToolUseId: "tu1", Model: "m"})
@@ -3319,9 +3403,10 @@ func TestPostTool_StreamingUpstreamErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			srv, mockManager, _ := newAssistantTestServer(t, true)
+			srv, mockManager, mockStore := newAssistantTestServer(t, true)
 			handler := NewAssistantHandler(srv)
 
+			mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(true, true, nil)
 			mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), "query_events").Return(nil, tc.err)
 
 			req, w := newToolStreamRequest(t, "s1", "query_events")
@@ -3334,6 +3419,64 @@ func TestPostTool_StreamingUpstreamErrors(t *testing.T) {
 			assert.Equal(t, tc.wantCode, w.Code)
 		})
 	}
+}
+
+// newToolRequest builds a non-streaming PostTool request for session "s1".
+func newToolRequest(t *testing.T) (*http.Request, *httptest.ResponseRecorder) {
+	t.Helper()
+	body, _ := json.Marshal(model.ToolRequest{SessionId: "s1", ToolUseId: "tu1", Model: "m"})
+	req := httptest.NewRequest("POST", "/assistant/tool/query_events", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "query_events")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	return withAssistantContext(req), httptest.NewRecorder()
+}
+
+func TestPostTool_SessionNotOwned(t *testing.T) {
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
+	handler := NewAssistantHandler(srv)
+
+	// The session exists but belongs to a different user than the requestor
+	// ("test-user"), so the tool call must be rejected before reaching the manager.
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(false, true, nil)
+	mockManager.EXPECT().ToolInSession(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	req, w := newToolRequest(t)
+	handler.PostTool(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestPostTool_SessionNotFound(t *testing.T) {
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
+	handler := NewAssistantHandler(srv)
+
+	// Unlike PostChat, a tool result can never start a new session: a nonexistent
+	// session is a 404, not an implicit create.
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(false, false, nil)
+	mockManager.EXPECT().ToolInSession(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	req, w := newToolRequest(t)
+	handler.PostTool(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPostTool_SessionLookupError(t *testing.T) {
+	srv, mockManager, mockStore := newAssistantTestServer(t, true)
+	handler := NewAssistantHandler(srv)
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "s1").Return(false, false, errors.New("es unavailable"))
+	mockManager.EXPECT().ToolInSession(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	req, w := newToolRequest(t)
+	handler.PostTool(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestPostTool_Unauthorized(t *testing.T) {
@@ -3384,6 +3527,8 @@ func TestPostTool_StreamingDelegationResolveError(t *testing.T) {
 	mockStore := mock.NewMockAssistantstore(ctrl)
 	srv.AssistantManager = mockManager
 	srv.Assistantstore = mockStore
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "parent").Return(true, true, nil)
 
 	mockManager.EXPECT().ToolStreamInSession(gomock.Any(), gomock.Any(), "query_events").Return(
 		&model.StreamedTurn{Response: sseTextResponse("child answer"), SessionId: "child", Model: "sonnet", Finalize: noopFinalize,
@@ -3458,7 +3603,11 @@ func TestPostTool_StreamingClientDisconnect_PersistsTurnWithoutDelegation(t *tes
 	defer ctrl.Finish()
 
 	mockManager := mock.NewMockAssistantManager(ctrl)
+	mockStore := mock.NewMockAssistantstore(ctrl)
 	srv.AssistantManager = mockManager
+	srv.Assistantstore = mockStore
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "parent").Return(true, true, nil)
 
 	finalized := make(chan []byte, 1)
 	toolUseResp := paddedSSE(
@@ -3497,7 +3646,11 @@ func TestPostTool_StreamingClientDisconnect_ResolvesDelegation(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockManager := mock.NewMockAssistantManager(ctrl)
+	mockStore := mock.NewMockAssistantstore(ctrl)
 	srv.AssistantManager = mockManager
+	srv.Assistantstore = mockStore
+
+	mockStore.EXPECT().DoesUserOwnSession(gomock.Any(), "test-user", "parent").Return(true, true, nil)
 
 	textResp := paddedSSE(
 		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"child answer\"}}\n\n" +

--- a/server/assistantstore.go
+++ b/server/assistantstore.go
@@ -21,6 +21,7 @@ type Assistantstore interface {
 	// re-fetching the session record.
 	GetChatMessages(context.Context, *model.AssistantSession) ([]*model.StoredMessage, error)
 	GetSessions(context.Context, ...model.GetSessionsOpt) ([]*model.AssistantSession, error)
+	DoesUserOwnSession(ctx context.Context, userId string, sessionId string) (ownedByUser bool, sessionExists bool, err error)
 	CreateSession(context.Context, *model.AssistantSession) error
 	UpdateSessionTags(ctx context.Context, sessionId string, tags []string) error
 	DeleteSession(context.Context, string) error

--- a/server/mock/mock_assistantstore.go
+++ b/server/mock/mock_assistantstore.go
@@ -70,6 +70,22 @@ func (mr *MockAssistantstoreMockRecorder) DeleteSession(arg0, arg1 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSession", reflect.TypeOf((*MockAssistantstore)(nil).DeleteSession), arg0, arg1)
 }
 
+// DoesUserOwnSession mocks base method.
+func (m *MockAssistantstore) DoesUserOwnSession(ctx context.Context, userId, sessionId string) (bool, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoesUserOwnSession", ctx, userId, sessionId)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DoesUserOwnSession indicates an expected call of DoesUserOwnSession.
+func (mr *MockAssistantstoreMockRecorder) DoesUserOwnSession(ctx, userId, sessionId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoesUserOwnSession", reflect.TypeOf((*MockAssistantstore)(nil).DoesUserOwnSession), ctx, userId, sessionId)
+}
+
 // FindSessionsPendingMemoryScan mocks base method.
 func (m *MockAssistantstore) FindSessionsPendingMemoryScan(arg0 context.Context) ([]*model.AssistantSessionDetails, error) {
 	m.ctrl.T.Helper()

--- a/server/mock/mock_notificationstore.go
+++ b/server/mock/mock_notificationstore.go
@@ -42,6 +42,21 @@ func (m *MockNotificationstore) EXPECT() *MockNotificationstoreMockRecorder {
 	return m.recorder
 }
 
+// GetAuditLogs mocks base method.
+func (m *MockNotificationstore) GetAuditLogs(ctx context.Context, id string) ([]*model.NotificationAuditEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuditLogs", ctx, id)
+	ret0, _ := ret[0].([]*model.NotificationAuditEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAuditLogs indicates an expected call of GetAuditLogs.
+func (mr *MockNotificationstoreMockRecorder) GetAuditLogs(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuditLogs", reflect.TypeOf((*MockNotificationstore)(nil).GetAuditLogs), ctx, id)
+}
+
 // GetLastUnreadTime mocks base method.
 func (m *MockNotificationstore) GetLastUnreadTime(ctx context.Context) (*time.Time, error) {
 	m.ctrl.T.Helper()
@@ -72,20 +87,6 @@ func (mr *MockNotificationstoreMockRecorder) GetNotifications(ctx, filter any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifications", reflect.TypeOf((*MockNotificationstore)(nil).GetNotifications), ctx, filter)
 }
 
-// SetRead mocks base method.
-func (m *MockNotificationstore) SetRead(ctx context.Context, id string, isRead bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRead", ctx, id, isRead)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetRead indicates an expected call of SetRead.
-func (mr *MockNotificationstoreMockRecorder) SetRead(ctx, id, isRead any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRead", reflect.TypeOf((*MockNotificationstore)(nil).SetRead), ctx, id, isRead)
-}
-
 // SetDismissed mocks base method.
 func (m *MockNotificationstore) SetDismissed(ctx context.Context, id string, isDismissed bool) error {
 	m.ctrl.T.Helper()
@@ -100,17 +101,16 @@ func (mr *MockNotificationstoreMockRecorder) SetDismissed(ctx, id, isDismissed a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDismissed", reflect.TypeOf((*MockNotificationstore)(nil).SetDismissed), ctx, id, isDismissed)
 }
 
-// GetAuditLogs mocks base method.
-func (m *MockNotificationstore) GetAuditLogs(ctx context.Context, id string) ([]*model.NotificationAuditEntry, error) {
+// SetRead mocks base method.
+func (m *MockNotificationstore) SetRead(ctx context.Context, id string, isRead bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAuditLogs", ctx, id)
-	ret0, _ := ret[0].([]*model.NotificationAuditEntry)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "SetRead", ctx, id, isRead)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetAuditLogs indicates an expected call of GetAuditLogs.
-func (mr *MockNotificationstoreMockRecorder) GetAuditLogs(ctx, id any) *gomock.Call {
+// SetRead indicates an expected call of SetRead.
+func (mr *MockNotificationstoreMockRecorder) SetRead(ctx, id, isRead any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuditLogs", reflect.TypeOf((*MockNotificationstore)(nil).GetAuditLogs), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRead", reflect.TypeOf((*MockNotificationstore)(nil).SetRead), ctx, id, isRead)
 }

--- a/server/modules/assistant/session_locks_test.go
+++ b/server/modules/assistant/session_locks_test.go
@@ -228,6 +228,12 @@ func (f *fakeAssistantstore) GetSessions(_ context.Context, opts ...model.GetSes
 	}
 	return []*model.AssistantSession{{SessionId: "default-session"}}, nil
 }
+func (f *fakeAssistantstore) DoesUserOwnSession(_ context.Context, _, sessionId string) (bool, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, exists := f.msgs[sessionId]
+	return exists, exists, nil
+}
 func (f *fakeAssistantstore) CreateSession(_ context.Context, _ *model.AssistantSession) error {
 	return nil
 }

--- a/server/modules/elastic/elasticassistantstore.go
+++ b/server/modules/elastic/elasticassistantstore.go
@@ -588,6 +588,78 @@ func (store *ElasticAssistantstore) GetSessions(ctx context.Context, opts ...mod
 	return sessions, nil
 }
 
+// DoesUserOwnSession reports whether the session identified by sessionId is
+// recorded (soft-deleted included) as owned by userId, and whether it exists at
+// all. Only the owner id is fetched from the index — the session document is
+// never transferred or deserialized. A session that doesn't exist returns
+// (false, false, nil).
+func (store *ElasticAssistantstore) DoesUserOwnSession(ctx context.Context, userId, sessionId string) (ownedByUser bool, sessionExists bool, err error) {
+	logger := log.FromContext(ctx)
+
+	query := map[string]any{
+		"query": map[string]any{
+			"bool": map[string]any{
+				"must": []map[string]any{
+					{
+						"term": map[string]any{
+							store.schemaPrefix + "kind": "session",
+						},
+					},
+					{
+						"term": map[string]any{
+							store.schemaPrefix + "session.sessionId": sessionId,
+						},
+					},
+				},
+			},
+		},
+		"_source": []string{store.schemaPrefix + "session.userId"},
+		"size":    1,
+	}
+
+	queryJSON, err := json.Marshal(query)
+	if err != nil {
+		logger.WithError(err).Error("Failed to marshal Elasticsearch query")
+		return false, false, err
+	}
+
+	res, err := store.esClient.Search(
+		store.esClient.Search.WithContext(ctx),
+		store.esClient.Search.WithIndex(store.sessionIndex),
+		store.esClient.Search.WithBody(strings.NewReader(string(queryJSON))),
+	)
+	if err != nil {
+		logger.WithError(err).Error("Failed to execute Elasticsearch search")
+		return false, false, err
+	}
+	defer res.Body.Close()
+
+	responseJSON, err := readJsonFromResponse(res)
+	if err != nil {
+		logger.WithError(err).Error("Failed to read Elasticsearch response")
+		return false, false, err
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(responseJSON), &response); err != nil {
+		logger.WithError(err).Error("Failed to unmarshal Elasticsearch response")
+		return false, false, err
+	}
+
+	hits, _ := response["hits"].(map[string]any)
+	hitsArray, _ := hits["hits"].([]any)
+	if len(hitsArray) == 0 {
+		return false, false, nil
+	}
+
+	hit, _ := hitsArray[0].(map[string]any)
+	source, _ := hit["_source"].(map[string]any)
+	sess, _ := source[store.schemaPrefix+"session"].(map[string]any)
+	owner, _ := sess["userId"].(string)
+
+	return owner == userId, true, nil
+}
+
 // searchSessions executes a session-index query and deserializes the hits into
 // AssistantSession values.
 func (store *ElasticAssistantstore) searchSessions(ctx context.Context, query map[string]any) ([]*model.AssistantSession, error) {

--- a/server/modules/elastic/elasticassistantstore_test.go
+++ b/server/modules/elastic/elasticassistantstore_test.go
@@ -2434,6 +2434,112 @@ func TestGetSessions_SessionIdFilter(t *testing.T) {
 	assert.True(t, foundSessionId, "sessionId filter should be in query")
 }
 
+func TestDoesUserOwnSession(t *testing.T) {
+	ownerHitResponse := func(owner string) string {
+		return `{
+			"hits": {
+				"total": {
+					"value": 1
+				},
+				"hits": [
+					{
+						"_id": "session123",
+						"_source": {
+							"so_session": {
+								"userId": "` + owner + `"
+							}
+						}
+					}
+				]
+			}
+		}`
+	}
+
+	testCases := []struct {
+		name       string
+		statusCode int
+		response   string
+		wantOwned  bool
+		wantExists bool
+		wantErr    bool
+	}{
+		{
+			name:       "session owned by the user",
+			statusCode: 200,
+			response:   ownerHitResponse("test-user"),
+			wantOwned:  true,
+			wantExists: true,
+		},
+		{
+			name:       "session owned by another user",
+			statusCode: 200,
+			response:   ownerHitResponse("someone-else"),
+			wantOwned:  false,
+			wantExists: true,
+		},
+		{
+			name:       "nonexistent session",
+			statusCode: 200,
+			response:   `{"hits": {"total": {"value": 0}, "hits": []}}`,
+			wantOwned:  false,
+			wantExists: false,
+		},
+		{
+			name:       "elasticsearch error propagates",
+			statusCode: 500,
+			response:   `{"error": "internal server error"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockEsClient, transport := modmock.NewMockClient(t)
+
+			store := NewElasticAssistantstore(server.NewFakeAuthorizedServer(nil), mockEsClient, 1000)
+			store.Init("chat-index", "session-index", "so_")
+
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user")
+
+			addJsonResponse(transport, tc.statusCode, tc.response)
+
+			ownedByUser, sessionExists, err := store.DoesUserOwnSession(ctx, "test-user", "session123")
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantOwned, ownedByUser)
+			assert.Equal(t, tc.wantExists, sessionExists)
+
+			// Verify the query fetches only the owner id: source-filtered to the
+			// session userId field, capped to a single hit, filtered by kind and
+			// sessionId.
+			reqs := transport.GetRequests()
+			assert.Len(t, reqs, 1)
+
+			var query map[string]any
+			assert.NoError(t, json.NewDecoder(reqs[0].Body).Decode(&query))
+			assert.Equal(t, []any{"so_session.userId"}, query["_source"])
+			assert.Equal(t, float64(1), query["size"])
+
+			mustQuery := query["query"].(map[string]any)["bool"].(map[string]any)["must"].([]any)
+			assert.Len(t, mustQuery, 2)
+			foundSessionId := false
+			for _, clause := range mustQuery {
+				if term, ok := clause.(map[string]any)["term"].(map[string]any); ok {
+					if sessionId, exists := term["so_session.sessionId"]; exists {
+						assert.Equal(t, "session123", sessionId)
+						foundSessionId = true
+					}
+				}
+			}
+			assert.True(t, foundSessionId, "sessionId filter should be in query")
+		})
+	}
+}
+
 func TestGetSessions_WithDescendants(t *testing.T) {
 	mockEsClient, transport := modmock.NewMockClient(t)
 


### PR DESCRIPTION
The original discovery was for PostChat but further research showed the same was true for PostTool. Updated both to hit the database with a new DoesUserOwnSession query.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->