### PR TITLE
Indicate Keyboard Trap

### DIFF
--- a/html/js/i18n.js
+++ b/html/js/i18n.js
@@ -1298,6 +1298,7 @@ const i18n = {
       playbooksPivot: 'Pivot to Playbooks in Alerts',
       premiumSupport: 'Premium Support',
       preparing: 'Preparing',
+      prismEscapeEditor: 'Note: To tab away from the editor, press Escape.',
       pro: 'Security Onion Pro',
       product: 'Security Onion',
       profile: 'Profile',

--- a/html/pages/detection.html
+++ b/html/pages/detection.html
@@ -27,9 +27,10 @@
 								<v-combobox id="detection-license-create" v-if="isPresetCustomEnabled('license')" v-model="detect.license" :items="getPresets('license')" :label="i18n.license" :rules="[$root.validators.required]" required></v-combobox>
 							</span>
 
-							<div id="signature-label" class="font-weight-bold mb-1">{{ i18n.signature }}:</div>
+							<div id="signature-label" class="font-weight-bold">{{ i18n.signature }}:</div>
+							<div id="escape-editor-label-create" class="text-secondary mb-1">{{ i18n.prismEscapeEditor }}</div>
 							<span data-aid="detection_signature_input">
-								<prism-editor v-aria-textarea class="prism" :highlight="highlighter" v-model="detect.content" aria-labelledby="signature-label"></prism-editor>
+								<prism-editor v-aria-textarea class="prism" :highlight="highlighter" v-model="detect.content" aria-labelledby="signature-label" aria-describedby="escape-editor-label-create"></prism-editor>
 							</span>
 						</div>
 						<div class="d-flex align-center align-self-end text-body-2 mt-2">
@@ -240,8 +241,9 @@
 					</v-tabs-window-item>
 					<v-tabs-window-item value="source" data-aid="detection_source">
 						<v-col class="contrast-bg rounded rounded-md pa-4">
+							<div id="escape-editor-label-signature" class="text-secondary mb-1">{{ i18n.prismEscapeEditor}}</div>
 							<span data-aid="detection_source_input">
-								<prism-editor v-aria-textarea class="prism" :highlight="highlighter" v-model="detect.content" :readonly="detect.isCommunity" :aria-label="i18n.signature"></prism-editor>
+								<prism-editor v-aria-textarea class="prism" :highlight="highlighter" v-model="detect.content" :readonly="detect.isCommunity" :aria-label="i18n.signature" aria-describedby="escape-editor-label-signature"></prism-editor>
 							</span>
 							<div class="d-flex align-self-end justify-end detection-source-button-row">
 								<div class="d-inline-flex">
@@ -593,8 +595,9 @@
 								<v-icon class="mr-3" data-aid="detection_playbook_ai_indicator">fa-flask</v-icon>
 								<span v-html="i18n.detectionPlaybooksAi" data-aid="detection_playbook_ai_text"></span>
 							</div>
+							<div id="escape-editor-label-playbook" class="text-secondary mb-1">{{ i18n.prismEscapeEditor }}</div>
 							<span data-aid="detection_source_input">
-								<prism-editor v-aria-textarea class="prism" :highlight="playbookHighlighter" v-model="joinedPlaybookSource" readonly :aria-label="i18n.playbooks"></prism-editor>
+								<prism-editor v-aria-textarea class="prism" :highlight="playbookHighlighter" v-model="joinedPlaybookSource" readonly :aria-label="i18n.playbooks" aria-describedby="escape-editor-label-playbook"></prism-editor>
 							</span>
 						</v-col>
 					</v-tabs-window-item>


### PR DESCRIPTION
Since the prism editor treats tab as a character to insert and not as an action that changes focus, we need to indicate to users how they can regain control over focus.

This satisfies WCAG 2.1.2 A "No Keyboard Trap"

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->