### PR TITLE
Up the Defaults For ToolTurn Waiting

### DIFF
--- a/server/modules/assistant/assistant.go
+++ b/server/modules/assistant/assistant.go
@@ -69,8 +69,8 @@ const (
 	// DEFAULT_TOOL_USE_TURN_ATTEMPTS and DEFAULT_TOOL_USE_TURN_DELAY_MS bound
 	// awaitToolUseTurn's polling for an asynchronously-persisted tool_use turn,
 	// unless an operator configures "toolUseTurnAttempts" / "toolUseTurnDelayMs".
-	DEFAULT_TOOL_USE_TURN_ATTEMPTS = 10
-	DEFAULT_TOOL_USE_TURN_DELAY_MS = 150
+	DEFAULT_TOOL_USE_TURN_ATTEMPTS = 12
+	DEFAULT_TOOL_USE_TURN_DELAY_MS = 175
 
 	DEFAULT_USE_MEMORY_SCANNER           = false
 	DEFAULT_MEMORY_SCAN_INTERVAL_SECONDS = 300


### PR DESCRIPTION
When the frontend is configured to auto approve tools, it can approve them before the API is done saving the message with the tool request. The variables describing the retry effort are being bumped up to give the API even more leniency.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->