### PR TITLE
Refactor ESQL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ RUN dnf install -y --nodocs wget tcpdump unzip git gcc python3.14 python3.14-dev
     dnf clean all
 RUN ln -s /usr/bin/python3.14 /usr/local/bin/python3 && ln -s /usr/bin/pip3.14 /usr/local/bin/pip3
 RUN ln -s /usr/bin/python3.14 /usr/local/bin/python && ln -s /usr/bin/pip3.14 /usr/local/bin/pip
-RUN pip3 install pysigma==1.4.0 sigma-cli==3.0.2 pysigma-backend-elasticsearch pysigma-pipeline-windows
+ARG PYSIGMA_ES_REF=esql-refactor
+RUN pip3 install pysigma==1.5.0 sigma-cli==3.0.2 pysigma-pipeline-windows==2.0.0 \
+    "pysigma-backend-elasticsearch @ git+https://github.com/Security-Onion-Solutions/pySigma-backend-elasticsearch.git@${PYSIGMA_ES_REF}"
 ADD dep/pysigma_backend_securityonion-1.0.0-py3-none-any.whl /tmp
 RUN pip3 install /tmp/pysigma_backend_securityonion-1.0.0-py3-none-any.whl
 RUN pip3 install yara-python==4.5.4

--- a/html/js/routes/detection.js
+++ b/html/js/routes/detection.js
@@ -1403,25 +1403,33 @@ routes.push({ path: '/detection/:id', name: 'detection', component: {
 		copyConvertToClipboard() {
 			this.$root.copyToClipboard(this.convertedRule);
 		},
-		runQueryInDiscover() {
-			let query;
-			if (this.isEsql) {
-				query = `POST /_query
+		risonEscape(value) {
+			// Rison escapes with '!', not backslash.
+			return value.replace(/!/g, '!!').replace(/'/g, "!'");
+		},
+		buildEsqlDiscoverUrl(esql) {
+			const query = this.risonEscape(esql.trim());
+			const appState = `(columns:!(),dataSource:(type:esql),filters:!(),interval:auto,query:(esql:'${query}'),sort:!(!('@timestamp',desc)))`;
+			const globalState = `(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h,to:now))`;
+
+			return `/kibana/app/discover#/?_a=${encodeURIComponent(appState)}&_g=${encodeURIComponent(globalState)}`;
+		},
+		buildEqlDevToolsUrl(eql) {
+			const query = `GET /.ds-logs-*/_eql/search
 {
 	"query": """
-	${this.convertedRule}
+	${eql}
 	"""
 }`;
-			} else {
-				query = `GET /.ds-logs-*/_eql/search
-{
-	"query": """
-	${this.convertedRule}
-	"""
-}`;
-			}
 			const compress = LZString.compressToEncodedURIComponent(query);
-			const url = `/kibana/app/dev_tools#/console?load_from=data:text/plain,${compress}`;
+
+			return `/kibana/app/dev_tools#/console?load_from=data:text/plain,${compress}`;
+		},
+		runQueryInDiscover() {
+			// EQL has no Discover equivalent, so it still goes to Dev Tools.
+			const url = this.isEsql
+				? this.buildEsqlDiscoverUrl(this.convertedRule)
+				: this.buildEqlDevToolsUrl(this.convertedRule);
 			window.open(url, '_blank');
 		},
 		isFieldValid(refName) {

--- a/html/js/routes/detection.test.js
+++ b/html/js/routes/detection.test.js
@@ -1208,18 +1208,17 @@ test('loadPlaybooks', async () => {
 
 		comp.runQueryInDiscover();
 
-		expect(window.open).toHaveBeenCalledWith(
-			'/kibana/app/dev_tools#/console?load_from=data:text/plain,compressed_query',
-			'_blank'
-		);
+		const esqlUrl = window.open.mock.calls[0][0];
+		expect(window.open).toHaveBeenCalledWith(esqlUrl, '_blank');
+		expect(esqlUrl.startsWith('/kibana/app/discover#/?_a=')).toBe(true);
+		expect(LZString.compressToEncodedURIComponent).not.toHaveBeenCalled();
 
-		const expectedQuery = `POST /_query
-{
-	"query": """
-	FROM logs-*
-	"""
-}`;
-		expect(LZString.compressToEncodedURIComponent).toHaveBeenCalledWith(expectedQuery);
+		const esqlAppState = decodeURIComponent(esqlUrl.split('_a=')[1].split('&_g=')[0]);
+		expect(esqlAppState).toContain('dataSource:(type:esql)');
+		expect(esqlAppState).toContain("query:(esql:'FROM logs-*')");
+
+		const esqlGlobalState = decodeURIComponent(esqlUrl.split('&_g=')[1]);
+		expect(esqlGlobalState).toContain('time:(from:now-24h,to:now)');
 
 		comp.isEsql = false;
 		comp.convertedRule = 'some eql query';
@@ -1232,10 +1231,28 @@ test('loadPlaybooks', async () => {
 	"""
 }`;
 		expect(LZString.compressToEncodedURIComponent).toHaveBeenCalledWith(expectedEqlQuery);
+		expect(window.open).toHaveBeenCalledWith(
+			'/kibana/app/dev_tools#/console?load_from=data:text/plain,compressed_query',
+			'_blank'
+		);
 
 		window.open = originalOpen;
 		LZString.compressToEncodedURIComponent = originalCompress;
 		resetPapi();
+	});
+
+	test('buildEsqlDiscoverUrl escapes rison special characters', () => {
+		const url = comp.buildEsqlDiscoverUrl(`from * | where process.command_line like "* /priv*" and message == "it's a !bang"`);
+
+		const appState = decodeURIComponent(url.split('_a=')[1].split('&_g=')[0]);
+		expect(appState).toContain(`query:(esql:'from * | where process.command_line like "* /priv*" and message == "it!'s a !!bang"')`);
+	});
+
+	test('buildEsqlDiscoverUrl trims and preserves backslashes', () => {
+		const url = comp.buildEsqlDiscoverUrl('  from * | where ends_with(process.executable.caseless, "\\whoami.exe")  ');
+
+		const appState = decodeURIComponent(url.split('_a=')[1].split('&_g=')[0]);
+		expect(appState).toContain(`query:(esql:'from * | where ends_with(process.executable.caseless, "\\whoami.exe")')`);
 	});
 
 	test('extract elastalert with multi-doc YAML', () => {

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -134,6 +134,7 @@ type ElastAlertEngine struct {
 	customAlerters                     *map[string]interface{}
 	autoUpdateEnabled                  bool
 	useEsql                            bool
+	caseInsensitive                    bool
 	detections.SyncSchedulerParams
 	detections.IntegrityCheckerData
 	detections.IOManager
@@ -283,6 +284,8 @@ func (e *ElastAlertEngine) Init(config module.ModuleConfig) (err error) {
 	e.criticalSeverityAlerterParams = module.GetStringDefault(config, "additionalSev5AlertersParams", "")
 	e.autoUpdateEnabled = module.GetBoolDefault(config, "autoUpdateEnabled", DEFAULT_AUTO_UPDATE_ENABLED)
 	e.useEsql = module.GetBoolDefault(config, "useEsql", false)
+	// EQL is already case-insensitive, so this is gated on useEsql below.
+	e.caseInsensitive = module.GetBoolDefault(config, "caseInsensitive", true)
 
 	if custom, ok := config["additionalUserDefinedNotifications"]; ok {
 		switch ct := custom.(type) {
@@ -1666,12 +1669,10 @@ func (e *ElastAlertEngine) sigmaToElastAlert(ctx context.Context, det *model.Det
 	if e.useEsql {
 		target = "esql"
 	}
-	args := []string{"convert", "-t", target, "-p", "/opt/sensoroni/sigma_final_pipeline.yaml", "-p", "/opt/sensoroni/sigma_so_pipeline.yaml", "-p", "windows-logsources"}
-
-	if !e.useEsql {
-		args = append(args, "-p", "ecs_windows")
+	args := []string{"convert", "-t", target, "-p", "/opt/sensoroni/sigma_final_pipeline.yaml", "-p", "/opt/sensoroni/sigma_so_pipeline.yaml", "-p", "windows-logsources", "-p", "ecs_windows", "--disable-pipeline-check", "/dev/stdin"}
+	if e.useEsql && e.caseInsensitive {
+		args = append(args, "-O", "case_insensitive=true")
 	}
-	args = append(args, "/dev/stdin")
 
 	cmd := exec.CommandContext(ctx, "sigma", args...)
 	cmd.Stdin = strings.NewReader(rule)

--- a/server/modules/elastalert/elastalert.go
+++ b/server/modules/elastalert/elastalert.go
@@ -284,7 +284,7 @@ func (e *ElastAlertEngine) Init(config module.ModuleConfig) (err error) {
 	e.criticalSeverityAlerterParams = module.GetStringDefault(config, "additionalSev5AlertersParams", "")
 	e.autoUpdateEnabled = module.GetBoolDefault(config, "autoUpdateEnabled", DEFAULT_AUTO_UPDATE_ENABLED)
 	e.useEsql = module.GetBoolDefault(config, "useEsql", false)
-	// EQL is already case-insensitive, so this is gated on useEsql below.
+	// EQL is already case-insensitive, this is for useEsql
 	e.caseInsensitive = module.GetBoolDefault(config, "caseInsensitive", true)
 
 	if custom, ok := config["additionalUserDefinedNotifications"]; ok {

--- a/server/modules/elastalert/elastalert_test.go
+++ b/server/modules/elastalert/elastalert_test.go
@@ -416,7 +416,6 @@ func TestSigmaToElastAlertSunnyDay(t *testing.T) {
 	query, err := engine.sigmaToElastAlert(context.Background(), det)
 	assert.NoError(t, err)
 
-	// Verify ecs_windows pipeline is included when useEsql is false
 	hasEcsWindows := false
 	for i, arg := range capturedArgs {
 		if arg == "-p" && i+1 < len(capturedArgs) && capturedArgs[i+1] == "ecs_windows" {
@@ -424,7 +423,9 @@ func TestSigmaToElastAlertSunnyDay(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, hasEcsWindows, "ecs_windows pipeline should be included when useEsql is false")
+	assert.True(t, hasEcsWindows, "ecs_windows pipeline should always be included")
+
+	assert.Contains(t, capturedArgs, "--disable-pipeline-check", "--disable-pipeline-check should always be included")
 
 	// No license
 	wrappedRule, err := engine.wrapRule(det, query)
@@ -596,8 +597,9 @@ func TestSigmaToElastAlertESQL(t *testing.T) {
 	})
 
 	engine := ElastAlertEngine{
-		IOManager: iom,
-		useEsql:   true,
+		IOManager:       iom,
+		useEsql:         true,
+		caseInsensitive: true,
 	}
 
 	det := &model.Detection{
@@ -611,7 +613,6 @@ func TestSigmaToElastAlertESQL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "<esql>", query)
 
-	// Verify ecs_windows pipeline is NOT included when useEsql is true
 	hasEcsWindows := false
 	for i, arg := range capturedArgs {
 		if arg == "-p" && i+1 < len(capturedArgs) && capturedArgs[i+1] == "ecs_windows" {
@@ -619,7 +620,12 @@ func TestSigmaToElastAlertESQL(t *testing.T) {
 			break
 		}
 	}
-	assert.False(t, hasEcsWindows, "ecs_windows pipeline should NOT be included when useEsql is true")
+	assert.True(t, hasEcsWindows, "ecs_windows pipeline should always be included")
+
+	assert.Contains(t, capturedArgs, "--disable-pipeline-check", "--disable-pipeline-check should always be included")
+	assert.Contains(t, capturedArgs, "esql")
+
+	assert.Contains(t, capturedArgs, "case_insensitive=true")
 
 	wrappedRule, err := engine.wrapRule(det, query)
 	assert.NoError(t, err)
@@ -2827,4 +2833,68 @@ func TestWriteFileWithCleanup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSigmaToElastAlertCaseInsensitiveDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+
+	var capturedArgs []string
+	iom.EXPECT().ExecCommand(gomock.Any()).DoAndReturn(func(cmd *exec.Cmd) ([]byte, int, time.Duration, error) {
+		capturedArgs = append(capturedArgs, cmd.Args...)
+		return []byte("<esql>"), 0, time.Duration(0), nil
+	})
+
+	engine := ElastAlertEngine{
+		IOManager:       iom,
+		useEsql:         true,
+		caseInsensitive: false,
+	}
+
+	det := &model.Detection{
+		PublicID: "11111111-1111-1111-1111-111111111111",
+		Content:  `{"detection": {"condition": "*"}}`,
+		Title:    "Test Detection",
+		Severity: model.SeverityHigh,
+	}
+
+	_, err := engine.sigmaToElastAlert(context.Background(), det)
+	assert.NoError(t, err)
+
+	assert.NotContains(t, capturedArgs, "case_insensitive=true")
+	assert.NotContains(t, capturedArgs, "case_insensitive=false")
+}
+
+func TestSigmaToElastAlertCaseInsensitiveNotSentForEql(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	iom := mock.NewMockIOManager(ctrl)
+
+	var capturedArgs []string
+	iom.EXPECT().ExecCommand(gomock.Any()).DoAndReturn(func(cmd *exec.Cmd) ([]byte, int, time.Duration, error) {
+		capturedArgs = append(capturedArgs, cmd.Args...)
+		return []byte("<eql>"), 0, time.Duration(0), nil
+	})
+
+	engine := ElastAlertEngine{
+		IOManager:       iom,
+		useEsql:         false,
+		caseInsensitive: true,
+	}
+
+	det := &model.Detection{
+		PublicID: "11111111-1111-1111-1111-111111111111",
+		Content:  `{"detection": {"condition": "*"}}`,
+		Title:    "Test Detection",
+		Severity: model.SeverityHigh,
+	}
+
+	_, err := engine.sigmaToElastAlert(context.Background(), det)
+	assert.NoError(t, err)
+
+	assert.Contains(t, capturedArgs, "eql")
+	assert.NotContains(t, capturedArgs, "case_insensitive=true")
 }


### PR DESCRIPTION
  Dockerfile
  - Bumps pysigma 1.4.0 → 1.5.0; pins pysigma-pipeline-windows==2.0.0
  - Installs pysigma-backend-elasticsearch from new temp Security Onion fork
  
  Sigma conversion (server/modules/elastalert/elastalert.go)
  - New caseInsensitive option, only applies to ESQL
  - ecs_windows pipeline and --disable-pipeline-check is now always passed
  
  Detection UI (html/js/routes/detection.js)
  - "Run query" for ESQL now opens Kibana Discover ES|QL instead of posting /_query in Dev Tools
  