### PR TITLE
Agentic Reload Logic and V-Alert Centering

### DIFF
--- a/html/css/modern.css
+++ b/html/css/modern.css
@@ -97,6 +97,15 @@ html, body, * {
   border-radius: var(--so-radius-panel) !important;
 }
 
+.v-alert__prepend > .v-icon {
+  display: inline-flex;
+}
+
+.v-alert__prepend {
+  align-self: center;
+  grid-row: 1 / -1;
+}
+
 .options-dialog {
   border-radius: var(--so-radius-panel) !important;
   padding: 8px

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -274,6 +274,7 @@ $(document).ready(function () {
           users: [],
           cacheRefreshIntervalMs: 300000,
           loadServerSettingsTime: 0,
+          lastAgenticParamsJson: null,
           user: null,
           username: '',
           maximizedParent: null,
@@ -637,9 +638,13 @@ $(document).ready(function () {
                     this.parameterCallback = null;
                   }
                   this.parametersLoaded = true;
-                  // These params just changed underneath any open page; this reload is
-                  // also what heals a push missed while the websocket was down.
-                  this.publish('assistant:agentic', this.parameters.assistant);
+                  // Heals a push missed while the websocket was down, but only when the
+                  // params actually differ from what subscribers already have.
+                  const agenticJson = JSON.stringify(this.parameters.assistant || null);
+                  if (agenticJson !== this.lastAgenticParamsJson) {
+                    this.lastAgenticParamsJson = agenticJson;
+                    this.publish('assistant:agentic', this.parameters.assistant);
+                  }
                   if (this.parameters.webSocketTimeoutMs > 0) {
                     this.wsConnectionTimeout = this.parameters.webSocketTimeoutMs;
                   }
@@ -1295,6 +1300,7 @@ $(document).ready(function () {
         updateAgenticParams(update) {
           if (!update || !this.parameters) return;
           this.parameters.assistant = update;
+          this.lastAgenticParamsJson = JSON.stringify(update);
         },
         subscribe(kind, fn) {
           this.ensureConnected();

--- a/html/js/app.test.js
+++ b/html/js/app.test.js
@@ -1695,3 +1695,51 @@ test('a server settings reload republishes the assistant params so open pages re
 
   expect(handler).toHaveBeenCalledWith(app.parameters.assistant);
 });
+
+const stubServerSettings = (assistant) => {
+  app.subgrids = [];
+  app.gridInfo = {};
+  app.parameterCallback = null;
+  app.loadServerSettingsTime = 0;
+  global.document.getElementById = jest.fn().mockReturnValue(true);
+  resetPapi();
+  app.papi.get = jest.fn().mockResolvedValue({ data: { parameters: { assistant: assistant }, userId: 'myUserId' } });
+};
+
+test('a server settings reload only republishes assistant params that actually changed', async () => {
+  const handler = jest.fn();
+  app.socket = {};
+  app.subscriptions = [];
+  app.subscribe('assistant:agentic', handler);
+  app.lastAgenticParamsJson = null;
+
+  const agents = [{ name: 'Triage' }];
+  stubServerSettings({ enabled: true, availableAgents: agents });
+  await app.loadServerSettings();
+  expect(handler).toHaveBeenCalledTimes(1);
+
+  stubServerSettings({ enabled: true, availableAgents: agents });
+  await app.loadServerSettings();
+  expect(handler).toHaveBeenCalledTimes(1);
+
+  stubServerSettings({ enabled: true, availableAgents: [{ name: 'Triage' }, { name: 'Hunter' }] });
+  await app.loadServerSettings();
+  expect(handler).toHaveBeenCalledTimes(2);
+});
+
+test('a live agentic push is not republished again by the next settings reload', async () => {
+  const handler = jest.fn();
+  app.socket = {};
+  app.subscriptions = [];
+  app.subscribe('assistant:agentic', handler);
+  app.parameters = { assistant: { availableAgents: [{ name: 'Old' }] } };
+  app.lastAgenticParamsJson = null;
+
+  const pushed = { enabled: true, availableAgents: [{ name: 'Triage' }] };
+  app.updateAgenticParams(pushed);
+
+  stubServerSettings(pushed);
+  await app.loadServerSettings();
+
+  expect(handler).not.toHaveBeenCalled();
+});

--- a/html/js/routes/assistant.sessions.js
+++ b/html/js/routes/assistant.sessions.js
@@ -15,9 +15,9 @@ globalThis.AssistantSessions = (function() {
   return {
     onAgenticUpdate() {
       if (!this.agentic) return;
-      this.initAssistant((this.$root.parameters || {}).assistant || {});
+      this.initAssistant((this.$root.parameters || {}).assistant || {}, false);
     },
-    async initAssistant(params) {
+    async initAssistant(params, loadSession = true) {
       this.assistantEnabled = params["enabled"] && this.$root.isLicensed('oai');
       this.investigationMsg = params["investigationPrompt"];
       this.compressContextMsg = params["compressContextPrompt"];
@@ -87,10 +87,15 @@ globalThis.AssistantSessions = (function() {
 
       if (this.assistantEnabled) {
         if (!this.$root.disclaimer) {
-          await this.loadStoredChats();
-          await this.handleRouteSessionId();
-          await this.loadCredits();
-          this.focusChatInput();
+          if (loadSession) {
+            await this.loadStoredChats();
+            await this.handleRouteSessionId();
+            await this.loadCredits();
+            this.focusChatInput();
+          } else {
+            await this.loadStoredChats(false);
+            await this.loadCredits();
+          }
         }
       } else {
         this.$root.disclaimer = false;

--- a/html/js/routes/assistant.test.js
+++ b/html/js/routes/assistant.test.js
@@ -7931,6 +7931,11 @@ test('isToolAlreadyResolvedError is false when the streamed body cannot be read'
 test('an agentic push refreshes the agent picker without a page reload', async () => {
   comp.agentic = true;
   comp.$root.isLicensed = jest.fn().mockReturnValue(true);
+  comp.$root.showDisclaimer = jest.fn();
+  comp.$root.disclaimer = false;
+  comp.loadStoredChats = jest.fn().mockResolvedValue();
+  comp.handleRouteSessionId = jest.fn().mockResolvedValue();
+  comp.loadCredits = jest.fn().mockResolvedValue();
   comp.$root.parameters = {
     assistant: {
       enabled: true,
@@ -7947,6 +7952,21 @@ test('an agentic push refreshes the agent picker without a page reload', async (
   // The agent added elsewhere is now selectable here.
   expect(comp.availableAgents.map(a => a.name)).toEqual(['Coordinator', 'Triage']);
   expect(comp.availableModels.map(m => m.key)).toEqual(['Coordinator', 'Triage']);
+  // The open chat is left alone: reloading it would rebuild the message tree and
+  // scroll the user back to the bottom. The sidebar refreshes without the spinner.
+  expect(comp.handleRouteSessionId).not.toHaveBeenCalled();
+  expect(comp.loadStoredChats).toHaveBeenCalledWith(false);
+  expect(comp.loadCredits).toHaveBeenCalled();
+});
+
+test('initAssistant still loads the session when not driven by an agentic push', async () => {
+  stubInitDeps();
+
+  await comp.initAssistant(agenticParams());
+
+  expect(comp.handleRouteSessionId).toHaveBeenCalled();
+  expect(comp.loadStoredChats).toHaveBeenCalledWith();
+  expect(comp.focusChatInput).toHaveBeenCalled();
 });
 
 test('an agentic push is ignored when not in agentic mode', async () => {

--- a/html/pages/agentstudio.html
+++ b/html/pages/agentstudio.html
@@ -111,7 +111,7 @@
       </v-card-title>
       <v-divider></v-divider>
       <v-card-text class="agentstudio-dialog-body">
-        <v-alert type="info" variant="tonal" density="compact" class="mb-4">
+        <v-alert type="info" icon="fa-info" variant="tonal" density="compact" class="mb-4">
           {{ i18n.agentStudioSystemPersonaNote }}
         </v-alert>
         <v-textarea v-model="memoryOptions.memoryPersona" :label="i18n.agentStudioMemoryModel" variant="outlined" density="comfortable" rows="8" auto-grow
@@ -418,7 +418,7 @@
                               </v-tabs-window-item>
 
                               <v-tabs-window-item value="persona">
-                                <v-alert v-if="item.isSystem" type="info" variant="tonal" density="compact" class="mb-4" :data-aid="'agentstudio_agent_persona_note_' + item.id">
+                                <v-alert v-if="item.isSystem" type="info" icon="fa-info" variant="tonal" density="compact" class="mb-4" :data-aid="'agentstudio_agent_persona_note_' + item.id">
                                   {{ i18n.agentStudioSystemPersonaNote }}
                                 </v-alert>
                                 <v-row>
@@ -532,7 +532,7 @@
                               </v-tabs-window-item>
 
                               <v-tabs-window-item value="persona">
-                                <v-alert v-if="item.isSystem" type="info" variant="tonal" density="compact" class="mb-4" :data-aid="'agentstudio_skill_persona_note_' + item.id">
+                                <v-alert v-if="item.isSystem" type="info" icon="fa-info" variant="tonal" density="compact" class="mb-4" :data-aid="'agentstudio_skill_persona_note_' + item.id">
                                   {{ i18n.agentStudioSystemSkillPersonaNote }}
                                 </v-alert>
                                 <v-row>
@@ -599,7 +599,7 @@
                       <div class="expanded-row-wrapper pa-4">
                         <v-card variant="flat" class="agentstudio-editor">
                           <v-card-text>
-                            <v-alert v-if="!item.userDefined" type="info" variant="tonal" density="compact" class="mb-4" :data-aid="'agentstudio_memory_scanned_note_' + item.id">
+                            <v-alert v-if="!item.userDefined" type="info" icon="fa-info" variant="tonal" density="compact" class="mb-4" :data-aid="'agentstudio_memory_scanned_note_' + item.id">
                               {{ i18n.agentStudioMemoryScanned }}
                             </v-alert>
                             <v-row>


### PR DESCRIPTION
## Description

- Reworked agentic subscribe and `initAssistant` logic to prevent unnecessary reloads and down-scrolls on the Assistant page.
- Added css rules to make prepended `v-alert` icons properly centered.

## Related Issues

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [x] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments