### PR TITLE
Assistant: Reports Tools

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -562,7 +562,7 @@
                   <v-list-item-title v-text="i18n.aiMetrics"></v-list-item-title>
                 </router-link>
               </v-list-item>
-              <v-list-item data-aid="nav_admin_agentstudio" v-if="$root.isUserAdmin() && isLicensed('oai') && $root.parameters.assistant?.agentic">
+              <v-list-item data-aid="nav_admin_agentstudio" v-if="$root.isUserAdmin() && isLicensed('oai') && ($root.parameters.assistant?.agentic || $root.parameters.assistant?.memoryEnabled)">
                 <template #prepend>
                   <router-link to="/agentstudio" class="text-decoration-none" aria-hidden="true" tabindex="-1">
                     <v-icon>fa-user-tie</v-icon>

--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -354,7 +354,7 @@ const i18n = {
       agentStudioMemoryThresholdHelp: 'How close a new memory must be to an existing one to be reconciled with it, and how close a memory must be to the message to be included.',
       agentStudioMemoryModel: 'Memory model',
       agentStudioMemoryModelHelp: 'Extracts memories from sessions.',
-      agentStudioEmbedModel: 'Embed model',
+      agentStudioEmbedModel: 'Embed agent',
       agentStudioEmbedModelHelp: 'Vectorizes memories. Changing it re-embeds all stored memories.',
       agentStudioReconcileModel: 'Reconcile model',
       agentStudioReconcileModelHelp: 'Merges near-duplicate memories.',

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -5129,6 +5129,14 @@ test('shouldAutoApproveTool returns true for get_playbooks when setting enabled'
   expect(result).toBe(true);
 });
 
+test('shouldAutoApproveTool returns true for query_reports when setting enabled', () => {
+  comp.alwaysApproveReadRequests = true;
+
+  const result = comp.shouldAutoApproveTool('query_reports');
+
+  expect(result).toBe(true);
+});
+
 test('shouldAutoApproveTool returns false for other tools when setting enabled', () => {
   comp.alwaysApproveReadRequests = true;
   

--- a/html/js/routes/assistant.utils.js
+++ b/html/js/routes/assistant.utils.js
@@ -265,6 +265,7 @@ globalThis.AssistantUtils = (function() {
             'get_playbooks',
             'query_cases',
             'query_detections',
+            'query_reports',
           ].includes(toolName) ||
           /^delegate_to_.+$/.test(toolName)
         )

--- a/server/modules/assistant/agentic.go
+++ b/server/modules/assistant/agentic.go
@@ -383,6 +383,11 @@ func (ac *AssistantCoordinator) setupAgentic(prompts map[string]string) {
 			Tools:            []string{"add_overrides", "create_detection", "toggle_detections", "update_detection_content", "update_overrides"},
 			AdditionalPrompt: prompts["prompt_skill_tuning"],
 		},
+		"Reports": {
+			Name:             "Reports",
+			Tools:            []string{"query_reports", "update_custom_report"},
+			AdditionalPrompt: prompts["prompt_skill_reports"],
+		},
 	}
 
 	// Everything above ships with the product and starts enabled.

--- a/server/modules/assistant/chat_session.go
+++ b/server/modules/assistant/chat_session.go
@@ -171,7 +171,7 @@ func (ac *AssistantCoordinator) createSessionIfNeeded(ctx context.Context, incMs
 }
 
 // buildNoTimeoutCtx returns a context detached from the request's cancellation and
-// timeout, carrying over the requestor identity and request-scoped logger.
+// timeout, carrying over the requestor identity, request id, and request-scoped logger.
 func buildNoTimeoutCtx(ctx context.Context) context.Context {
 	noTimeOutCtx := context.Background()
 	if val := ctx.Value(web.ContextKeyRunAsUsername); val != nil {
@@ -181,6 +181,11 @@ func buildNoTimeoutCtx(ctx context.Context) context.Context {
 	}
 	if requestorId, ok := ctx.Value(web.ContextKeyRequestorId).(string); ok {
 		noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRequestorId, requestorId)
+	}
+	// Carried so downstream stores that key work off the request id (e.g. the salt
+	// relay's queue filename) still find it on a detached turn.
+	if requestId, ok := ctx.Value(web.ContextKeyRequestId).(string); ok {
+		noTimeOutCtx = context.WithValue(noTimeOutCtx, web.ContextKeyRequestId, requestId)
 	}
 	noTimeOutCtx = log.NewContext(noTimeOutCtx, log.FromContext(ctx))
 	return noTimeOutCtx

--- a/server/modules/assistant/chat_session_test.go
+++ b/server/modules/assistant/chat_session_test.go
@@ -91,8 +91,19 @@ func TestBuildNoTimeoutCtx(t *testing.T) {
 		ctxBuilder      func() context.Context
 		wantRequestorId any
 		wantRunAs       any
+		wantRequestId   any
 		checkNoDeadline bool
 	}{
+		{
+			name: "preserves request id when present",
+			ctxBuilder: func() context.Context {
+				ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "user-1")
+				return context.WithValue(ctx, web.ContextKeyRequestId, "req-1")
+			},
+			wantRequestorId: "user-1",
+			wantRunAs:       nil,
+			wantRequestId:   "req-1",
+		},
 		{
 			name: "preserves requestor id and drops any deadline",
 			ctxBuilder: func() context.Context {
@@ -125,6 +136,7 @@ func TestBuildNoTimeoutCtx(t *testing.T) {
 
 			assert.Equal(t, tc.wantRequestorId, out.Value(web.ContextKeyRequestorId))
 			assert.Equal(t, tc.wantRunAs, out.Value(web.ContextKeyRunAsUsername))
+			assert.Equal(t, tc.wantRequestId, out.Value(web.ContextKeyRequestId))
 
 			if tc.checkNoDeadline {
 				_, hasDeadline := out.Deadline()

--- a/server/modules/assistant/query_reports.go
+++ b/server/modules/assistant/query_reports.go
@@ -72,10 +72,13 @@ type reportDetail struct {
 	Content  string `json:"content"`
 }
 
-func (t *QueryReportsTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
-	logger := log.FromContext(ctx)
+func (t *QueryReportsTool) Execute(ctx context.Context, srv *server.Server, req *model.ToolRequest) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx).WithFields(log.Fields{
+		"sessionId": req.SessionId,
+		"toolUseId": req.ToolUseId,
+	})
 
-	logger.WithField("toolParameters", params).Info("running tool for assistant")
+	logger.WithField("toolParameters", req.Params).Info("running tool for assistant")
 
 	err = srv.CheckAuthorized(ctx, "read", "config")
 	if err != nil {
@@ -98,9 +101,9 @@ func (t *QueryReportsTool) Execute(ctx context.Context, srv *server.Server, para
 		}
 	}()
 
-	err = json.Unmarshal([]byte(params), args)
+	err = json.Unmarshal(req.Params, args)
 	if err != nil {
-		logger.WithError(err).WithField("toolParams", params).Error("failed to unmarshal tool params")
+		logger.WithError(err).WithField("toolParams", req.Params).Error("failed to unmarshal tool params")
 		return nil, errors.New("ERROR_ASSISTANT_UNMARSHAL_PARAMS")
 	}
 

--- a/server/modules/assistant/query_reports.go
+++ b/server/modules/assistant/query_reports.go
@@ -1,0 +1,168 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+)
+
+func init() {
+	t := &QueryReportsTool{}
+	knownTools[t.GetName()] = t
+}
+
+type QueryReportsTool struct{}
+
+func (t *QueryReportsTool) GetName() string {
+	return "query_reports"
+}
+
+func (t *QueryReportsTool) GetDescription() string {
+	return "List the report templates configured in Security Onion (built-in 'standard' reports and the " +
+		"fixed 'custom' report slots), including which custom slots are empty and available to fill. " +
+		"Optionally pass a filename to return that report's full template content. Use this to see what " +
+		"reports exist (e.g. before authoring a new one) or to inspect a report's definition."
+}
+
+func (t *QueryReportsTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"filename": {
+					Type: "string",
+					Description: "Optional. The filename of a specific report (e.g. \"generic_report2.md\") to " +
+						"return full template content for. Omit to list all reports.",
+				},
+			},
+		},
+	}
+}
+
+type queryReportsArgs struct {
+	Filename string `json:"filename,omitempty"`
+}
+
+type reportSummary struct {
+	Filename string `json:"filename"`
+	Title    string `json:"title"`
+	Type     string `json:"type"`
+	Empty    bool   `json:"empty"`
+}
+
+type reportDetail struct {
+	Filename string `json:"filename"`
+	Title    string `json:"title"`
+	Type     string `json:"type"`
+	Empty    bool   `json:"empty"`
+	Content  string `json:"content"`
+}
+
+func (t *QueryReportsTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	err = srv.CheckAuthorized(ctx, "read", "config")
+	if err != nil {
+		logger.WithError(err).Error("user is not authorized to query reports")
+		return nil, errors.New("ERROR_PERMISSION_DENIED")
+	}
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &queryReportsArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		logger.WithError(err).WithField("toolParams", params).Error("failed to unmarshal tool params")
+		return nil, errors.New("ERROR_ASSISTANT_UNMARSHAL_PARAMS")
+	}
+
+	result.Parameters = args
+
+	if srv.Configstore == nil {
+		logger.Error("config store is not available")
+		return nil, errors.New("ERROR_ASSISTANT_CONFIG_STORE_UNAVAILABLE")
+	}
+
+	slots, err := loadReportSlots(ctx, srv)
+	if err != nil {
+		logger.WithError(err).Error("failed to load report slots")
+		return nil, errors.New("ERROR_ASSISTANT_LOAD_REPORT_SLOTS")
+	}
+
+	if name := strings.TrimSpace(args.Filename); name != "" {
+		for _, s := range slots {
+			if s.Filename == name {
+				result.Result = reportDetail{
+					Filename: s.Filename,
+					Title:    s.Setting.Title,
+					Type:     s.Kind,
+					Empty:    s.isEmpty(),
+					Content:  s.effectiveContent(),
+				}
+				return result, nil
+			}
+		}
+
+		result.Result = fmt.Sprintf("Report %q not found", name)
+		return result, nil
+	}
+
+	sort.Slice(slots, func(i, j int) bool {
+		if slots[i].Kind != slots[j].Kind {
+			return slots[i].Kind < slots[j].Kind
+		}
+		if slots[i].Slot != slots[j].Slot {
+			return slots[i].Slot < slots[j].Slot
+		}
+		return slots[i].Filename < slots[j].Filename
+	})
+
+	reports := make([]reportSummary, 0, len(slots))
+	for _, s := range slots {
+		reports = append(reports, reportSummary{
+			Filename: s.Filename,
+			Title:    s.Setting.Title,
+			Type:     s.Kind,
+			Empty:    s.isEmpty(),
+		})
+	}
+
+	if len(reports) == 0 {
+		result.Result = "No reports found"
+		return result, nil
+	}
+
+	logger.WithField("reportsFound", len(reports)).Info("query executed successfully")
+
+	result.Result = reports
+
+	return result, nil
+}

--- a/server/modules/assistant/query_reports_test.go
+++ b/server/modules/assistant/query_reports_test.go
@@ -1,0 +1,192 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/config"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryReportsTool_Metadata(t *testing.T) {
+	tool := &QueryReportsTool{}
+
+	assert.Equal(t, "query_reports", tool.GetName())
+	assert.NotEmpty(t, tool.GetDescription())
+
+	schema := tool.GetSchema()
+	assert.NotNil(t, schema.Json)
+	assert.Contains(t, schema.Json.Properties, "filename")
+}
+
+type errorConfigstore struct {
+	server.Configstore
+	err error
+}
+
+func (e *errorConfigstore) GetSettings(ctx context.Context, advanced bool) ([]*model.Setting, error) {
+	return nil, e.err
+}
+
+func TestQueryReportsTool_Execute(t *testing.T) {
+	reportSettings := []*model.Setting{
+		{Id: "sensoroni.files.templates.reports.custom.generic_report1__md", File: true, Title: "Custom Report 1", Default: "Example Report\n===\nbody"},
+		{Id: "sensoroni.files.templates.reports.custom.generic_report2__md", File: true, Title: "Custom Report 2", Value: ""},
+		{Id: "sensoroni.files.templates.reports.standard.case_report__md", File: true, Title: "Case Report Template", Default: "Case body"},
+		{Id: "sensoroni.some.other.setting", File: false},
+	}
+
+	testCases := []struct {
+		name          string
+		params        string
+		settings      []*model.Setting
+		configstore   server.Configstore
+		nilStore      bool
+		unauthorized  bool
+		expectedError bool
+		assertResult  func(t *testing.T, result any)
+	}{
+		{
+			name:     "list all reports",
+			params:   `{}`,
+			settings: reportSettings,
+			assertResult: func(t *testing.T, result any) {
+				reports, ok := result.([]reportSummary)
+				assert.True(t, ok)
+				assert.Len(t, reports, 3)
+
+				assert.Equal(t, "generic_report1.md", reports[0].Filename)
+				assert.Equal(t, "Custom Report 1", reports[0].Title)
+				assert.Equal(t, "custom", reports[0].Type)
+				assert.False(t, reports[0].Empty)
+
+				assert.Equal(t, "generic_report2.md", reports[1].Filename)
+				assert.Equal(t, "custom", reports[1].Type)
+				assert.True(t, reports[1].Empty)
+
+				assert.Equal(t, "case_report.md", reports[2].Filename)
+				assert.Equal(t, "standard", reports[2].Type)
+				assert.False(t, reports[2].Empty)
+			},
+		},
+		{
+			name:     "get specific report content",
+			params:   `{"filename": "generic_report1.md"}`,
+			settings: reportSettings,
+			assertResult: func(t *testing.T, result any) {
+				detail, ok := result.(reportDetail)
+				assert.True(t, ok)
+				assert.Equal(t, "generic_report1.md", detail.Filename)
+				assert.Equal(t, "Custom Report 1", detail.Title)
+				assert.Equal(t, "custom", detail.Type)
+				assert.False(t, detail.Empty)
+				assert.Equal(t, "Example Report\n===\nbody", detail.Content)
+			},
+		},
+		{
+			name:     "get empty slot content",
+			params:   `{"filename": "generic_report2.md"}`,
+			settings: reportSettings,
+			assertResult: func(t *testing.T, result any) {
+				detail, ok := result.(reportDetail)
+				assert.True(t, ok)
+				assert.True(t, detail.Empty)
+				assert.Equal(t, "", detail.Content)
+			},
+		},
+		{
+			name:     "report not found",
+			params:   `{"filename": "does_not_exist.md"}`,
+			settings: reportSettings,
+			assertResult: func(t *testing.T, result any) {
+				msg, ok := result.(string)
+				assert.True(t, ok)
+				assert.Contains(t, msg, "not found")
+			},
+		},
+		{
+			name:     "no reports found",
+			params:   `{}`,
+			settings: []*model.Setting{{Id: "sensoroni.some.other.setting", File: false}},
+			assertResult: func(t *testing.T, result any) {
+				msg, ok := result.(string)
+				assert.True(t, ok)
+				assert.Equal(t, "No reports found", msg)
+			},
+		},
+		{
+			name:          "invalid params",
+			params:        `{invalid json}`,
+			settings:      reportSettings,
+			expectedError: true,
+		},
+		{
+			name:          "nil config store",
+			params:        `{}`,
+			nilStore:      true,
+			expectedError: true,
+		},
+		{
+			name:          "config store error",
+			params:        `{}`,
+			configstore:   &errorConfigstore{err: errors.New("boom")},
+			expectedError: true,
+		},
+		{
+			name:          "unauthorized",
+			params:        `{}`,
+			settings:      reportSettings,
+			unauthorized:  true,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cs server.Configstore
+			switch {
+			case tc.nilStore:
+				cs = nil
+			case tc.configstore != nil:
+				cs = tc.configstore
+			default:
+				cs = server.NewMemConfigStore(tc.settings)
+			}
+
+			mockServer := &server.Server{
+				Configstore: cs,
+				Config: &config.ServerConfig{
+					DeveloperEnabled: !tc.unauthorized,
+				},
+			}
+
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			tool := &QueryReportsTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, ``)
+
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "query_reports", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+
+			if tc.assertResult != nil {
+				tc.assertResult(t, result.Result)
+			}
+		})
+	}
+}

