### PR TITLE
Remove Typo

### DIFF
--- a/rbac/permissions
+++ b/rbac/permissions
@@ -79,7 +79,6 @@ query-monitor:      query-admin
 subgrid-monitor:    subgrid-admin
 user-monitor:       user-admin
 playbook-monitor:   playbook-admin
-detections-monitor: playbook-monitor
 assistant-user:     assistant-admin
 assistant-monitor:  assistant-admin
 memory-user:        memory-curator


### PR DESCRIPTION
`detections-monitor` is not a real permissions group, `detection-monitor` is. However, fixing the typo wouldn't change any effective permissions. Roles get the same permissions from other groups without this inheritance line.

## Description

<!-- 
Explain the purpose of the pull request. Be brief or detailed depending on the scope of the changes.
-->

## Related Issues

<!-- 
Optionally, list any related issues that this pull request addresses.
-->

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/Security-Onion-Solutions/securityonion/blob/3/main/CONTRIBUTING.md) file.
- [ ] I have read and agree to the terms of the [Contributor License Agreement](https://securityonionsolutions.com/cla)

## Questions or Comments

<!--
If you have any questions or comments about this pull request, add them here.
-->