### PR TITLE
Fix Race In Test

### DIFF
--- a/server/modules/detections/integrity_check.go
+++ b/server/modules/detections/integrity_check.go
@@ -32,7 +32,6 @@ type IntegrityCheckerData struct {
 }
 
 func IntegrityChecker(engName model.EngineName, eng IntegrityChecked, data *IntegrityCheckerData, intCheckFailure *bool) {
-	data.Thread.Add(1)
 	defer func() {
 		data.Thread.Done()
 		data.IsRunning = false

--- a/server/modules/detections/sync.go
+++ b/server/modules/detections/sync.go
@@ -46,7 +46,6 @@ type SyncSchedulerParams struct {
 }
 
 func SyncScheduler(ctx context.Context, detStore TemplateChecker, e DetailedDetectionEngine, syncParams *SyncSchedulerParams, engineState *model.EngineState, engName model.EngineName, isRunning *bool) {
-	syncParams.SyncThread.Add(1)
 	defer func() {
 		syncParams.SyncThread.Done()
 		*isRunning = false
@@ -105,6 +104,12 @@ func SyncScheduler(ctx context.Context, detStore TemplateChecker, e DetailedDete
 		case <-timer.C:
 		case typ := <-syncParams.InterruptChan:
 			forceSync = forceSync || typ
+		}
+
+		// Stop() clears isRunning before signaling InterruptChan, so this read is
+		// ordered by the channel receive; bail before touching the store
+		if !*isRunning {
+			break
 		}
 
 		haveTemplate := CheckTemplate(ctx, detStore)

--- a/server/modules/detections/sync_test.go
+++ b/server/modules/detections/sync_test.go
@@ -35,8 +35,6 @@ func TestSyncScheduler(t *testing.T) {
 				eng.EXPECT().ResumeIntegrityChecker().DoAndReturn(func() {
 					*isRunning = false
 				})
-
-				eng.EXPECT().PauseIntegrityChecker()
 			},
 			CheckMock: func(t *testing.T, ctx context.Context, detStore *servermock.MockDetectionstore, eng *mock.MockDetailedDetectionEngine, syncParams *SyncSchedulerParams, engineState *model.EngineState, engName model.EngineName, isRunning *bool) {
 				assert.False(t, *isRunning)
@@ -114,6 +112,7 @@ func TestSyncScheduler(t *testing.T) {
 
 			test.InitMock(t, ctx, detStore, eng, syncParams, engineState, engName, isRunning)
 
+			syncParams.SyncThread.Add(1)
 			SyncScheduler(ctx, detStore, eng, syncParams, engineState, engName, isRunning)
 
 			test.CheckMock(t, ctx, detStore, eng, syncParams, engineState, engName, isRunning)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -328,6 +328,8 @@ func (e *ElastAlertEngine) Start() error {
 	e.IntegrityCheckerData.IsRunning = true
 
 	// start long running processes
+	e.SyncSchedulerParams.SyncThread.Add(1)
+	e.IntegrityCheckerData.Thread.Add(1)
 	go detections.SyncScheduler(e.srv.Context, e.srv.Detectionstore, e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameElastAlert, &e.isRunning)
 	go detections.IntegrityChecker(model.EngineNameElastAlert, e, &e.IntegrityCheckerData, &e.EngineState.IntegrityFailure)
 

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -131,6 +131,8 @@ func TestElastAlertModule(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	detStore := servermock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().DoesTemplateExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
+
 	srv := &server.Server{
 		DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
 		Detectionstore:   detStore,

--- a/server/modules/strelka/strelka.go
+++ b/server/modules/strelka/strelka.go
@@ -155,6 +155,8 @@ func (e *StrelkaEngine) Start() error {
 	e.isRunning = true
 
 	// start long running processes
+	e.SyncSchedulerParams.SyncThread.Add(1)
+	e.IntegrityCheckerData.Thread.Add(1)
 	go detections.SyncScheduler(e.srv.Context, e.srv.Detectionstore, e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameStrelka, &e.isRunning)
 	go detections.IntegrityChecker(model.EngineNameStrelka, e, &e.IntegrityCheckerData, &e.EngineState.IntegrityFailure)
 

--- a/server/modules/strelka/strelka_test.go
+++ b/server/modules/strelka/strelka_test.go
@@ -231,8 +231,15 @@ rule ExtractableRule {
 }`
 
 func TestStrelkaModule(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	detStore := servermock.NewMockDetectionstore(ctrl)
+	detStore.EXPECT().DoesTemplateExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
+
 	srv := &server.Server{
 		DetectionEngines: sync.Map{}, // map[model.EngineName]server.DetectionEngine{},
+		Detectionstore:   detStore,
 	}
 	mod := NewStrelkaEngine(srv)
 

--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -294,6 +294,8 @@ func (e *SuricataEngine) Start() error {
 	}
 
 	// start long running processes
+	e.SyncSchedulerParams.SyncThread.Add(1)
+	e.IntegrityCheckerData.Thread.Add(1)
 	go detections.SyncScheduler(e.srv.Context, e.srv.Detectionstore, e, &e.SyncSchedulerParams, &e.EngineState, model.EngineNameSuricata, &e.isRunning)
 	go detections.IntegrityChecker(model.EngineNameSuricata, e, &e.IntegrityCheckerData, &e.EngineState.IntegrityFailure)
 


### PR DESCRIPTION
Some tests had race conditions because of how the sync scheduler and integrity checker added to their mutexes.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->