### PR TITLE
Ensure Suricata Rules are 1 Line Even After Overrides

### DIFF
--- a/server/modules/suricata/suricata.go
+++ b/server/modules/suricata/suricata.go
@@ -1034,6 +1034,10 @@ func (e *SuricataEngine) writeAllRulesFile(detections []*model.Detection) error 
 				}
 			}
 
+			if !isSingleLine(content) {
+				return fmt.Errorf("modify override for SID %s produces a multi-line rule; suricata rules must be a single line", det.PublicID)
+			}
+
 			// Handle disabled rules that are needed for flowbits
 			if !det.IsEnabled && e.flowbitRequired[det.PublicID] != nil {
 				dep := e.flowbitRequired[det.PublicID]
@@ -1609,13 +1613,13 @@ func (e *SuricataEngine) readFingerprint(path string) (fingerprint *string, ok b
 	return fingerprint, true, nil
 }
 
-func (e *SuricataEngine) ValidateRule(rule string) (string, error) {
-	lines := strings.Split(rule, "\n")
-	nonEmpty := lo.Filter(lines, func(line string, _ int) bool {
-		return strings.TrimSpace(line) != ""
-	})
+func isSingleLine(rule string) bool {
+	trimmed := strings.TrimSpace(rule)
+	return trimmed != "" && !strings.Contains(trimmed, "\n")
+}
 
-	if len(nonEmpty) != 1 {
+func (e *SuricataEngine) ValidateRule(rule string) (string, error) {
+	if !isSingleLine(rule) {
 		return "", fmt.Errorf("suricata rules must be a single line")
 	}
 

--- a/server/modules/suricata/suricata_test.go
+++ b/server/modules/suricata/suricata_test.go
@@ -249,6 +249,40 @@ func TestIndexRules(t *testing.T) {
 	assert.Equal(t, output["1100000"], 2)
 }
 
+func TestIsSingleLine(t *testing.T) {
+	t.Parallel()
+
+	table := []struct {
+		Name     string
+		Input    string
+		Expected bool
+	}{
+		{Name: "Simple Rule", Input: SimpleRule, Expected: true},
+		{Name: "Trailing Newline", Input: SimpleRule + "\n", Expected: true},
+		{Name: "Leading Newline", Input: "\n" + SimpleRule, Expected: true},
+		{Name: "Surrounding Blank Lines", Input: "\n\n" + SimpleRule + "\n\n", Expected: true},
+		{Name: "Whitespace-Only Extra Lines", Input: "  \t\n" + SimpleRule + "\n \t ", Expected: true},
+		{Name: "CRLF Line Ending", Input: SimpleRule + "\r\n", Expected: true},
+		{Name: "Empty String", Input: "", Expected: false},
+		{Name: "Whitespace Only", Input: " \n\t\n ", Expected: false},
+		{Name: "Only Newlines", Input: "\n\n\n", Expected: false},
+		{Name: "Two Rules", Input: FlowbitsRuleA + "\n" + FlowbitsRuleB, Expected: false},
+		{Name: "Comment Then Rule", Input: "# comment\n" + SimpleRule, Expected: false},
+		{Name: "Rule Split Mid-Option", Input: `alert tcp any any -> any any (msg:"Test";` + "\n" + `sid:1001;)`, Expected: false},
+		{Name: "Two Rules Separated By Blank Line", Input: SimpleRule + "\n\n" + SimpleRule, Expected: false},
+		{Name: "Two Rules On One Line", Input: FlowbitsRuleA + " " + FlowbitsRuleB, Expected: true},
+	}
+
+	for _, test := range table {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.Expected, isSingleLine(test.Input))
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
 	table := []struct {
 		Name        string
@@ -3410,6 +3444,43 @@ func TestWriteAllRulesFileAdditionalCoverage(t *testing.T) {
 		err := eng.writeAllRulesFile(detections)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported backreference")
+		assert.Contains(t, err.Error(), "SID 1001")
+	})
+
+	t.Run("Modify override producing multi-line rule returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		iom := mock.NewMockIOManager(ctrl)
+
+		eng := &SuricataEngine{
+			IOManager:       iom,
+			allRulesFile:    "/test/all.rules",
+			flowbitRequired: map[string]*FlowbitDependency{},
+		}
+
+		detections := []*model.Detection{
+			{
+				PublicID:  "1001",
+				Content:   `alert tcp any any -> any any (msg:"Test"; sid:1001;)`,
+				IsEnabled: true,
+				Ruleset:   "test",
+				Overrides: []*model.Override{
+					{
+						Type:      model.OverrideTypeModify,
+						IsEnabled: true,
+						OverrideParameters: model.OverrideParameters{
+							Regex: util.Ptr(`msg:"Test"`),
+							Value: util.Ptr("msg:\"Test\";\nsid:9999"),
+						},
+					},
+				},
+			},
+		}
+
+		err := eng.writeAllRulesFile(detections)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "multi-line")
 		assert.Contains(t, err.Error(), "SID 1001")
 	})
 


### PR DESCRIPTION
Overrides can add a newline to a suricata rule. The check we do before applying overrides isn't sufficient. Added a check immediately after applying the overrides. Added tests.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->