--- a/server/modules/assistant/query_reports_test.go
+++ b/server/modules/assistant/query_reports_test.go
@@ -7,6 +7,7 @@ package assistant
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -172,7 +173,7 @@ func TestQueryReportsTool_Execute(t *testing.T) {
 			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
 
 			tool := &QueryReportsTool{}
-			result, err := tool.Execute(ctx, mockServer, tc.params, ``)
+			result, err := tool.Execute(ctx, mockServer, &model.ToolRequest{Params: json.RawMessage(tc.params)})
 
 			if tc.expectedError {
 				assert.Error(t, err)

--- a/server/modules/assistant/reports_common.go
+++ b/server/modules/assistant/reports_common.go
@@ -1,0 +1,112 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+)
+
+const customReportSlotPrefix = "generic_report"
+
+const reportSaltModule = "sensoroni"
+
+type reportSlot struct {
+	Setting  *model.Setting
+	Filename string
+	Kind     string
+	Slot     int
+}
+
+func (r reportSlot) effectiveContent() string {
+	if strings.TrimSpace(r.Setting.Value) != "" {
+		return r.Setting.Value
+	}
+	return r.Setting.Default
+}
+
+func (r reportSlot) isEmpty() bool {
+	return strings.TrimSpace(r.effectiveContent()) == ""
+}
+
+func loadReportSlots(ctx context.Context, srv *server.Server) ([]reportSlot, error) {
+	settings, err := srv.Configstore.GetSettings(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+
+	slots := []reportSlot{}
+	for _, s := range settings {
+		if !s.File || !strings.HasSuffix(s.Id, "__md") {
+			continue
+		}
+
+		var kind string
+		switch {
+		case strings.Contains(s.Id, ".reports.custom."):
+			kind = "custom"
+		case strings.Contains(s.Id, ".reports.standard."):
+			kind = "standard"
+		default:
+			continue
+		}
+
+		filename := reportSettingFilename(s.Id)
+		slot := reportSlot{Setting: s, Filename: filename, Kind: kind}
+
+		if kind == "custom" {
+			n, ok := customReportSlotNumber(filename)
+			if !ok {
+				continue
+			}
+			slot.Slot = n
+		}
+
+		slots = append(slots, slot)
+	}
+
+	return slots, nil
+}
+
+func reportSettingFilename(id string) string {
+	last := id
+	if idx := strings.LastIndex(id, "."); idx >= 0 {
+		last = id[idx+1:]
+	}
+	return strings.ReplaceAll(last, "__", ".")
+}
+
+func customReportSlotNumber(filename string) (int, bool) {
+	if !strings.HasPrefix(filename, customReportSlotPrefix) || !strings.HasSuffix(filename, ".md") {
+		return 0, false
+	}
+	numStr := strings.TrimSuffix(strings.TrimPrefix(filename, customReportSlotPrefix), ".md")
+	n, err := strconv.Atoi(numStr)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
+}
+
+func parseReportTitle(content []byte, deflt string) string {
+	title := deflt
+
+	prevLine := ""
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "===") && prevLine != "" {
+			title = strings.TrimSpace(prevLine)
+			break
+		}
+		prevLine = strings.TrimSpace(line)
+	}
+
+	return title
+}

--- a/server/modules/assistant/reports_common.go
+++ b/server/modules/assistant/reports_common.go
@@ -95,18 +95,23 @@ func customReportSlotNumber(filename string) (int, bool) {
 	return n, true
 }
 
-func parseReportTitle(content []byte, deflt string) string {
-	title := deflt
-
+func titleUnderlineIndex(lines []string) int {
 	prevLine := ""
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
+	for i, line := range lines {
 		if strings.HasPrefix(line, "===") && prevLine != "" {
-			title = strings.TrimSpace(prevLine)
-			break
+			return i
 		}
 		prevLine = strings.TrimSpace(line)
 	}
+	return -1
+}
 
-	return title
+func parseReportTitle(content []byte, deflt string) string {
+	lines := strings.Split(string(content), "\n")
+
+	if i := titleUnderlineIndex(lines); i > 0 {
+		return strings.TrimSpace(lines[i-1])
+	}
+
+	return deflt
 }

--- a/server/modules/assistant/reports_common_test.go
+++ b/server/modules/assistant/reports_common_test.go
@@ -1,0 +1,208 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseReportTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  []byte
+		deflt    string
+		expected string
+	}{
+		{
+			name: "Valid title with equals underline",
+			content: []byte(`My Report Title
+===============
+Some content here`),
+			deflt:    "default.md",
+			expected: "My Report Title",
+		},
+		{
+			name: "Multiple underlines, first one wins",
+			content: []byte(`First Title
+===========
+Content
+Second Title
+============
+More content`),
+			deflt:    "default.md",
+			expected: "First Title",
+		},
+		{
+			name: "No valid title format",
+			content: []byte(`# Header
+Some content
+## Another header`),
+			deflt:    "fallback.md",
+			expected: "fallback.md",
+		},
+		{
+			name:     "Empty content",
+			content:  []byte(``),
+			deflt:    "empty.md",
+			expected: "empty.md",
+		},
+		{
+			name: "Only underline without title",
+			content: []byte(`===============
+Content`),
+			deflt:    "noTitle.md",
+			expected: "noTitle.md",
+		},
+		{
+			name: "Title with whitespace",
+			content: []byte(`   Trimmed Title
+===================
+Content`),
+			deflt:    "default.md",
+			expected: "Trimmed Title",
+		},
+		{
+			name: "Underline too short",
+			content: []byte(`Title Here
+===
+Content`),
+			deflt:    "short.md",
+			expected: "Title Here",
+		},
+		{
+			name:     "Single line content",
+			content:  []byte(`Just one line`),
+			deflt:    "single.md",
+			expected: "single.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseReportTitle(tt.content, tt.deflt)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReportSettingFilename(t *testing.T) {
+	tests := []struct {
+		id       string
+		expected string
+	}{
+		{"sensoroni.files.templates.reports.custom.generic_report2__md", "generic_report2.md"},
+		{"sensoroni.files.templates.reports.standard.case_report__md", "case_report.md"},
+		{"generic_report1__md", "generic_report1.md"},
+		{"noprefix", "noprefix"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			assert.Equal(t, tt.expected, reportSettingFilename(tt.id))
+		})
+	}
+}
+
+func TestCustomReportSlotNumber(t *testing.T) {
+	tests := []struct {
+		filename string
+		num      int
+		ok       bool
+	}{
+		{"generic_report1.md", 1, true},
+		{"generic_report9.md", 9, true},
+		{"generic_report10.md", 10, true},
+		{"addl_generic_report.md", 0, false},
+		{"generic_report.md", 0, false},
+		{"generic_report0.md", 0, false},
+		{"generic_reportx.md", 0, false},
+		{"generic_report2.txt", 0, false},
+		{"case_report.md", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			n, ok := customReportSlotNumber(tt.filename)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.num, n)
+		})
+	}
+}
+
+func TestReportSlotContentAndEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		deflt   string
+		content string
+		empty   bool
+	}{
+		{"value set", "real content", "", "real content", false},
+		{"falls back to default", "", "example", "example", false},
+		{"value over default", "override", "example", "override", false},
+		{"both empty", "", "", "", true},
+		{"whitespace only", "   \n  ", "", "", true},
+		{"whitespace value falls back to default", "  ", "example", "example", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slot := reportSlot{Setting: &model.Setting{Value: tt.value, Default: tt.deflt}}
+			assert.Equal(t, tt.content, slot.effectiveContent())
+			assert.Equal(t, tt.empty, slot.isEmpty())
+		})
+	}
+}
+
+func TestLoadReportSlots(t *testing.T) {
+	settings := []*model.Setting{
+		{Id: "sensoroni.files.templates.reports.custom.generic_report1__md", File: true, Default: "Example\n===\ncontent"},
+		{Id: "sensoroni.files.templates.reports.custom.generic_report2__md", File: true, Value: ""},
+		{Id: "sensoroni.files.templates.reports.custom.addl_generic_report__md", File: true},
+		{Id: "sensoroni.files.templates.reports.standard.case_report__md", File: true, Default: "Case"},
+		{Id: "sensoroni.files.templates.reports.custom.generic_report3__md", File: false},
+		{Id: "sensoroni.some.other.setting", File: false},
+		{Id: "sensoroni.files.templates.reports.custom.notnumbered__md", File: true},
+	}
+
+	srv := &server.Server{Configstore: server.NewMemConfigStore(settings)}
+
+	slots, err := loadReportSlots(context.Background(), srv)
+	assert.NoError(t, err)
+	assert.Len(t, slots, 3)
+
+	byFilename := map[string]reportSlot{}
+	for _, s := range slots {
+		byFilename[s.Filename] = s
+	}
+
+	r1, ok := byFilename["generic_report1.md"]
+	assert.True(t, ok)
+	assert.Equal(t, "custom", r1.Kind)
+	assert.Equal(t, 1, r1.Slot)
+	assert.False(t, r1.isEmpty())
+
+	r2, ok := byFilename["generic_report2.md"]
+	assert.True(t, ok)
+	assert.Equal(t, "custom", r2.Kind)
+	assert.Equal(t, 2, r2.Slot)
+	assert.True(t, r2.isEmpty())
+
+	cr, ok := byFilename["case_report.md"]
+	assert.True(t, ok)
+	assert.Equal(t, "standard", cr.Kind)
+	assert.Equal(t, 0, cr.Slot)
+
+	for _, skipped := range []string{"addl_generic_report.md", "generic_report3.md", "notnumbered.md"} {
+		_, ok := byFilename[skipped]
+		assert.False(t, ok, "expected %s to be skipped", skipped)
+	}
+}

--- a/server/modules/assistant/update_custom_report.go
+++ b/server/modules/assistant/update_custom_report.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -61,11 +62,12 @@ func (t *UpdateCustomReportTool) GetSchema() model.JSONSchema {
    - .Metrics maps groupby_<n>_<fields, dots as underscores> to metric lists: an OQL ending
      "| groupby source.ip" (spaces, no colon) gives .Metrics.groupby_0_source_ip. Range that
      key, not .Metrics. Entries have .Keys, .Value, .Ratio, .Percentage; order them with
-     sortMetrics "Value" "desc".
+     sortMetrics "Value" "desc" $list -- the list is the LAST argument.
    - ASCII only (no emoji, em dashes, arrows, smart quotes); pipe dynamic text through
      stripEmoji.
-   - End row loops with {{- end }}; a plain {{ end }} blank-lines between rows and breaks
-     the table after row 1.`,
+   - An action alone on a line still emits that line's newline, and one blank line ends a
+     Markdown table early. Around table rows, trim standalone actions ({{- $n := 0 -}})
+     and close row loops with {{- end }}.`,
 				},
 				"filename": {
 					Type: "string",
@@ -271,12 +273,38 @@ func deployNoteFor(deployed bool) string {
 
 const queryDirectivePrefix = "/* query."
 
-var reportTemplateFuncs = []string{
-	"getUserDetail", "formatDateTime", "join", "lower", "upper",
-	"sortHistory", "sortComments", "sortRelatedEvents", "sortArtifacts",
-	"sortDetections", "sortMetrics", "sortAssistantMessages",
-	"sortAssistantSessionDetails", "formatNumber", "parseJSON", "toJSON",
-	"add", "stripEmoji",
+func reportTemplateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"getUserDetail":     func(attr string, userId string) string { return "" },
+		"formatDateTime":    func(format string, t *time.Time) string { return "" },
+		"join":              strings.Join,
+		"lower":             strings.ToLower,
+		"upper":             strings.ToUpper,
+		"sortHistory":       func(f, d string, l []*model.Auditable) []*model.Auditable { return l },
+		"sortComments":      func(f, d string, l []*model.Comment) []*model.Comment { return l },
+		"sortRelatedEvents": func(f, d string, l []*model.RelatedEvent) []*model.RelatedEvent { return l },
+		"sortArtifacts":     func(f, d string, l []*model.Artifact) []*model.Artifact { return l },
+		"sortDetections":    func(f, d string, l []*model.Detection) []*model.Detection { return l },
+		"sortMetrics":       func(f, d string, l []*model.EventMetric) []*model.EventMetric { return l },
+		"sortAssistantMessages": func(f, d string, l []*model.StoredMessage) []*model.StoredMessage {
+			return l
+		},
+		"sortAssistantSessionDetails": func(f, d string, l []*model.AssistantSessionDetails) []*model.AssistantSessionDetails {
+			return l
+		},
+		"formatNumber": func(format string, language string, value interface{}) string { return "" },
+		"parseJSON":    func(data interface{}) map[string]interface{} { return map[string]interface{}{} },
+		"toJSON":       func(data interface{}) string { return "" },
+		"add":          func(a, b int) int { return a + b },
+		"stripEmoji":   func(text string) string { return text },
+	}
+}
+
+type reportTemplateInput struct {
+	Error     string
+	BeginDate time.Time
+	EndDate   time.Time
+	Results   map[string]*model.EventSearchResults
 }
 
 func validateReportTemplate(content string) error {
@@ -284,12 +312,8 @@ func validateReportTemplate(content string) error {
 		return errors.New("report template is empty")
 	}
 
-	funcs := template.FuncMap{}
-	for _, name := range reportTemplateFuncs {
-		funcs[name] = func(args ...interface{}) interface{} { return nil }
-	}
-
-	if _, err := template.New("custom_report").Funcs(funcs).Parse(content); err != nil {
+	tmpl, err := template.New("custom_report").Funcs(reportTemplateFuncs()).Parse(content)
+	if err != nil {
 		return fmt.Errorf("failed to parse as a Go text/template: %w", err)
 	}
 
@@ -305,7 +329,139 @@ func validateReportTemplate(content string) error {
 		return err
 	}
 
-	return validateReportASCII(content)
+	if err := validateReportASCII(content); err != nil {
+		return err
+	}
+
+	if err := validateReportResultNames(content); err != nil {
+		return err
+	}
+
+	rendered := &strings.Builder{}
+	if err := tmpl.Execute(rendered, syntheticReportInput(content)); err != nil {
+		return fmt.Errorf("template failed to render against sample data: %w", err)
+	}
+
+	return validateRenderedTables(rendered.String())
+}
+
+var tableSeparator = regexp.MustCompile(`^\|[\s\-:|]+\|$`)
+
+func isTableRow(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "|")
+}
+
+func isTableSeparator(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.Contains(trimmed, "-") && tableSeparator.MatchString(trimmed)
+}
+
+func validateRenderedTables(rendered string) error {
+	lines := strings.Split(rendered, "\n")
+
+	for i := 0; i+2 < len(lines); i++ {
+		if !isTableRow(lines[i]) || strings.TrimSpace(lines[i+1]) != "" || !isTableRow(lines[i+2]) {
+			continue
+		}
+
+		// A blank line followed by a header and its separator is a second table, not a break.
+		if i+3 < len(lines) && isTableSeparator(lines[i+3]) {
+			continue
+		}
+
+		return fmt.Errorf("a blank line splits a Markdown table before the row %q, so every row after it renders as plain text; trim the standalone action that emits that newline ({{- ... -}}) or close the row loop with {{- end }}", strings.TrimSpace(lines[i+2]))
+	}
+
+	return nil
+}
+
+var resultReference = regexp.MustCompile(`\.Results\.([A-Za-z_][A-Za-z0-9_]*)`)
+
+func validateReportResultNames(content string) error {
+	declared := map[string]bool{}
+	names := []string{}
+
+	for _, directive := range oqlDirectives(content) {
+		declared[directive.Name] = true
+		names = append(names, directive.Name)
+	}
+
+	for _, match := range resultReference.FindAllStringSubmatch(content, -1) {
+		if !declared[match[1]] {
+			return fmt.Errorf("body reads .Results.%s but no query declares %q; declared queries are: %s", match[1], match[1], strings.Join(names, ", "))
+		}
+	}
+
+	return nil
+}
+
+func syntheticReportInput(content string) *reportTemplateInput {
+	now := time.Now()
+	input := &reportTemplateInput{
+		BeginDate: now,
+		EndDate:   now,
+		Results:   map[string]*model.EventSearchResults{},
+	}
+
+	for _, directive := range oqlDirectives(content) {
+		results := &model.EventSearchResults{
+			TotalEvents: 2,
+			Events:      []*model.EventRecord{sampleEventRecord(), sampleEventRecord()},
+			Metrics:     map[string][]*model.EventMetric{},
+		}
+
+		if key := groupByMetricKey(directive.Value); key != "" {
+			results.Metrics[key] = []*model.EventMetric{sampleEventMetric(), sampleEventMetric()}
+		}
+
+		input.Results[directive.Name] = results
+	}
+
+	return input
+}
+
+func sampleEventRecord() *model.EventRecord {
+	return &model.EventRecord{
+		Source:    "sample",
+		Time:      time.Now(),
+		Timestamp: time.Now().Format(time.RFC3339),
+		Id:        "sample-id",
+		Payload:   map[string]interface{}{},
+	}
+}
+
+func sampleEventMetric() *model.EventMetric {
+	return &model.EventMetric{
+		Keys:       []interface{}{"sample", "sample", "sample", "sample"},
+		Value:      1,
+		Ratio:      0.5,
+		Percentage: 50,
+	}
+}
+
+func groupByMetricKey(oql string) string {
+	lowered := strings.ToLower(oql)
+
+	idx := strings.Index(lowered, "| groupby ")
+	if idx < 0 {
+		return ""
+	}
+
+	segment := oql[idx+len("| groupby "):]
+	if end := strings.Index(segment, "|"); end >= 0 {
+		segment = segment[:end]
+	}
+
+	fields := strings.FieldsFunc(segment, func(r rune) bool { return r == ' ' || r == ',' || r == '\t' })
+	if len(fields) == 0 {
+		return ""
+	}
+
+	for i, field := range fields {
+		fields[i] = strings.ReplaceAll(strings.TrimSuffix(field, "*"), ".", "_")
+	}
+
+	return "groupby_0_" + strings.Join(fields, "_")
 }
 
 func validateReportDirectives(content string) error {
@@ -356,6 +512,7 @@ func hasOqlQueryDirective(content string) bool {
 
 type oqlDirective struct {
 	Line  int
+	Name  string
 	Value string
 }
 
@@ -388,7 +545,7 @@ func oqlDirectives(content string) []oqlDirective {
 		}
 
 		if strings.EqualFold(strings.TrimSpace(parts[1]), "oql") && value != "" {
-			found = append(found, oqlDirective{Line: i, Value: value})
+			found = append(found, oqlDirective{Line: i, Name: strings.TrimSpace(parts[0]), Value: value})
 		}
 	}
 

--- a/server/modules/assistant/update_custom_report.go
+++ b/server/modules/assistant/update_custom_report.go
@@ -410,8 +410,8 @@ func syntheticReportInput(content string) *reportTemplateInput {
 			Metrics:     map[string][]*model.EventMetric{},
 		}
 
-		if key := groupByMetricKey(directive.Value); key != "" {
-			results.Metrics[key] = []*model.EventMetric{sampleEventMetric(), sampleEventMetric()}
+		for key, arity := range groupByMetricKeys(directive.Value) {
+			results.Metrics[key] = []*model.EventMetric{sampleEventMetric(arity), sampleEventMetric(arity)}
 		}
 
 		input.Results[directive.Name] = results
@@ -430,21 +430,26 @@ func sampleEventRecord() *model.EventRecord {
 	}
 }
 
-func sampleEventMetric() *model.EventMetric {
+func sampleEventMetric(arity int) *model.EventMetric {
+	keys := make([]interface{}, arity)
+	for i := range keys {
+		keys[i] = "sample"
+	}
+
 	return &model.EventMetric{
-		Keys:       []interface{}{"sample", "sample", "sample", "sample"},
+		Keys:       keys,
 		Value:      1,
 		Ratio:      0.5,
 		Percentage: 50,
 	}
 }
 
-func groupByMetricKey(oql string) string {
-	lowered := strings.ToLower(oql)
+func groupByMetricKeys(oql string) map[string]int {
+	keys := map[string]int{}
 
-	idx := strings.Index(lowered, "| groupby ")
+	idx := strings.Index(strings.ToLower(oql), "| groupby ")
 	if idx < 0 {
-		return ""
+		return keys
 	}
 
 	segment := oql[idx+len("| groupby "):]
@@ -453,15 +458,15 @@ func groupByMetricKey(oql string) string {
 	}
 
 	fields := strings.FieldsFunc(segment, func(r rune) bool { return r == ' ' || r == ',' || r == '\t' })
-	if len(fields) == 0 {
-		return ""
-	}
-
 	for i, field := range fields {
 		fields[i] = strings.ReplaceAll(strings.TrimSuffix(field, "*"), ".", "_")
 	}
 
-	return "groupby_0_" + strings.Join(fields, "_")
+	for depth := 1; depth <= len(fields); depth++ {
+		keys["groupby_0_"+strings.Join(fields[:depth], "_")] = depth
+	}
+
+	return keys
 }
 
 func validateReportDirectives(content string) error {

--- a/server/modules/assistant/update_custom_report.go
+++ b/server/modules/assistant/update_custom_report.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"unicode"
 
 	"github.com/apex/log"
 	"github.com/security-onion-solutions/securityonion-soc/model"
@@ -33,12 +34,10 @@ func (t *UpdateCustomReportTool) GetName() string {
 }
 
 func (t *UpdateCustomReportTool) GetDescription() string {
-	return "Author or update a custom report for Security Onion from the user's request. Provide the " +
-		"complete report template in 'content'. By default the report is saved into the next free custom " +
-		"report slot (slot 1 is the shipped example; slots 2-9 are user-fillable). To update an existing " +
-		"report instead, pass its 'filename' (use query_reports to find it). The report is saved as a grid " +
-		"configuration setting and deployed to the grid. Follow the custom report authoring guidelines " +
-		"when composing the content, and include a title block so the report has a display name."
+	return "Author, update, or clear a custom report for Security Onion. The template is saved as a grid " +
+		"configuration setting and deployed to the grid. Custom reports fill 9 fixed slots: slot 1 is the " +
+		"shipped example and slots 2-9 are user-fillable, and without a 'filename' the report goes into the " +
+		"next free slot. Pass an empty 'content' with a 'filename' to clear that report and free its slot."
 }
 
 func (t *UpdateCustomReportTool) GetSchema() model.JSONSchema {
@@ -48,17 +47,30 @@ func (t *UpdateCustomReportTool) GetSchema() model.JSONSchema {
 			Properties: map[string]model.ToolSchemaProperty{
 				"content": {
 					Type: "string",
-					Description: "The complete custom report template as Markdown: a title block (title line " +
-						"followed by a line of '='), one or more /* query.<name>.oql = <OQL> */ directives " +
-						"(optionally metricLimit/eventLimit), and a Go text/template body that renders the query " +
-						"results via .Results.<name> (.TotalEvents, .Metrics, .Events). Pass an empty string " +
-						"together with 'filename' to clear/reset that report back to empty, freeing the slot.",
+					Description: `The complete report template as Markdown, in three parts.
+
+1. QUERY DIRECTIVES -- one per line at the very top, above the title, wrapped exactly so:
+   {{- /* query.<name>.oql = <OQL> */ -}}
+   {{- /* query.<name>.metricLimit = 50 */ -}}   (optional, as is eventLimit)
+
+2. TITLE BLOCK -- a title line, then a line of '='. The title becomes the display name.
+
+3. BODY -- Go text/template over .Results.<name>: .TotalEvents (int), .Events, .Metrics.
+   - Event fields are in .Payload by dotted name: index $e.Payload "rule.name" (not
+     index $e "rule.name"). Events also have .Id, .Time, .Timestamp, .Source, .Type, .Score.
+   - .Metrics maps groupby_<n>_<fields, dots as underscores> to metric lists: an OQL ending
+     "| groupby source.ip" (spaces, no colon) gives .Metrics.groupby_0_source_ip. Range that
+     key, not .Metrics. Entries have .Keys, .Value, .Ratio, .Percentage; order them with
+     sortMetrics "Value" "desc".
+   - ASCII only (no emoji, em dashes, arrows, smart quotes); pipe dynamic text through
+     stripEmoji.
+   - End row loops with {{- end }}; a plain {{ end }} blank-lines between rows and breaks
+     the table after row 1.`,
 				},
 				"filename": {
 					Type: "string",
-					Description: "Optional. The filename of an existing custom report to update, overwrite, or " +
-						"clear (e.g. \"generic_report2.md\"). Use query_reports to find it. If omitted, the report " +
-						"is saved into the next free slot.",
+					Description: "Optional. Which existing custom report to target, e.g. \"generic_report2.md\". " +
+						"Use query_reports to list them.",
 				},
 			},
 			Required: []string{"content"},
@@ -71,10 +83,13 @@ type updateCustomReportArgs struct {
 	Filename string `json:"filename,omitempty"`
 }
 
-func (t *UpdateCustomReportTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
-	logger := log.FromContext(ctx)
+func (t *UpdateCustomReportTool) Execute(ctx context.Context, srv *server.Server, req *model.ToolRequest) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx).WithFields(log.Fields{
+		"sessionId": req.SessionId,
+		"toolUseId": req.ToolUseId,
+	})
 
-	logger.WithField("toolParameters", params).Info("running tool for assistant")
+	logger.WithField("toolParameters", req.Params).Info("running tool for assistant")
 
 	err = srv.CheckAuthorized(ctx, "write", "config")
 	if err != nil {
@@ -97,9 +112,9 @@ func (t *UpdateCustomReportTool) Execute(ctx context.Context, srv *server.Server
 		}
 	}()
 
-	err = json.Unmarshal([]byte(params), args)
+	err = json.Unmarshal(req.Params, args)
 	if err != nil {
-		logger.WithError(err).WithField("toolParams", params).Error("failed to unmarshal tool params")
+		logger.WithError(err).WithField("toolParams", req.Params).Error("failed to unmarshal tool params")
 		return nil, errors.New("ERROR_ASSISTANT_UNMARSHAL_PARAMS")
 	}
 
@@ -129,12 +144,18 @@ func (t *UpdateCustomReportTool) Execute(ctx context.Context, srv *server.Server
 			return nil, ferr
 		}
 
+		// Slot 1 ships the example report; clearing it would blank that example on the grid.
+		if target.Slot == 1 {
+			return nil, fmt.Errorf("%s is the shipped example report and cannot be cleared; overwrite it with new content instead", target.Filename)
+		}
+
 		if strings.TrimSpace(target.Setting.Value) == "" {
 			result.Result = fmt.Sprintf("Custom report %s has no saved content to clear.", target.Filename)
 			return result, nil
 		}
 
-		if err = srv.Configstore.UpdateSetting(ctx, &model.Setting{Id: target.Setting.Id, Value: ""}, false); err != nil {
+		// Remove the override rather than saving an empty one, so the slot returns to its default.
+		if err = srv.Configstore.UpdateSetting(ctx, &model.Setting{Id: target.Setting.Id}, true); err != nil {
 			logger.WithError(err).WithField("settingId", target.Setting.Id).Error("failed to clear custom report setting")
 			return nil, errors.New("ERROR_ASSISTANT_CLEAR_REPORT_TEMPLATE")
 		}
@@ -248,6 +269,8 @@ func deployNoteFor(deployed bool) string {
 	return "Synchronize the grid to apply the change."
 }
 
+const queryDirectivePrefix = "/* query."
+
 var reportTemplateFuncs = []string{
 	"getUserDetail", "formatDateTime", "join", "lower", "upper",
 	"sortHistory", "sortComments", "sortRelatedEvents", "sortArtifacts",
@@ -274,19 +297,78 @@ func validateReportTemplate(content string) error {
 		return errors.New("must define at least one /* query.<name>.oql = ... */ directive")
 	}
 
+	if err := validateReportDirectives(content); err != nil {
+		return err
+	}
+
+	if err := validateReportOql(content); err != nil {
+		return err
+	}
+
+	return validateReportASCII(content)
+}
+
+func validateReportDirectives(content string) error {
+	lines := strings.Split(content, "\n")
+	titleLine := titleUnderlineIndex(lines)
+
+	for i, line := range lines {
+		if !strings.Contains(line, queryDirectivePrefix) {
+			continue
+		}
+
+		if titleLine >= 0 && i > titleLine {
+			return fmt.Errorf("line %d places a query directive below the title block; move every directive above the title, or its comment's trim markers will run the title's '=' underline into the following line", i+1)
+		}
+
+		if strings.Count(line, queryDirectivePrefix) > 1 {
+			return fmt.Errorf("line %d declares more than one query directive; only the first is read, so put each directive on its own line", i+1)
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "{{") || !strings.HasSuffix(trimmed, "}}") {
+			return fmt.Errorf("line %d must wrap its query directive in a template comment, e.g. {{- /* query.<name>.oql = ... */ -}}, otherwise it renders as literal text in the report", i+1)
+		}
+	}
+
+	return nil
+}
+
+func validateReportASCII(content string) error {
+	for i, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, queryDirectivePrefix) {
+			continue
+		}
+
+		for _, r := range line {
+			if r > unicode.MaxASCII {
+				return fmt.Errorf("line %d contains the non-ASCII character %q; the report renderer handles ASCII only, so avoid emoji, em dashes, arrows and smart quotes, and pipe dynamic text through stripEmoji", i+1, r)
+			}
+		}
+	}
+
 	return nil
 }
 
 func hasOqlQueryDirective(content string) bool {
-	const prefix = "/* query."
+	return len(oqlDirectives(content)) > 0
+}
 
-	for _, line := range strings.Split(content, "\n") {
-		start := strings.Index(line, prefix)
+type oqlDirective struct {
+	Line  int
+	Value string
+}
+
+func oqlDirectives(content string) []oqlDirective {
+	found := []oqlDirective{}
+
+	for i, line := range strings.Split(content, "\n") {
+		start := strings.Index(line, queryDirectivePrefix)
 		if start < 0 {
 			continue
 		}
 
-		body := line[start+len(prefix):]
+		body := line[start+len(queryDirectivePrefix):]
 		end := strings.Index(body, "*/")
 		if end < 0 {
 			continue
@@ -306,9 +388,25 @@ func hasOqlQueryDirective(content string) bool {
 		}
 
 		if strings.EqualFold(strings.TrimSpace(parts[1]), "oql") && value != "" {
-			return true
+			found = append(found, oqlDirective{Line: i, Value: value})
 		}
 	}
 
-	return false
+	return found
+}
+
+var oqlSegmentKinds = []string{"groupby", "sortby", "table"}
+
+func validateReportOql(content string) error {
+	for _, directive := range oqlDirectives(content) {
+		lowered := strings.ToLower(directive.Value)
+
+		for _, kind := range oqlSegmentKinds {
+			if strings.Contains(lowered, kind+":") {
+				return fmt.Errorf("line %d writes %q in its OQL; the segment keyword is separated by a space, e.g. | %s source.ip", directive.Line+1, kind+":", kind)
+			}
+		}
+	}
+
+	return nil
 }

--- a/server/modules/assistant/update_custom_report.go
+++ b/server/modules/assistant/update_custom_report.go
@@ -1,0 +1,314 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+)
+
+func init() {
+	t := &UpdateCustomReportTool{}
+	knownTools[t.GetName()] = t
+}
+
+type UpdateCustomReportTool struct{}
+
+func (t *UpdateCustomReportTool) GetName() string {
+	return "update_custom_report"
+}
+
+func (t *UpdateCustomReportTool) GetDescription() string {
+	return "Author or update a custom report for Security Onion from the user's request. Provide the " +
+		"complete report template in 'content'. By default the report is saved into the next free custom " +
+		"report slot (slot 1 is the shipped example; slots 2-9 are user-fillable). To update an existing " +
+		"report instead, pass its 'filename' (use query_reports to find it). The report is saved as a grid " +
+		"configuration setting and deployed to the grid. Follow the custom report authoring guidelines " +
+		"when composing the content, and include a title block so the report has a display name."
+}
+
+func (t *UpdateCustomReportTool) GetSchema() model.JSONSchema {
+	return model.JSONSchema{
+		Json: &model.ToolSchema{
+			Type: "object",
+			Properties: map[string]model.ToolSchemaProperty{
+				"content": {
+					Type: "string",
+					Description: "The complete custom report template as Markdown: a title block (title line " +
+						"followed by a line of '='), one or more /* query.<name>.oql = <OQL> */ directives " +
+						"(optionally metricLimit/eventLimit), and a Go text/template body that renders the query " +
+						"results via .Results.<name> (.TotalEvents, .Metrics, .Events). Pass an empty string " +
+						"together with 'filename' to clear/reset that report back to empty, freeing the slot.",
+				},
+				"filename": {
+					Type: "string",
+					Description: "Optional. The filename of an existing custom report to update, overwrite, or " +
+						"clear (e.g. \"generic_report2.md\"). Use query_reports to find it. If omitted, the report " +
+						"is saved into the next free slot.",
+				},
+			},
+			Required: []string{"content"},
+		},
+	}
+}
+
+type updateCustomReportArgs struct {
+	Content  string `json:"content"`
+	Filename string `json:"filename,omitempty"`
+}
+
+func (t *UpdateCustomReportTool) Execute(ctx context.Context, srv *server.Server, params string, auxData string) (result *model.ToolResponse, err error) {
+	logger := log.FromContext(ctx)
+
+	logger.WithField("toolParameters", params).Info("running tool for assistant")
+
+	err = srv.CheckAuthorized(ctx, "write", "config")
+	if err != nil {
+		logger.WithError(err).Error("user is not authorized to generate custom reports")
+		return nil, errors.New("ERROR_PERMISSION_DENIED")
+	}
+
+	userId := ctx.Value(web.ContextKeyRequestorId).(string)
+
+	args := &updateCustomReportArgs{}
+	result = &model.ToolResponse{
+		ToolName:       t.GetName(),
+		OnBehalfOfUser: userId,
+	}
+
+	start := time.Now()
+	defer func() {
+		if result != nil {
+			result.TimeToExecute = time.Since(start)
+		}
+	}()
+
+	err = json.Unmarshal([]byte(params), args)
+	if err != nil {
+		logger.WithError(err).WithField("toolParams", params).Error("failed to unmarshal tool params")
+		return nil, errors.New("ERROR_ASSISTANT_UNMARSHAL_PARAMS")
+	}
+
+	result.Parameters = args
+
+	if srv.Configstore == nil {
+		logger.Error("config store is not available")
+		return nil, errors.New("ERROR_ASSISTANT_CONFIG_STORE_UNAVAILABLE")
+	}
+
+	slots, err := loadReportSlots(ctx, srv)
+	if err != nil {
+		logger.WithError(err).Error("failed to load report slots")
+		return nil, errors.New("ERROR_ASSISTANT_LOAD_REPORT_SLOTS")
+	}
+
+	custom := customReportSlots(slots)
+
+	if strings.TrimSpace(args.Content) == "" {
+		name := strings.TrimSpace(args.Filename)
+		if name == "" {
+			return nil, errors.New("ERROR_ASSISTANT_TEMPLATE_FILENAME_NEEDED")
+		}
+
+		target, ferr := findCustomSlotByName(custom, name)
+		if ferr != nil {
+			return nil, ferr
+		}
+
+		if strings.TrimSpace(target.Setting.Value) == "" {
+			result.Result = fmt.Sprintf("Custom report %s has no saved content to clear.", target.Filename)
+			return result, nil
+		}
+
+		if err = srv.Configstore.UpdateSetting(ctx, &model.Setting{Id: target.Setting.Id, Value: ""}, false); err != nil {
+			logger.WithError(err).WithField("settingId", target.Setting.Id).Error("failed to clear custom report setting")
+			return nil, errors.New("ERROR_ASSISTANT_CLEAR_REPORT_TEMPLATE")
+		}
+
+		deployed := deployReportModule(ctx, srv, logger)
+		logger.WithFields(log.Fields{
+			"filename":  target.Filename,
+			"settingId": target.Setting.Id,
+			"deployed":  deployed,
+		}).Info("custom report cleared")
+
+		result.Result = fmt.Sprintf("Cleared custom report slot %s. %s", target.Filename, deployNoteFor(deployed))
+		return result, nil
+	}
+
+	if err = validateReportTemplate(args.Content); err != nil {
+		logger.WithError(err).Warn("authored report template failed validation")
+		return nil, fmt.Errorf("ERROR_ASSISTANT_REPORT_TEMPLATE_INVALID: %w", err)
+	}
+
+	target, updating, err := selectReportSlot(custom, args.Filename)
+	if err != nil {
+		return nil, err
+	}
+
+	setting := &model.Setting{Id: target.Setting.Id, Value: args.Content}
+	if err = srv.Configstore.UpdateSetting(ctx, setting, false); err != nil {
+		logger.WithError(err).WithField("settingId", setting.Id).Error("failed to save custom report setting")
+		return nil, errors.New("ERROR_ASSISTANT_SAVE_REPORT_TEMPLATE")
+	}
+
+	deployed := deployReportModule(ctx, srv, logger)
+
+	title := parseReportTitle([]byte(args.Content), target.Filename)
+
+	verb := "Created"
+	if updating {
+		verb = "Updated"
+	}
+
+	logger.WithFields(log.Fields{
+		"reportTitle": title,
+		"filename":    target.Filename,
+		"settingId":   target.Setting.Id,
+		"updating":    updating,
+		"deployed":    deployed,
+	}).Info("custom report saved")
+
+	result.Result = fmt.Sprintf("%s custom report %q in slot %s. %s", verb, title, target.Filename, deployNoteFor(deployed))
+
+	return result, nil
+}
+
+func customReportSlots(slots []reportSlot) []reportSlot {
+	custom := []reportSlot{}
+	for _, s := range slots {
+		if s.Kind == "custom" {
+			custom = append(custom, s)
+		}
+	}
+	sort.Slice(custom, func(i, j int) bool { return custom[i].Slot < custom[j].Slot })
+	return custom
+}
+
+func findCustomSlotByName(custom []reportSlot, name string) (reportSlot, error) {
+	for _, s := range custom {
+		if s.Filename == name {
+			return s, nil
+		}
+	}
+	valid := make([]string, 0, len(custom))
+	for _, s := range custom {
+		valid = append(valid, s.Filename)
+	}
+	return reportSlot{}, fmt.Errorf("%q is not a custom report; valid options are: %s", name, strings.Join(valid, ", "))
+}
+
+func selectReportSlot(custom []reportSlot, filename string) (reportSlot, bool, error) {
+	if name := strings.TrimSpace(filename); name != "" {
+		s, err := findCustomSlotByName(custom, name)
+		if err != nil {
+			return reportSlot{}, false, err
+		}
+		return s, true, nil
+	}
+
+	for _, s := range custom {
+		if s.Slot >= 2 && s.isEmpty() {
+			return s, false, nil
+		}
+	}
+
+	return reportSlot{}, false, fmt.Errorf("ERROR_ASSISTANT_ALL_REPORT_SLOTS_IN_USE")
+}
+
+func deployReportModule(ctx context.Context, srv *server.Server, logger log.Interface) bool {
+	if srv.AdminConfigstore == nil {
+		return false
+	}
+	if err := srv.AdminConfigstore.SyncModule(ctx, reportSaltModule, true); err != nil {
+		logger.WithError(err).WithField("module", reportSaltModule).Warn("custom report change saved but grid sync failed")
+		return false
+	}
+	return true
+}
+
+func deployNoteFor(deployed bool) string {
+	if deployed {
+		return "A grid sync was started to apply the change; it will take effect shortly."
+	}
+	return "Synchronize the grid to apply the change."
+}
+
+var reportTemplateFuncs = []string{
+	"getUserDetail", "formatDateTime", "join", "lower", "upper",
+	"sortHistory", "sortComments", "sortRelatedEvents", "sortArtifacts",
+	"sortDetections", "sortMetrics", "sortAssistantMessages",
+	"sortAssistantSessionDetails", "formatNumber", "parseJSON", "toJSON",
+	"add", "stripEmoji",
+}
+
+func validateReportTemplate(content string) error {
+	if strings.TrimSpace(content) == "" {
+		return errors.New("report template is empty")
+	}
+
+	funcs := template.FuncMap{}
+	for _, name := range reportTemplateFuncs {
+		funcs[name] = func(args ...interface{}) interface{} { return nil }
+	}
+
+	if _, err := template.New("custom_report").Funcs(funcs).Parse(content); err != nil {
+		return fmt.Errorf("failed to parse as a Go text/template: %w", err)
+	}
+
+	if !hasOqlQueryDirective(content) {
+		return errors.New("must define at least one /* query.<name>.oql = ... */ directive")
+	}
+
+	return nil
+}
+
+func hasOqlQueryDirective(content string) bool {
+	const prefix = "/* query."
+
+	for _, line := range strings.Split(content, "\n") {
+		start := strings.Index(line, prefix)
+		if start < 0 {
+			continue
+		}
+
+		body := line[start+len(prefix):]
+		end := strings.Index(body, "*/")
+		if end < 0 {
+			continue
+		}
+		body = strings.TrimSpace(body[:end])
+
+		kv := strings.SplitN(body, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+
+		parts := strings.SplitN(key, ".", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		if strings.EqualFold(strings.TrimSpace(parts[1]), "oql") && value != "" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/modules/assistant/update_custom_report_test.go
+++ b/server/modules/assistant/update_custom_report_test.go
@@ -1,0 +1,333 @@
+// Copyright Security Onion Solutions LLC and/or licensed to Security Onion Solutions LLC under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0 as shown at
+// https://securityonion.net/license; you may not use this file except in compliance with the
+// Elastic License 2.0.
+
+package assistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/security-onion-solutions/securityonion-soc/config"
+	"github.com/security-onion-solutions/securityonion-soc/model"
+	"github.com/security-onion-solutions/securityonion-soc/server"
+	"github.com/security-onion-solutions/securityonion-soc/web"
+	"github.com/stretchr/testify/assert"
+)
+
+func jsonEscape(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b[1 : len(b)-1])
+}
+
+const validReportTemplate = "My Report\n===\n/* query.alerts.oql = tags:alert */\nTotal: {{ .Results.alerts.TotalEvents }}"
+
+const reportIDPrefix = "sensoroni.files.templates.reports."
+
+type updateErrorConfigstore struct {
+	*server.MemConfigStore
+	err error
+}
+
+func (u *updateErrorConfigstore) UpdateSetting(ctx context.Context, setting *model.Setting, remove bool) error {
+	return u.err
+}
+
+func newReportSettings() []*model.Setting {
+	return []*model.Setting{
+		{Id: reportIDPrefix + "custom.generic_report1__md", File: true, Title: "Custom Report 1", Default: validReportTemplate},
+		{Id: reportIDPrefix + "custom.generic_report2__md", File: true, Title: "Custom Report 2"},
+		{Id: reportIDPrefix + "custom.generic_report3__md", File: true, Title: "Custom Report 3"},
+		{Id: reportIDPrefix + "standard.case_report__md", File: true, Title: "Case Report Template", Default: "Case body"},
+	}
+}
+
+func settingByIDSuffix(settings []*model.Setting, suffix string) *model.Setting {
+	for _, s := range settings {
+		if strings.HasSuffix(s.Id, suffix) {
+			return s
+		}
+	}
+	return nil
+}
+
+func TestUpdateCustomReportTool_Metadata(t *testing.T) {
+	tool := &UpdateCustomReportTool{}
+
+	assert.Equal(t, "update_custom_report", tool.GetName())
+	assert.NotEmpty(t, tool.GetDescription())
+
+	schema := tool.GetSchema()
+	assert.NotNil(t, schema.Json)
+	assert.Contains(t, schema.Json.Properties, "content")
+	assert.Contains(t, schema.Json.Properties, "filename")
+	assert.Contains(t, schema.Json.Required, "content")
+}
+
+func TestUpdateCustomReportTool_Execute(t *testing.T) {
+	testCases := []struct {
+		name          string
+		params        string
+		settings      func() []*model.Setting
+		configstore   server.Configstore
+		nilStore      bool
+		noAdmin       bool
+		unauthorized  bool
+		expectedError bool
+		assertResult  func(t *testing.T, result *model.ToolResponse, store *server.MemConfigStore)
+	}{
+		{
+			name:   "author into next free slot",
+			params: `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			assertResult: func(t *testing.T, result *model.ToolResponse, store *server.MemConfigStore) {
+				msg := result.Result.(string)
+				assert.Contains(t, msg, "Created")
+				assert.Contains(t, msg, "generic_report2.md")
+				assert.Contains(t, msg, "sync was started")
+
+				settings, _ := store.GetSettings(context.Background(), false)
+				assert.Equal(t, validReportTemplate, settingByIDSuffix(settings, "generic_report2__md").Value)
+			},
+		},
+		{
+			name:   "update named slot",
+			params: `{"content": "` + jsonEscape(validReportTemplate) + `", "filename": "generic_report3.md"}`,
+			assertResult: func(t *testing.T, result *model.ToolResponse, store *server.MemConfigStore) {
+				msg := result.Result.(string)
+				assert.Contains(t, msg, "Updated")
+				assert.Contains(t, msg, "generic_report3.md")
+
+				settings, _ := store.GetSettings(context.Background(), false)
+				assert.Equal(t, validReportTemplate, settingByIDSuffix(settings, "generic_report3__md").Value)
+			},
+		},
+		{
+			name:   "clear a slot with content",
+			params: `{"content": "", "filename": "generic_report2.md"}`,
+			settings: func() []*model.Setting {
+				s := newReportSettings()
+				s[1].Value = validReportTemplate
+				return s
+			},
+			assertResult: func(t *testing.T, result *model.ToolResponse, store *server.MemConfigStore) {
+				msg := result.Result.(string)
+				assert.Contains(t, msg, "Cleared")
+				assert.Contains(t, msg, "generic_report2.md")
+
+				settings, _ := store.GetSettings(context.Background(), false)
+				assert.Equal(t, "", settingByIDSuffix(settings, "generic_report2__md").Value)
+			},
+		},
+		{
+			name:   "clear an already empty slot",
+			params: `{"content": "", "filename": "generic_report2.md"}`,
+			assertResult: func(t *testing.T, result *model.ToolResponse, store *server.MemConfigStore) {
+				assert.Contains(t, result.Result.(string), "no saved content to clear")
+			},
+		},
+		{
+			name:   "author without admin store reports not deployed",
+			params: `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			noAdmin: true,
+			assertResult: func(t *testing.T, result *model.ToolResponse, store *server.MemConfigStore) {
+				assert.Contains(t, result.Result.(string), "Synchronize the grid")
+			},
+		},
+		{
+			name:          "clear without filename",
+			params:        `{"content": ""}`,
+			expectedError: true,
+		},
+		{
+			name:          "invalid filename",
+			params:        `{"content": "` + jsonEscape(validReportTemplate) + `", "filename": "nope.md"}`,
+			expectedError: true,
+		},
+		{
+			name:   "all slots in use",
+			params: `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			settings: func() []*model.Setting {
+				s := newReportSettings()
+				s[1].Value = validReportTemplate
+				s[2].Value = validReportTemplate
+				return s
+			},
+			expectedError: true,
+		},
+		{
+			name:          "invalid template",
+			params:        `{"content": "Just a title\n===\nno query directive"}`,
+			expectedError: true,
+		},
+		{
+			name:          "invalid params",
+			params:        `{invalid json}`,
+			expectedError: true,
+		},
+		{
+			name:          "nil config store",
+			params:        `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			nilStore:      true,
+			expectedError: true,
+		},
+		{
+			name:          "get settings error",
+			params:        `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			configstore:   &errorConfigstore{err: errors.New("read boom")},
+			expectedError: true,
+		},
+		{
+			name:          "update setting error",
+			params:        `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			configstore:   &updateErrorConfigstore{MemConfigStore: server.NewMemConfigStore(newReportSettings()), err: errors.New("write boom")},
+			expectedError: true,
+		},
+		{
+			name:          "unauthorized",
+			params:        `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			unauthorized:  true,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			build := tc.settings
+			if build == nil {
+				build = newReportSettings
+			}
+
+			var cs server.Configstore
+			var admin server.AdminConfigstore
+			var memStore *server.MemConfigStore
+
+			switch {
+			case tc.nilStore:
+				cs = nil
+			case tc.configstore != nil:
+				cs = tc.configstore
+			default:
+				memStore = server.NewMemConfigStore(build())
+				cs = memStore
+				if !tc.noAdmin {
+					admin = memStore
+				}
+			}
+
+			mockServer := &server.Server{
+				Configstore:      cs,
+				AdminConfigstore: admin,
+				Config: &config.ServerConfig{
+					DeveloperEnabled: !tc.unauthorized,
+				},
+			}
+
+			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
+
+			tool := &UpdateCustomReportTool{}
+			result, err := tool.Execute(ctx, mockServer, tc.params, ``)
+
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "update_custom_report", result.ToolName)
+			assert.Equal(t, "test-user-id", result.OnBehalfOfUser)
+
+			if tc.assertResult != nil {
+				tc.assertResult(t, result, memStore)
+			}
+		})
+	}
+}
+
+func TestCustomReportSlots(t *testing.T) {
+	slots := []reportSlot{
+		{Filename: "case_report.md", Kind: "standard"},
+		{Filename: "generic_report3.md", Kind: "custom", Slot: 3},
+		{Filename: "generic_report1.md", Kind: "custom", Slot: 1},
+		{Filename: "generic_report2.md", Kind: "custom", Slot: 2},
+	}
+
+	custom := customReportSlots(slots)
+
+	assert.Len(t, custom, 3)
+	assert.Equal(t, 1, custom[0].Slot)
+	assert.Equal(t, 2, custom[1].Slot)
+	assert.Equal(t, 3, custom[2].Slot)
+}
+
+func TestFindCustomSlotByName(t *testing.T) {
+	custom := []reportSlot{
+		{Filename: "generic_report1.md", Kind: "custom", Slot: 1},
+		{Filename: "generic_report2.md", Kind: "custom", Slot: 2},
+	}
+
+	found, err := findCustomSlotByName(custom, "generic_report2.md")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, found.Slot)
+
+	_, err = findCustomSlotByName(custom, "nope.md")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "generic_report1.md")
+	assert.Contains(t, err.Error(), "generic_report2.md")
+}
+
+func TestSelectReportSlot(t *testing.T) {
+	withContent := &model.Setting{Value: "content"}
+	empty := &model.Setting{}
+
+	slots := []reportSlot{
+		{Filename: "generic_report1.md", Kind: "custom", Slot: 1, Setting: withContent},
+		{Filename: "generic_report2.md", Kind: "custom", Slot: 2, Setting: withContent},
+		{Filename: "generic_report3.md", Kind: "custom", Slot: 3, Setting: empty},
+	}
+
+	t.Run("named slot", func(t *testing.T) {
+		slot, updating, err := selectReportSlot(slots, "generic_report2.md")
+		assert.NoError(t, err)
+		assert.True(t, updating)
+		assert.Equal(t, 2, slot.Slot)
+	})
+
+	t.Run("named invalid slot", func(t *testing.T) {
+		_, _, err := selectReportSlot(slots, "nope.md")
+		assert.Error(t, err)
+	})
+
+	t.Run("lowest free slot", func(t *testing.T) {
+		slot, updating, err := selectReportSlot(slots, "")
+		assert.NoError(t, err)
+		assert.False(t, updating)
+		assert.Equal(t, 3, slot.Slot)
+	})
+
+	t.Run("slot 1 is reserved even if empty", func(t *testing.T) {
+		reserved := []reportSlot{
+			{Filename: "generic_report1.md", Kind: "custom", Slot: 1, Setting: empty},
+			{Filename: "generic_report2.md", Kind: "custom", Slot: 2, Setting: withContent},
+		}
+		_, _, err := selectReportSlot(reserved, "")
+		assert.Error(t, err)
+	})
+
+	t.Run("all slots in use", func(t *testing.T) {
+		full := []reportSlot{
+			{Filename: "generic_report2.md", Kind: "custom", Slot: 2, Setting: withContent},
+		}
+		_, _, err := selectReportSlot(full, "")
+		assert.Error(t, err)
+	})
+}
+
+func TestDeployNoteFor(t *testing.T) {
+	assert.Contains(t, deployNoteFor(true), "sync was started")
+	assert.Contains(t, deployNoteFor(false), "Synchronize the grid")
+}

--- a/server/modules/assistant/update_custom_report_test.go
+++ b/server/modules/assistant/update_custom_report_test.go
@@ -459,6 +459,15 @@ func TestValidateReportTemplate(t *testing.T) {
 			content: "{{- /* query.d.oql = tags:alert */ -}}\nMy Report\n===\n| a |\n|---|\n| 1 |\n\n| b |\n|---|\n| 2 |\n",
 		},
 		{
+			name:    "indexing .Keys past the grouping depth",
+			content: "{{- /* query.a.oql = tags:alert | groupby rule.name @timestamp */ -}}\nMy Report\n===\n{{ range index .Results.a.Metrics \"groupby_0_rule_name\" }}{{ index .Keys 1 }}{{ end }}",
+			wantErr: "sample data",
+		},
+		{
+			name:    "the deeper grouping key carries both bucket values",
+			content: "{{- /* query.a.oql = tags:alert | groupby rule.name @timestamp */ -}}\nMy Report\n===\n{{ range index .Results.a.Metrics \"groupby_0_rule_name_@timestamp\" }}{{ index .Keys 1 }}{{ end }}",
+		},
+		{
 			name:    "non-ASCII inside a directive is allowed",
 			content: "{{- /* query.alerts.oql = message:été */ -}}\nMy Report\n===\nTotal: 5",
 		},

--- a/server/modules/assistant/update_custom_report_test.go
+++ b/server/modules/assistant/update_custom_report_test.go
@@ -24,7 +24,7 @@ func jsonEscape(s string) string {
 	return string(b[1 : len(b)-1])
 }
 
-const validReportTemplate = "My Report\n===\n/* query.alerts.oql = tags:alert */\nTotal: {{ .Results.alerts.TotalEvents }}"
+const validReportTemplate = "{{- /* query.alerts.oql = tags:alert */ -}}\nMy Report\n===\nTotal: {{ .Results.alerts.TotalEvents }}"
 
 const reportIDPrefix = "sensoroni.files.templates.reports."
 
@@ -118,9 +118,16 @@ func TestUpdateCustomReportTool_Execute(t *testing.T) {
 				assert.Contains(t, msg, "Cleared")
 				assert.Contains(t, msg, "generic_report2.md")
 
+				// Cleared with remove=true, so the override is dropped rather than saved as empty;
+				// the mem store discards the whole entry where the real store reverts to the default.
 				settings, _ := store.GetSettings(context.Background(), false)
-				assert.Equal(t, "", settingByIDSuffix(settings, "generic_report2__md").Value)
+				assert.Nil(t, settingByIDSuffix(settings, "generic_report2__md"))
 			},
+		},
+		{
+			name:          "clear the shipped example slot",
+			params:        `{"content": "", "filename": "generic_report1.md"}`,
+			expectedError: true,
 		},
 		{
 			name:   "clear an already empty slot",
@@ -130,8 +137,8 @@ func TestUpdateCustomReportTool_Execute(t *testing.T) {
 			},
 		},
 		{
-			name:   "author without admin store reports not deployed",
-			params: `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
+			name:    "author without admin store reports not deployed",
+			params:  `{"content": "` + jsonEscape(validReportTemplate) + `"}`,
 			noAdmin: true,
 			assertResult: func(t *testing.T, result *model.ToolResponse, store *server.MemConfigStore) {
 				assert.Contains(t, result.Result.(string), "Synchronize the grid")
@@ -229,7 +236,7 @@ func TestUpdateCustomReportTool_Execute(t *testing.T) {
 			ctx := context.WithValue(context.Background(), web.ContextKeyRequestorId, "test-user-id")
 
 			tool := &UpdateCustomReportTool{}
-			result, err := tool.Execute(ctx, mockServer, tc.params, ``)
+			result, err := tool.Execute(ctx, mockServer, &model.ToolRequest{Params: json.RawMessage(tc.params)})
 
 			if tc.expectedError {
 				assert.Error(t, err)
@@ -330,4 +337,97 @@ func TestSelectReportSlot(t *testing.T) {
 func TestDeployNoteFor(t *testing.T) {
 	assert.Contains(t, deployNoteFor(true), "sync was started")
 	assert.Contains(t, deployNoteFor(false), "Synchronize the grid")
+}
+
+func TestValidateReportTemplate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name:    "valid template",
+			content: validReportTemplate,
+		},
+		{
+			name:    "multiple directives on their own lines",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\n{{- /* query.alerts.metricLimit = 50 */ -}}\nMy Report\n===\nTotal: {{ .Results.alerts.TotalEvents }}",
+		},
+		{
+			name:    "directive below the title block",
+			content: "My Report\n===\n{{- /* query.alerts.oql = tags:alert */ -}}\nTotal: 5",
+			wantErr: "below the title block",
+		},
+		{
+			name:    "empty content",
+			content: "   ",
+			wantErr: "empty",
+		},
+		{
+			name:    "unparsable template",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\n{{ .Unclosed ",
+			wantErr: "text/template",
+		},
+		{
+			name:    "no query directive",
+			content: "My Report\n===\nTotal: 5",
+			wantErr: "must define at least one",
+		},
+		{
+			name:    "bare directive renders as text",
+			content: "/* query.alerts.oql = tags:alert */\nMy Report\n===\nTotal: 5",
+			wantErr: "template comment",
+		},
+		{
+			name:    "two directives on one line",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}} {{- /* query.alerts.metricLimit = 50 */ -}}\nMy Report\n===\nTotal: 5",
+			wantErr: "more than one query directive",
+		},
+		{
+			name:    "emoji in body",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\nMy Report\n===\n\U0001F4CB Alerts: 5",
+			wantErr: "non-ASCII",
+		},
+		{
+			name:    "em dash in body",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\nMy Report\n===\nAlerts — recent",
+			wantErr: "non-ASCII",
+		},
+		{
+			name:    "groupby with a colon",
+			content: "{{- /* query.alerts.oql = tags:alert | groupby:source.ip */ -}}\nMy Report\n===\nTotal: 5",
+			wantErr: "separated by a space",
+		},
+		{
+			name:    "sortby with a colon",
+			content: "{{- /* query.alerts.oql = tags:alert | sortby:@timestamp */ -}}\nMy Report\n===\nTotal: 5",
+			wantErr: "separated by a space",
+		},
+		{
+			name:    "space separated groupby is allowed",
+			content: "{{- /* query.alerts.oql = tags:alert | groupby source.ip destination.ip */ -}}\nMy Report\n===\nTotal: 5",
+		},
+		{
+			name:    "colons elsewhere in the query are allowed",
+			content: "{{- /* query.alerts.oql = tags:alert AND source.ip:1.2.3.4 | groupby rule.name */ -}}\nMy Report\n===\nTotal: 5",
+		},
+		{
+			name:    "non-ASCII inside a directive is allowed",
+			content: "{{- /* query.alerts.oql = message:été */ -}}\nMy Report\n===\nTotal: 5",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateReportTemplate(tc.content)
+
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }

--- a/server/modules/assistant/update_custom_report_test.go
+++ b/server/modules/assistant/update_custom_report_test.go
@@ -412,6 +412,53 @@ func TestValidateReportTemplate(t *testing.T) {
 			content: "{{- /* query.alerts.oql = tags:alert AND source.ip:1.2.3.4 | groupby rule.name */ -}}\nMy Report\n===\nTotal: 5",
 		},
 		{
+			name:    "sortMetrics called with the list first",
+			content: "{{- /* query.alerts.oql = tags:alert | groupby rule.name */ -}}\nMy Report\n===\n{{ $m := index .Results.alerts.Metrics \"groupby_0_rule_name\" }}\n{{ range sortMetrics $m \"Value\" \"desc\" }}{{ .Value }}{{ end }}",
+			wantErr: "sample data",
+		},
+		{
+			name:    "sortMetrics with the list last renders",
+			content: "{{- /* query.alerts.oql = tags:alert | groupby rule.name */ -}}\nMy Report\n===\n{{ $m := index .Results.alerts.Metrics \"groupby_0_rule_name\" }}\n{{ range sortMetrics \"Value\" \"desc\" $m }}{{ index .Keys 0 }}{{ end }}",
+		},
+		{
+			name:    "indexing an event instead of its payload",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\nMy Report\n===\n{{ range .Results.alerts.Events }}{{ index . \"rule.name\" }}{{ end }}",
+			wantErr: "sample data",
+		},
+		{
+			name:    "indexing the payload renders",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\nMy Report\n===\n{{ range .Results.alerts.Events }}{{ index .Payload \"rule.name\" }}{{ end }}",
+		},
+		{
+			// The dry run cannot see this (a missing map key renders as "<no value>" rather
+			// than erroring), so the static name check is what catches it.
+			name:    "unknown query name",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\nMy Report\n===\nTotal: {{ .Results.typo.TotalEvents }}",
+			wantErr: "no query declares",
+		},
+		{
+			name:    "dynamic Results access is not flagged",
+			content: "{{- /* query.alerts.oql = tags:alert */ -}}\nMy Report\n===\n{{ range $name, $r := .Results }}{{ $r.TotalEvents }}{{ end }}",
+		},
+		{
+			name:    "untrimmed action blank-lines the table",
+			content: "{{- /* query.d.oql = tags:alert */ -}}\nMy Report\n===\n| # | T |\n|---|---|\n{{ $c := 0 }}\n{{- range .Results.d.Events }}\n{{- $c = add $c 1 }}\n| {{ $c }} | x |\n{{- end }}\n",
+			wantErr: "blank line splits a Markdown table",
+		},
+		{
+			name:    "trimmed action keeps the table intact",
+			content: "{{- /* query.d.oql = tags:alert */ -}}\nMy Report\n===\n| # | T |\n|---|---|\n{{- $c := 0 -}}\n{{- range .Results.d.Events }}\n{{- $c = add $c 1 }}\n| {{ $c }} | x |\n{{- end }}\n",
+		},
+		{
+			name:    "blank lines between rows",
+			content: "{{- /* query.d.oql = tags:alert */ -}}\nMy Report\n===\n| # | T |\n|---|---|\n{{ range .Results.d.Events }}\n| x | y |\n{{ end }}",
+			wantErr: "blank line splits a Markdown table",
+		},
+		{
+			name:    "two adjacent tables are not a break",
+			content: "{{- /* query.d.oql = tags:alert */ -}}\nMy Report\n===\n| a |\n|---|\n| 1 |\n\n| b |\n|---|\n| 2 |\n",
+		},
+		{
 			name:    "non-ASCII inside a directive is allowed",
 			content: "{{- /* query.alerts.oql = message:été */ -}}\nMy Report\n===\nTotal: 5",
 		},


### PR DESCRIPTION
## Description

- Added two reports tools to Onion AI:
  - `query_reports`: Lists reports and returns content when a single report is specified.
  - `update_report_content`: CRUDs reports and performs validation checks on content.
- Created a new `Reports` skill.
- Made a couple minor UI fixes to the Agent Studio page.

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments